### PR TITLE
Fix petab

### DIFF
--- a/pypesto/objective/amici_objective.py
+++ b/pypesto/objective/amici_objective.py
@@ -141,7 +141,7 @@ class AmiciObjective(Objective):
         if mapping_par_opt_to_par_sim is None:
             # use identity mapping for each condition
             mapping_par_opt_to_par_sim = \
-                [x_ids for _ in range(len(self.edatas))]
+                [(x_ids, x_ids) for _ in range(len(self.edatas))]
         self.mapping_par_opt_to_par_sim = mapping_par_opt_to_par_sim
 
         # mapping of parameter scales
@@ -590,7 +590,7 @@ def create_scale_mapping_from_model(amici_scales, n_edata):
                 f"recognized.")
         scales.append(scale)
 
-    mapping_scale_opt_to_scale_sim = [scales for _ in range(n_edata)]
+    mapping_scale_opt_to_scale_sim = [(scales, scales) for _ in range(n_edata)]
 
     return mapping_scale_opt_to_scale_sim
 

--- a/pypesto/objective/amici_objective.py
+++ b/pypesto/objective/amici_objective.py
@@ -141,7 +141,7 @@ class AmiciObjective(Objective):
         if mapping_par_opt_to_par_sim is None:
             # use identity mapping for each condition
             mapping_par_opt_to_par_sim = \
-                [(x_ids, x_ids) for _ in range(len(self.edatas))]
+                [x_ids for _ in range(len(self.edatas))]
         self.mapping_par_opt_to_par_sim = mapping_par_opt_to_par_sim
 
         # mapping of parameter scales
@@ -590,7 +590,7 @@ def create_scale_mapping_from_model(amici_scales, n_edata):
                 f"recognized.")
         scales.append(scale)
 
-    mapping_scale_opt_to_scale_sim = [(scales, scales) for _ in range(n_edata)]
+    mapping_scale_opt_to_scale_sim = [scales for _ in range(n_edata)]
 
     return mapping_scale_opt_to_scale_sim
 

--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -638,14 +638,12 @@ def _merge_preeq_and_sim_pars(parameter_mappings, scale_mappings):
 
     Parameters
     ----------
-
     parameter_mappings, scale_mappings: list of tuple of dict
         As returned by petab.get_optimization_to_simulation_parameter_mapping
         and petab.get_optimization_to_simulation_scale_mapping.
 
     Returns
     -------
-
     parameter_mapping, scale_mapping: list of dict
         The parameter and scale simulation mappings, modified and checked.
     """
@@ -673,11 +671,15 @@ def _mapping_to_list(mapping, par_sim_ids):
 
     Parameters
     ----------
-
     mapping: list of dict
         as created by _merge_preeq_and_sim_pars.
     par_sim_ids: list of str
         The simulation ids as returned by list(amici_model.getParameterIds()).
+
+    Returns
+    -------
+    mapping_list: list of list
+        Each dict turned into a list with order according to `par_sim_ids`.
     """
     mapping_list = []
     for map_for_cond in mapping:

--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -371,7 +371,8 @@ class PetabImporter:
         scale_mapping = _mapping_to_list(scale_mapping, par_sim_ids)
 
         # check whether there is something suspicious in the mapping
-        _check_parameter_mapping_ok(parameter_mapping, model, edatas)
+        _check_parameter_mapping_ok(
+            parameter_mapping, par_sim_ids, model, edatas)
 
         # create objective
         obj = PetabAmiciObjective(
@@ -469,7 +470,7 @@ class PetabImporter:
 
 
 def _check_parameter_mapping_ok(
-        mapping_par_opt_to_par_sim, model, edatas):
+        mapping_par_opt_to_par_sim, par_sim_ids, model, edatas):
     """
     Check whether there are suspicious parameter mappings and/or data points.
 
@@ -484,9 +485,6 @@ def _check_parameter_mapping_ok(
     # prepare output
     msg_data_notnan = ""
     msg_data_nan = ""
-
-    # simulation parameter ids
-    par_sim_ids = list(model.getParameterIds())
 
     # iterate over conditions
     for i_condition, (mapping_for_condition, edata_for_condition) in \

--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -500,7 +500,7 @@ def _check_parameter_mapping_ok(
                 continue
             # extract observable id
             obs_id = re.sub(pattern, "", par_sim_id)
-            # extract mapped optimization parameter (ignore preeq)
+            # extract mapped optimization parameter
             mapped_par = mapping_for_condition[i_sim_id]
             # check if opt par is nan, but not all corresponding data points
             if not isinstance(mapped_par, str) and np.isnan(mapped_par) \

--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -633,6 +633,24 @@ def _find_model_name(output_folder):
 
 
 def _merge_preeq_and_sim_pars(parameter_mappings, scale_mappings):
+    """
+    Wrapper around petab.merge_preeq_and_sim_pars_condition for multiple
+    conditions. Merges preequilibration and simulation parameter mappings
+    and checks conformity with the amici capabilities.
+
+    Parameters
+    ----------
+
+    parameter_mappings, scale_mappings: list of tuple of dict
+        As returned by petab.get_optimization_to_simulation_parameter_mapping
+        and petab.get_optimization_to_simulation_scale_mapping.
+
+    Returns
+    -------
+
+    parameter_mapping, scale_mapping: list of dict
+        The parameter and scale simulation mappings, modified and checked.
+    """
     parameter_mapping = []
     scale_mapping = []
     for ic, ((map_preeq, map_sim), (scale_map_preeq, scale_map_sim)) in \
@@ -649,6 +667,20 @@ def _merge_preeq_and_sim_pars(parameter_mappings, scale_mappings):
 
 
 def _mapping_to_list(mapping, par_sim_ids):
+    """
+    Petab returns for each condition a dictionary which maps simulation
+    to optimization parameters. Given we know the correct order of
+    simulation parameters as used in the amici model, we here create
+    a list from the dictionary.
+
+    Parameters
+    ----------
+
+    mapping: list of dict
+        as created by _merge_preeq_and_sim_pars.
+    par_sim_ids: list of str
+        The simulation ids as returned by list(amici_model.getParameterIds()).
+    """
     mapping_list = []
     for map_for_cond in mapping:
         map_for_cond_list = []


### PR DESCRIPTION
Adapt to changes of petab, in particular the parameter and scale mapping, and preequilibration.

Currently, the amici objective was not touched. That means that there everything still works based on indices, assuming we know the order of amici simulation parameters fixed (which is the case). The new mapping from dicts to lists happens in the petab_importer already. Dont' know if there is a "nicer" way, but this seems the easiest one to me.