### PR TITLE
Fix mapping in add_sim_hess_to_opt_hess

### DIFF
--- a/pypesto/objective/amici_objective.py
+++ b/pypesto/objective/amici_objective.py
@@ -651,7 +651,6 @@ def add_sim_hess_to_opt_hess(par_opt_ids,
     Same as for add_sim_grad_to_opt_grad, replacing the gradients by hessians.
     """
 
-    # https://github.com/ICB-DCM/AMICI/issues/274
     par_sim_idx = 0
     for par_opt_id in mapping_par_opt_to_par_sim:
         if not isinstance(par_opt_id, str):

--- a/pypesto/objective/amici_objective.py
+++ b/pypesto/objective/amici_objective.py
@@ -653,7 +653,8 @@ def add_sim_hess_to_opt_hess(par_opt_ids,
 
     # use enumerate for first axis as plist is not applied
     # https://github.com/ICB-DCM/AMICI/issues/274
-    for par_sim_idx, par_opt_id in enumerate(mapping_par_opt_to_par_sim):
+    par_sim_idx = 0
+    for par_opt_id in mapping_par_opt_to_par_sim:
         if not isinstance(par_opt_id, str):
             # this was a numeric override for which we ignore the hessian
             continue
@@ -675,6 +676,7 @@ def add_sim_hess_to_opt_hess(par_opt_ids,
             opt_hess[par_opt_idx, par_opt_idx_2] += \
                 coefficient * sim_hess[par_sim_idx, par_sim_idx_2]
             par_sim_idx_2 += 1
+        par_sim_idx += 1
 
 
 def sim_sres_to_opt_sres(par_opt_ids,

--- a/pypesto/objective/amici_objective.py
+++ b/pypesto/objective/amici_objective.py
@@ -651,7 +651,6 @@ def add_sim_hess_to_opt_hess(par_opt_ids,
     Same as for add_sim_grad_to_opt_grad, replacing the gradients by hessians.
     """
 
-    # use enumerate for first axis as plist is not applied
     # https://github.com/ICB-DCM/AMICI/issues/274
     par_sim_idx = 0
     for par_opt_id in mapping_par_opt_to_par_sim:


### PR DESCRIPTION
Tried to optimize the Boehm model from the benchmark collection and got an out of index error in line 677 in `amici_objective`, because the `par_opt_id` did not skip over numeric values ('sim_hess' has dimensions 9x9 and `par_sim_idx` was out of bounds). 

Tested this on the Boehm model and seems to work