### PR TITLE
copy parameter vector to avoid side effects

### DIFF
--- a/pypesto/objective/objective.py
+++ b/pypesto/objective/objective.py
@@ -237,6 +237,8 @@ class Objective:
             is flattened). If `return_dict`, then instead a dict is returned
             with function values and derivatives indicated by ids.
         """
+        # copy parameter vector to prevent side effects
+        x = np.array(x).copy()
 
         # check input
         self.check_sensi_orders(sensi_orders, mode)

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -260,7 +260,13 @@ def test_history_properties(history: pypesto.History):
         assert len(grads) == 10
         assert len(grads[0]) == 7
 
-    if type(history) == pypesto.MemoryHistory:
-        # TODO extend as funcionality is implemented
+    if type(history) in \
+            (pypesto.MemoryHistory,):
+        # TODO extend as functionality is implemented in other histories
+
+        # assert x values are not all the same
+        xs = np.array(history.get_x_trace())
+        assert (xs[:-1] != xs[-1]).all()
+
         ress = history.get_res_trace()
         assert all(res is None for res in ress)


### PR DESCRIPTION
previously, some optimizers were the x vector was not copied, would end up with having the full trace set to the latest parameter in MemoryHistory.