### PR TITLE
Changes to pymc3

### DIFF
--- a/pypesto/sampling/pymc3.py
+++ b/pypesto/sampling/pymc3.py
@@ -135,21 +135,21 @@ class TheanoLogProbability(tt.Op):
 
     def __init__(self, problem: Problem, beta: float = 1.):
         self._objective: Objective = problem.objective
-
-        # initialize the log probability Op
-        self._log_prob = \
-            lambda x: - beta * self._objective(x, sensi_orders=(0,))
-
+        self._beta: float = beta
+        self._cached_theta = None
+        self._cached_dlogp = None
         # initialize the sensitivity Op
         if problem.objective.has_grad:
-            self._log_prob_grad = TheanoLogProbabilityGradient(problem, beta)
+            self._log_prob_grad = TheanoLogProbabilityGradient(self)
         else:
             self._log_prob_grad = None
 
     def perform(self, node, inputs, outputs, params=None):
         theta, = inputs
-        log_prob = self._log_prob(theta)
-        outputs[0][0] = np.array(log_prob)
+        logp, dlogp = self._objective(theta, sensi_orders=(0, 1))
+        outputs[0][0] = np.array(-self._beta * logp)
+        self._cached_theta = theta
+        self._cached_dlogp = dlogp
 
     def grad(self, inputs, g):
         # the method that calculates the gradients - it actually returns the
@@ -167,25 +167,23 @@ class TheanoLogProbabilityGradient(tt.Op):
     Theano wrapper around a (non-normalized) log-probability gradient function.
     This Op will be called with a vector of values and also return a vector of
     values - the gradients in each dimension.
-
-    Parameters
-    ----------
-    problem:
-        The `pypesto.Problem` to analyze.
-    beta:
-        Inverse temperature (e.g. in parallel tempering).
     """
 
     itypes = [tt.dvector]  # expects a vector of parameter values when called
     otypes = [tt.dvector]  # outputs a vector (the log prob grad)
 
-    def __init__(self, problem: Problem, beta: float = 1.):
-        self._objective: Objective = problem.objective
-        self._log_prob_grad = \
-            lambda x: - beta * self._objective(x, sensi_orders=(1,))
+    def __init__(self, logp_op: TheanoLogProbability):
+        self._logp_op: TheanoLogProbability = logp_op
+        self._objective = logp_op._objective
+        self._beta = logp_op._beta
 
     def perform(self, node, inputs, outputs, params=None):
         theta, = inputs
-        # calculate gradients
-        log_prob_grad = self._log_prob_grad(theta)
-        outputs[0][0] = log_prob_grad
+
+        cached_theta = self._logp_op._cached_theta
+        if cached_theta is not None and np.all(theta == cached_theta):
+            dlogp = self._logp_op._cached_dlogp
+        else:
+            dlogp = self._objective(theta, sensi_orders=(1,))
+
+        outputs[0][0] = -self._beta * dlogp

--- a/pypesto/sampling/pymc3.py
+++ b/pypesto/sampling/pymc3.py
@@ -181,7 +181,7 @@ class TheanoLogProbabilityGradient(tt.Op):
         theta, = inputs
 
         cached_theta = self._logp_op._cached_theta
-        if cached_theta is not None and np.all(theta == cached_theta):
+        if cached_theta is not None and np.array_equal(theta, cached_theta):
             dlogp = self._logp_op._cached_dlogp
         else:
             dlogp = self._objective(theta, sensi_orders=(1,))

--- a/pypesto/sampling/pymc3.py
+++ b/pypesto/sampling/pymc3.py
@@ -60,7 +60,7 @@ class Pymc3Sampler(Sampler):
         trace = self.trace
 
         x0 = None
-        if self.x0 is not None:
+        if self.x0 is not None and self.trace is None:
             x0 = {x_name: val
                   for x_name, val in zip(self.problem.x_names, self.x0)}
 


### PR DESCRIPTION
* Added caching of the gradients so that the forward problem is only computed once
* If a `trace` has already been started, resume sampling from the last point (which I think is the behaviour for the other samplers?)