### PR TITLE
fix #390: Hessian computation

### DIFF
--- a/pypesto/objective/amici.py
+++ b/pypesto/objective/amici.py
@@ -3,7 +3,7 @@ import copy
 import tempfile
 import os
 import abc
-from typing import Dict, Tuple, Sequence, Union
+from typing import Dict, Sequence, Union
 from collections import OrderedDict
 
 from .base import ObjectiveBase
@@ -60,6 +60,7 @@ class AmiciObjective(ObjectiveBase):
                  parameter_mapping: 'ParameterMapping' = None,
                  guess_steadystate: bool = True,
                  n_threads: int = 1,
+                 fim_for_hess: bool = True,
                  amici_object_builder: AmiciObjectBuilder = None,
                  calculator: AmiciCalculator = None):
         """
@@ -96,6 +97,12 @@ class AmiciObjective(ObjectiveBase):
             Number of threads that are used for parallelization over
             experimental conditions. If amici was not installed with openMP
             support this option will have no effect.
+        fim_for_hess:
+            Whether to use the FIM whenever the Hessian is requested. This only
+            applies with forward sensitivities.
+            With adjoint sensitivities, the true Hessian will be used,
+            if available.
+            FIM or Hessian will only be exposed if `max_sensi_order>1`.
         amici_object_builder:
             AMICI object builder. Allows recreating the objective for
             pickling, required in some parallelization schemes.
@@ -108,11 +115,6 @@ class AmiciObjective(ObjectiveBase):
                 "This objective requires an installation of amici "
                 "(https://github.com/icb-dcm/amici). "
                 "Install via `pip3 install amici`.")
-
-        if max_sensi_order is None:
-            # 2 if model was compiled with second orders,
-            # otherwise 1 can be guaranteed
-            max_sensi_order = 2 if amici_model.o2mode else 1
 
         self.amici_model = amici.ModelPtr(amici_model.clone())
         self.amici_solver = amici.SolverPtr(amici_solver.clone())
@@ -169,6 +171,7 @@ class AmiciObjective(ObjectiveBase):
             x_names = x_ids
 
         self.n_threads = n_threads
+        self.fim_for_hess = fim_for_hess
         self.amici_object_builder = amici_object_builder
 
         if calculator is None:
@@ -222,7 +225,6 @@ class AmiciObjective(ObjectiveBase):
             raise NotImplementedError(
                 "AmiciObjective does not support __setstate__ without "
                 "an `amici_object_builder`.")
-
         self.__dict__.update(state)
 
         # note: attributes not defined in the builder are lost
@@ -242,37 +244,35 @@ class AmiciObjective(ObjectiveBase):
         except AttributeError as err:
             if not err.args:
                 err.args = ('',)
-            err.args = err.args + ("Amici must have been compiled with hdf5 "
-                                   "support",)
+            err.args += ("Amici must have been compiled with hdf5 support",)
             raise
         self.amici_model = model
         self.amici_solver = solver
         self.edatas = edatas
 
     def check_sensi_orders(self, sensi_orders, mode) -> bool:
-        sensi_order = self._get_amici_sensi_order(sensi_orders)
+        sensi_order = max(sensi_orders)
 
-        if self.max_sensi_order is None:
-            if mode == MODE_FUN:
-                max_sensi_order = 1 + self.amici_model.o2mode
-            else:
-                max_sensi_order = 1
-        else:
-            max_sensi_order = self.max_sensi_order
+        # dynamically obtain maximum allowed sensitivity order
+        max_sensi_order = self.max_sensi_order
+        if max_sensi_order is None:
+            max_sensi_order = 1
+            # check whether it is ok to request 2nd order
+            sensi_mthd = self.amici_solver.getSensitivityMethod()
+            mthd_fwd = amici.SensitivityMethod_forward
+            if mode == MODE_FUN and (
+                    self.amici_model.o2mode or (
+                    sensi_mthd == mthd_fwd and self.fim_for_hess)):
+                max_sensi_order = 2
 
+        # evaluate sensitivity order
         return sensi_order <= max_sensi_order
-
-    def _get_amici_sensi_order(self, sensi_orders: Tuple[int, ...]) -> int:
-        # amici is built such that only the maximum sensitivity is required,
-        # the lower orders are then automatically computed
-        # order 2 currently not implemented, we are using the FIM
-        return min(max(sensi_orders), 1)
 
     def check_mode(self, mode):
         return mode in [MODE_FUN, MODE_RES]
 
     def call_unprocessed(self, x, sensi_orders, mode):
-        sensi_order = self._get_amici_sensi_order(sensi_orders)
+        sensi_order = max(sensi_orders)
 
         x_dct = self.par_arr_to_dct(x)
 
@@ -286,7 +286,9 @@ class AmiciObjective(ObjectiveBase):
             x_dct=x_dct, sensi_order=sensi_order, mode=mode,
             amici_model=self.amici_model, amici_solver=self.amici_solver,
             edatas=self.edatas, n_threads=self.n_threads,
-            x_ids=self.x_ids, parameter_mapping=self.parameter_mapping)
+            x_ids=self.x_ids, parameter_mapping=self.parameter_mapping,
+            fim_for_hess=self.fim_for_hess,
+        )
 
         nllh = ret[FVAL]
         rdatas = ret[RDATAS]

--- a/pypesto/objective/amici_calculator.py
+++ b/pypesto/objective/amici_calculator.py
@@ -41,7 +41,8 @@ class AmiciCalculator:
                  edatas: List['amici.ExpData'],
                  n_threads: int,
                  x_ids: Sequence[str],
-                 parameter_mapping: 'ParameterMapping'):
+                 parameter_mapping: 'ParameterMapping',
+                 fim_for_hess: bool):
         """Perform the actual AMICI call.
 
         Called within the :func:`AmiciObjective.__call__` method.
@@ -66,9 +67,16 @@ class AmiciCalculator:
             Ids of optimization parameters.
         parameter_mapping:
             Mapping of optimization to simulation parameters.
+        fim_for_hess:
+            Whether to use the FIM (if available) instead of the Hessian (if
+            requested).
         """
         # set order in solver
-        amici_solver.setSensitivityOrder(sensi_order)
+        if sensi_order == 2 and fim_for_hess:
+            # we use the FIM
+            amici_solver.setSensitivityOrder(sensi_order-1)
+        else:
+            amici_solver.setSensitivityOrder(sensi_order)
 
         # fill in parameters
         # TODO (#226) use plist to compute only required derivatives
@@ -100,8 +108,10 @@ class AmiciCalculator:
             self._known_least_squares_safe = True  # don't check this again
 
         return calculate_function_values(
-            rdatas, sensi_order, mode, amici_model, amici_solver, edatas,
-            x_ids, parameter_mapping)
+            rdatas=rdatas, sensi_order=sensi_order, mode=mode,
+            amici_model=amici_model, amici_solver=amici_solver, edatas=edatas,
+            x_ids=x_ids, parameter_mapping=parameter_mapping,
+            fim_for_hess=fim_for_hess)
 
 
 def calculate_function_values(rdatas,
@@ -111,7 +121,8 @@ def calculate_function_values(rdatas,
                               amici_solver: AmiciSolver,
                               edatas: List['amici.ExpData'],
                               x_ids: Sequence[str],
-                              parameter_mapping: 'ParameterMapping'):
+                              parameter_mapping: 'ParameterMapping',
+                              fim_for_hess: bool):
     # full optimization problem dimension (including fixed parameters)
     dim = len(x_ids)
 
@@ -139,17 +150,19 @@ def calculate_function_values(rdatas,
     par_sim_ids = list(amici_model.getParameterIds())
     sensi_method = amici_solver.getSensitivityMethod()
 
+    # iterate over return data
     for data_ix, rdata in enumerate(rdatas):
         log_simulation(data_ix, rdata)
 
         condition_map_sim_var = \
             parameter_mapping[data_ix].map_sim_var
 
+        # add objective value
         nllh -= rdata['llh']
 
-        # compute objective
         if mode == MODE_FUN:
             if sensi_order > 0:
+                # add gradient
                 add_sim_grad_to_opt_grad(
                     x_ids,
                     par_sim_ids,
@@ -158,16 +171,22 @@ def calculate_function_values(rdatas,
                     snllh,
                     coefficient=-1.0
                 )
-                if sensi_method == 1:
-                    # TODO Compute the full Hessian, and check here
-                    add_sim_hess_to_opt_hess(
-                        x_ids,
-                        par_sim_ids,
-                        condition_map_sim_var,
-                        rdata['FIM'],
-                        s2nllh,
-                        coefficient=+1.0
-                    )
+
+                # Hessian
+                if sensi_order > 1:
+                    if sensi_method == amici.SensitivityMethod_forward \
+                            and fim_for_hess:
+                        # add FIM for Hessian
+                        add_sim_hess_to_opt_hess(
+                            x_ids,
+                            par_sim_ids,
+                            condition_map_sim_var,
+                            rdata['FIM'],
+                            s2nllh,
+                            coefficient=+1.0
+                        )
+                    else:
+                        raise ValueError("AMICI cannot compute Hessians yet.")
 
         elif mode == MODE_RES:
             chi2 += rdata['chi2']


### PR DESCRIPTION
* Allow to define whether the FIM should be used in place of the Hessian
* Check in detail whether requested derivatives are available

Breaking change:
* FIM is now only computed (and thus logged) if `sensi_order > 1` and `fim_for_hess == True`

Fixes #390