### PR TITLE
PEtab import: Remove outdated warning regarding parameter dependent c…

### DIFF
--- a/pypesto/objective/petab_import.py
+++ b/pypesto/objective/petab_import.py
@@ -162,13 +162,6 @@ class PetabImporter:
         deleted.
         """
 
-        # check prerequisites
-        if not petab.condition_table_is_parameter_free(
-                self.petab_problem.condition_df):
-            raise AssertionError(
-                "Parameter dependent conditions in the condition file "
-                "are not yet supported.")
-
         # delete output directory
         if os.path.exists(self.output_folder):
             shutil.rmtree(self.output_folder)


### PR DESCRIPTION
…onditions

This has been implemented in the PEtab parameter mapping functions and is thereby supported in pyPESTO.