### PR TITLE
fix minus sign in get_error_output

### DIFF
--- a/pypesto/objective/amici.py
+++ b/pypesto/objective/amici.py
@@ -289,7 +289,7 @@ class AmiciObjective(ObjectiveBase):
             edatas=self.edatas, n_threads=self.n_threads,
             x_ids=self.x_ids, parameter_mapping=self.parameter_mapping)
 
-        nllh = - ret[FVAL]
+        nllh = ret[FVAL]
         rdatas = ret[RDATAS]
 
         # check whether we should update data for preequilibration guesses

--- a/pypesto/objective/amici.py
+++ b/pypesto/objective/amici.py
@@ -294,7 +294,8 @@ class AmiciObjective(ObjectiveBase):
 
         # check whether we should update data for preequilibration guesses
         if self.guess_steadystate and \
-                nllh <= self.steadystate_guesses['fval']:
+                nllh <= self.steadystate_guesses['fval'] and \
+                nllh < np.inf:
             self.steadystate_guesses['fval'] = nllh
             for data_ix, rdata in enumerate(rdatas):
                 self.store_steadystate_guess(data_ix, x_dct, rdata)

--- a/pypesto/objective/amici_util.py
+++ b/pypesto/objective/amici_util.py
@@ -225,7 +225,11 @@ def get_error_output(
         edatas: Sequence['amici.ExpData'],
         rdatas: Sequence['amici.ReturnData'],
         dim: int):
-    """Default output upon error."""
+    """Default output upon error.
+
+    Returns values indicative of an error, that is with nan entries in all
+    vectors, and a function value, i.e. nllh, of `np.inf`.
+    """
     if not amici_model.nt():
         nt = sum([data.nt() for data in edatas])
     else:
@@ -234,7 +238,7 @@ def get_error_output(
     n_res = nt * amici_model.nytrue
 
     return {
-        FVAL: - np.inf,
+        FVAL: np.inf,
         GRAD: np.nan * np.ones(dim),
         HESS: np.nan * np.ones([dim, dim]),
         RES:  np.nan * np.ones(n_res),

--- a/pypesto/objective/amici_util.py
+++ b/pypesto/objective/amici_util.py
@@ -234,7 +234,7 @@ def get_error_output(
     n_res = nt * amici_model.nytrue
 
     return {
-        FVAL: np.inf,
+        FVAL: - np.inf,
         GRAD: np.nan * np.ones(dim),
         HESS: np.nan * np.ones([dim, dim]),
         RES:  np.nan * np.ones(n_res),


### PR DESCRIPTION
It looks like the error output of the amici objective returned an NLLH value instead of an LLH value. Hence, if simulation failed, the nllh value was -infty, which no best parameter vector can ever beat, making simulation crashes highly desirable for the optimizer... :joy:
