### PR TITLE
allow arbitrary number of replicates in measurement_df when creating edatas

### DIFF
--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -170,16 +170,29 @@ class PetabImporter:
             # amici.ExpData for each simulation
 
             # extract rows for condition
-            cur_measurement_df = petab.core.get_rows_for_condition(
+            df_for_condition = petab.core.get_rows_for_condition(
                 measurement_df, condition)
 
             # make list of all timepoints for which measurements exist
             timepoints = sorted(
-                cur_measurement_df.time.unique().astype(float))
+                df_for_condition.time.unique().astype(float))
 
             # init edata object
             edata = amici.ExpData(model.get())
-            edata.setTimepoints(timepoints)
+
+            # find rep numbers of time points
+            timepoints_w_reps = []
+            for time in timepoints:
+                # subselect for time
+                df_for_time = df_for_condition[df_for_condition.time == time]
+                # rep number is maximum over rep numbers for observables
+                n_reps = max(df_for_time.groupby(
+                    ['observableId', 'time']).size())
+                # append time point n_rep times
+                timepoints_w_reps.extend([time] * n_reps)
+
+            # set time points in edata
+            edata.setTimepoints(timepoints_w_reps)
 
             # handle fixed parameters
             _handle_fixed_parameters(
@@ -193,15 +206,20 @@ class PetabImporter:
                 fill_value=np.nan)
 
             # add measurements and sigmas
-            for _, measurement in cur_measurement_df.iterrows():
-                time_ix = timepoints.index(measurement.time)
-                observable_ix = observable_ids.index(
-                    f'observable_{measurement.observableId}')
-
-                y[time_ix, observable_ix] = measurement.measurement
-                if isinstance(measurement.noiseParameters, numbers.Number):
-                    sigma_y[time_ix, observable_ix] = \
-                        measurement.noiseParameters
+            # iterate over time points
+            for time_ix, time in enumerate(timepoints_w_reps):
+                # subselect for time
+                df_for_time = df_for_condition[df_for_condition.time == time]
+                # iterate over measurements
+                for _, measurement in df_for_time.iterrows():
+                    # get observable index
+                    observable_ix = observable_ids.index(
+                        f'observable_{measurement.observableId}')
+                    # fill observable and possibly noise parameter
+                    y[time_ix, observable_ix] = measurement.measurement
+                    if isinstance(measurement.noiseParameters, numbers.Number):
+                        sigma_y[time_ix, observable_ix] = \
+                            measurement.noiseParameters
 
             # fill measurements and sigmas into edata
             edata.setObservedData(y.flatten())

--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -217,10 +217,11 @@ class PetabImporter:
 
                 # iterate over measurements
                 for _, measurement in df_for_time.iterrows():
-
-                    # update time indexf for observable
+                    # extract observable index
                     observable_ix = observable_ids.index(
                         f'observable_{measurement.observableId}')
+
+                    # update time index for observable
                     if observable_ix in time_ix_for_obs_ix:
                         time_ix_for_obs_ix[observable_ix] += 1
                     else:

--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -207,19 +207,31 @@ class PetabImporter:
 
             # add measurements and sigmas
             # iterate over time points
-            for time_ix, time in enumerate(timepoints_w_reps):
+            for time in timepoints:
                 # subselect for time
                 df_for_time = df_for_condition[df_for_condition.time == time]
+                time_ix_0 = timepoints_w_reps.index(time)
+
+                # remember used time indices for each observable
+                time_ix_for_obs_ix = {}
+
                 # iterate over measurements
                 for _, measurement in df_for_time.iterrows():
-                    # get observable index
+
+                    # update time indexf for observable
                     observable_ix = observable_ids.index(
                         f'observable_{measurement.observableId}')
+                    if observable_ix in time_ix_for_obs_ix:
+                        time_ix_for_obs_ix[observable_ix] += 1
+                    else:
+                        time_ix_for_obs_ix[observable_ix] = time_ix_0
+
                     # fill observable and possibly noise parameter
-                    y[time_ix, observable_ix] = measurement.measurement
+                    y[time_ix_for_obs_ix[observable_ix],
+                        observable_ix] = measurement.measurement
                     if isinstance(measurement.noiseParameters, numbers.Number):
-                        sigma_y[time_ix, observable_ix] = \
-                            measurement.noiseParameters
+                        sigma_y[time_ix_for_obs_ix[observable_ix],
+                                observable_ix] = measurement.noiseParameters
 
             # fill measurements and sigmas into edata
             edata.setObservedData(y.flatten())

--- a/test/petab_util.py
+++ b/test/petab_util.py
@@ -10,6 +10,3 @@ except Exception:
 
 # model folder base
 folder_base = repo_base + "hackathon_contributions_new_data_format/"
-
-# model names
-model_names = ["Zheng_PNAS2012", "Boehm_JProteomeRes2014"]

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -3,7 +3,7 @@ import unittest
 
 import pypesto
 import test.test_objective as test_objective
-from test.util import folder_base, model_names
+from test.petab_util import folder_base
 
 
 class EngineTest(unittest.TestCase):
@@ -29,7 +29,7 @@ class EngineTest(unittest.TestCase):
 
     def _test_petab(self, engine):
         petab_importer = pypesto.PetabImporter.from_folder(
-            folder_base + model_names[0])
+            folder_base + "Zheng_PNAS2012")
         objective = petab_importer.create_objective()
         problem = petab_importer.create_problem(objective)
         result = pypesto.minimize(problem=problem, n_starts=3, engine=engine)

--- a/test/test_petab_import.py
+++ b/test/test_petab_import.py
@@ -139,7 +139,6 @@ class SpecialFeaturesTest(unittest.TestCase):
                 # test if the measurement data coincide for the given time
                 # point
                 for amici_val, meas_val in zip(amici_vals, meas_vals):
-                    print(amici_val)
                     self.assertTrue(np.isclose(amici_val, meas_val))
 
 


### PR DESCRIPTION
here, replicate means that time point, observableId, preequilibrationConditionId, simulationConditionId coincide. This is allowed by the petab format. Solves #122 