### PR TITLE
Fix exception type for `import_module` in PEtab import

### DIFF
--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -137,7 +137,7 @@ class PetabImporter(AmiciObjectBuilder):
         try:
             # importing will already raise an exception if version wrong
             importlib.import_module(self.model_name)
-        except RuntimeError:
+        except ModuleNotFoundError:
             return True
 
         # no need to (re-)compile


### PR DESCRIPTION
Correctly use `MuduleNotFoundError` instead of `RuntimeError`, as in AMICI (see https://github.com/ICB-DCM/AMICI/blob/8f7f2819a0648e3e319ae9390b6b38ddb5baf4c1/python/amici/petab_import.py#L355).