### PR TITLE
Fix 213

### DIFF
--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 import numpy as np
+import numbers
 from .reference_points import create_references
 from .clust_color import assign_colors
 from .misc import process_result_list
@@ -245,7 +246,7 @@ def handle_inputs(result, free_indices_only, lb=None, ub=None,
     # parse indices which should be plotted
     if start_indices is not None:
         # handle, if only a number was passed
-        if type(start_indices) in (float, int):
+        if isinstance(start_indices, numbers.Number):
             start_indices = range(int(start_indices))
 
         start_indices = np.array(start_indices, dtype=int)

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -244,6 +244,10 @@ def handle_inputs(result, free_indices_only, lb=None, ub=None,
 
     # parse indices which should be plotted
     if start_indices is not None:
+        # handle, if only a number was passed
+        if type(start_indices) in (float, int):
+            start_indices = range(int(start_indices))
+
         start_indices = np.array(start_indices, dtype=int)
 
         # reduce number of displayed results

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -195,7 +195,7 @@ class TestVisualize(unittest.TestCase):
                                      free_indices_only=False,
                                      reference=ref_point,
                                      balance_alpha=False,
-                                     start_indices=(0,1,4))
+                                     start_indices=(0, 1, 4))
 
         pypesto.visualize.parameters([result_1, result_2],
                                      free_indices_only=True,

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -194,7 +194,12 @@ class TestVisualize(unittest.TestCase):
         pypesto.visualize.parameters([result_1, result_2],
                                      free_indices_only=False,
                                      reference=ref_point,
-                                     balance_alpha=False)
+                                     balance_alpha=False,
+                                     start_indices=(0,1,4))
+
+        pypesto.visualize.parameters([result_1, result_2],
+                                     free_indices_only=True,
+                                     start_indices=3)
 
     @staticmethod
     def test_parameters_lowlevel():


### PR DESCRIPTION
Fixes the not correctly working option `start_indices` in visualize.parameters and covers it by a test