### PR TITLE
Specify logger descendant.

### DIFF
--- a/pypesto/logging.py
+++ b/pypesto/logging.py
@@ -8,40 +8,53 @@ Logging convenience functions.
 import logging
 
 
-def log_to_console(level=None):
+def log_to_console(level: int = None, child: str = None):
     """
     Log to console.
 
     Parameters
     ----------
 
-    level: int
+    level:
         The output level to use. Default: logging.DEBUG.
+
+    child:
+        The name of the descendant to the 'pypesto' logger. For example, if
+        child is 'model_selection', then the logger name will be
+        'pypesto.model_selection'.
 
     """
     if level is None:
         level = logging.DEBUG
 
     logger = logging.getLogger('pypesto')
+    if child is not None:
+        logger = logger.getChild(child)
+
     logger.setLevel(level)
     ch = logging.StreamHandler()
     ch.setLevel(level)
     logger.addHandler(ch)
 
 
-def log_to_file(level=None, filename=None):
+def log_to_file(level: int = None, filename: str = None, child: str = None):
     """
     Log to file.
 
     Parameters
     ----------
 
-    level: int
+    level:
         The output level to use. Default: logging.DEBUG.
 
-    filename: str
+    filename:
         The name of the file to append to.
         Default: .pypesto_logging.log.
+
+    child:
+        The name of the descendant to the 'pypesto' logger. For example, if
+        child is 'model_selection', then the logger name will be
+        'pypesto.model_selection'.
     """
 
     if level is None:
@@ -51,6 +64,9 @@ def log_to_file(level=None, filename=None):
         filename = ".pypesto_logging.log"
 
     logger = logging.getLogger('pypesto')
+    if child is not None:
+        logger = logger.getChild(child)
+
     logger.setLevel(level)
     fh = logging.FileHandler(filename)
     fh.setLevel(level)

--- a/pypesto/logging.py
+++ b/pypesto/logging.py
@@ -7,6 +7,7 @@ Logging convenience functions.
 
 import logging
 
+
 def log(name: str = 'pypesto',
         level: int = logging.DEBUG,
         console: bool = False,
@@ -41,6 +42,7 @@ def log(name: str = 'pypesto',
         fh = logging.FileHandler(filename)
         fh.setLevel(level)
         logger.addHandler(fh)
+
 
 def log_to_console(level: int = logging.DEBUG):
     """

--- a/pypesto/logging.py
+++ b/pypesto/logging.py
@@ -11,7 +11,7 @@ def log(name: str = 'pypesto',
         level: int = logging.DEBUG,
         console: bool = False,
         filename: str = ''):
-    '''
+    """
     Log messages from a specified name with a specified level to any
     combination of console and file.
 
@@ -28,7 +28,7 @@ def log(name: str = 'pypesto',
 
     filename:
         If specified, messages are logged to a file with this name.
-    '''
+    """
     logger = logging.getLogger(name)
     logger.setLevel(level)
 

--- a/pypesto/logging.py
+++ b/pypesto/logging.py
@@ -7,67 +7,63 @@ Logging convenience functions.
 
 import logging
 
+def log(name: str = 'pypesto',
+        level: int = None,
+        console: bool = False,
+        filename: str = ''):
+    '''
+    Log messages from a specified name with a specified level to any
+    combination of console and file.
 
-def log_to_console(level: int = None, child: str = None):
+    Parameters
+    ----------
+    name:
+        The name of the logger.
+
+    level:
+        The output level to use. Default: logging.DEBUG.
+
+    console:
+        If True, messages are logged to console.
+
+    filename:
+        If specified, messages are logged to a file with this name.
+    '''
+    if level is None:
+        level = logging.DEBUG
+
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    if console:
+        ch = logging.StreamHandler()
+        ch.setLevel(level)
+        logger.addHandler(ch)
+
+    if filename:
+        fh = logging.FileHandler(filename)
+        fh.setLevel(level)
+        logger.addHandler(fh)
+
+def log_to_console(level: int = None):
     """
     Log to console.
 
     Parameters
     ----------
-
-    level:
-        The output level to use. Default: logging.DEBUG.
-
-    child:
-        The name of the descendant to the 'pypesto' logger. For example, if
-        child is 'model_selection', then the logger name will be
-        'pypesto.model_selection'.
-
+    See the `log` method.
     """
-    if level is None:
-        level = logging.DEBUG
-
-    logger = logging.getLogger('pypesto')
-    if child is not None:
-        logger = logger.getChild(child)
-
-    logger.setLevel(level)
-    ch = logging.StreamHandler()
-    ch.setLevel(level)
-    logger.addHandler(ch)
+    log(level=level, console=True)
 
 
-def log_to_file(level: int = None, filename: str = None, child: str = None):
+def log_to_file(level: int = None, filename: str = None):
     """
     Log to file.
 
     Parameters
     ----------
-
-    level:
-        The output level to use. Default: logging.DEBUG.
-
-    filename:
-        The name of the file to append to.
-        Default: .pypesto_logging.log.
-
-    child:
-        The name of the descendant to the 'pypesto' logger. For example, if
-        child is 'model_selection', then the logger name will be
-        'pypesto.model_selection'.
+    See the `log` method.
     """
-
-    if level is None:
-        level = logging.DEBUG
-
     if filename is None:
         filename = ".pypesto_logging.log"
-
-    logger = logging.getLogger('pypesto')
-    if child is not None:
-        logger = logger.getChild(child)
-
-    logger.setLevel(level)
-    fh = logging.FileHandler(filename)
-    fh.setLevel(level)
-    logger.addHandler(fh)
+    log(level=level, filename=filename)

--- a/pypesto/logging.py
+++ b/pypesto/logging.py
@@ -21,7 +21,7 @@ def log(name: str = 'pypesto',
         The name of the logger.
 
     level:
-        The output level to use. Default: logging.DEBUG.
+        The output level to use.
 
     console:
         If True, messages are logged to console.

--- a/pypesto/logging.py
+++ b/pypesto/logging.py
@@ -8,7 +8,7 @@ Logging convenience functions.
 import logging
 
 def log(name: str = 'pypesto',
-        level: int = None,
+        level: int = logging.DEBUG,
         console: bool = False,
         filename: str = ''):
     '''
@@ -29,9 +29,6 @@ def log(name: str = 'pypesto',
     filename:
         If specified, messages are logged to a file with this name.
     '''
-    if level is None:
-        level = logging.DEBUG
-
     logger = logging.getLogger(name)
     logger.setLevel(level)
 
@@ -45,7 +42,7 @@ def log(name: str = 'pypesto',
         fh.setLevel(level)
         logger.addHandler(fh)
 
-def log_to_console(level: int = None):
+def log_to_console(level: int = logging.DEBUG):
     """
     Log to console.
 
@@ -56,7 +53,8 @@ def log_to_console(level: int = None):
     log(level=level, console=True)
 
 
-def log_to_file(level: int = None, filename: str = None):
+def log_to_file(level: int = logging.DEBUG,
+                filename: str = '.pypesto_logging.log'):
     """
     Log to file.
 
@@ -64,6 +62,4 @@ def log_to_file(level: int = None, filename: str = None):
     ----------
     See the `log` method.
     """
-    if filename is None:
-        filename = ".pypesto_logging.log"
     log(level=level, filename=filename)


### PR DESCRIPTION
Log only the messages from model selection, for example.

Also changed type hinting.