### PR TITLE
use imported-members in autodoc

### DIFF
--- a/doc/api_engine.rst
+++ b/doc/api_engine.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_objective.rst
+++ b/doc/api_objective.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_optimize.rst
+++ b/doc/api_optimize.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_problem.rst
+++ b/doc/api_problem.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_profile.rst
+++ b/doc/api_profile.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_result.rst
+++ b/doc/api_result.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_sample.rst
+++ b/doc/api_sample.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_startpoint.rst
+++ b/doc/api_startpoint.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:

--- a/doc/api_visualize.rst
+++ b/doc/api_visualize.rst
@@ -2,3 +2,4 @@
    :members:
    :inherited-members:
    :special-members:
+   :imported-members:


### PR DESCRIPTION
otherwise, the automatically generated API docs are (as currently) totally empty.