### PR TITLE
Fix metropolis initial parameters

### DIFF
--- a/pypesto/sampling/sample.py
+++ b/pypesto/sampling/sample.py
@@ -51,9 +51,8 @@ def sample(
     # try to find initial parameters
     if x0 is None:
         result.optimize_result.sort()
-        xs = result.optimize_result.get_for_key('x')
-        if len(xs) > 0:
-            x0 = xs[0]
+        if len(result.optimize_result.list) > 0:
+            x0 = problem.get_reduced_vector(result.optimize_result.list[0]['x'])
         # TODO multiple x0 for PT, #269
 
     # set sampler

--- a/pypesto/sampling/sample.py
+++ b/pypesto/sampling/sample.py
@@ -52,7 +52,8 @@ def sample(
     if x0 is None:
         result.optimize_result.sort()
         if len(result.optimize_result.list) > 0:
-            x0 = problem.get_reduced_vector(result.optimize_result.list[0]['x'])
+            x0 = problem.get_reduced_vector(
+                result.optimize_result.list[0]['x'])
         # TODO multiple x0 for PT, #269
 
     # set sampler

--- a/test/test_sampling.py
+++ b/test/test_sampling.py
@@ -60,28 +60,22 @@ def gaussian_mixture_separated_modes_problem():
 
 
 def rosenbrock_problem():
-    """Problem based on rosenbrock objective."""
+    """Problem based on rosenbrock objective.
+
+    Features
+    --------
+    * 3-dim
+    * has fixed parameters
+    """
     objective = pypesto.Objective(fun=so.rosen)
 
     dim_full = 2
     lb = -5 * np.ones((dim_full, 1))
     ub = 5 * np.ones((dim_full, 1))
 
-    problem = pypesto.Problem(objective=objective, lb=lb, ub=ub)
-    return problem
-
-
-def rosenbrock_fixed_problem():
-    """Problem based on rosenbrock objective with fixed parameters."""
-    objective = pypesto.Objective(fun=so.rosen)
-
-    dim_full = 2
-    lb = -5 * np.ones((dim_full, 1))
-    ub = 5 * np.ones((dim_full, 1))
-
-    # rosenbrock with one fixed parameter
-    problem = pypesto.Problem(objective=objective, lb=lb, ub=ub,
-                              x_fixed_indices=[1], x_fixed_vals=[42])
+    problem = pypesto.Problem(
+            objective=objective, lb=lb, ub=ub,
+            x_fixed_indices=[1], x_fixed_vals=[2])
     return problem
 
 
@@ -138,29 +132,6 @@ def test_pipeline(sampler, problem):
     # optimization
     optimizer = pypesto.ScipyOptimizer(options={'maxiter': 10})
     result = pypesto.minimize(problem, n_starts=3, optimizer=optimizer)
-
-    # sampling
-    result = pypesto.sample(
-        problem, sampler=sampler, n_samples=100, result=result)
-
-    # some plot
-    pypesto.visualize.sampling_1d_marginals(result)
-    plt.close()
-
-
-def test_fixed_parameters():
-    """Check that pipeline runs with fixed parameters."""
-
-    # define problem
-    problem = rosenbrock_fixed_problem()
-
-    # optimization
-    optimizer = pypesto.ScipyOptimizer(options={'maxiter': 10})
-    result = pypesto.minimize(problem, n_starts=3, optimizer=optimizer)
-
-    # define sampler
-    sampler = pypesto.AdaptiveParallelTemperingSampler(
-        internal_sampler=pypesto.AdaptiveMetropolisSampler(), n_chains=5)
 
     # sampling
     result = pypesto.sample(

--- a/test/test_sampling.py
+++ b/test/test_sampling.py
@@ -71,6 +71,20 @@ def rosenbrock_problem():
     return problem
 
 
+def rosenbrock_fixed_problem():
+    """Problem based on rosenbrock objective with fixed parameters."""
+    objective = pypesto.Objective(fun=so.rosen)
+
+    dim_full = 2
+    lb = -5 * np.ones((dim_full, 1))
+    ub = 5 * np.ones((dim_full, 1))
+
+    # rosenbrock with one fixed parameter
+    problem = pypesto.Problem(objective=objective, lb=lb, ub=ub,
+                              x_fixed_indices=[1], x_fixed_vals=[42])
+    return problem
+
+
 def prior(x):
     return multivariate_normal.pdf(x, mean=-1., cov=0.7)
 
@@ -124,6 +138,29 @@ def test_pipeline(sampler, problem):
     # optimization
     optimizer = pypesto.ScipyOptimizer(options={'maxiter': 10})
     result = pypesto.minimize(problem, n_starts=3, optimizer=optimizer)
+
+    # sampling
+    result = pypesto.sample(
+        problem, sampler=sampler, n_samples=100, result=result)
+
+    # some plot
+    pypesto.visualize.sampling_1d_marginals(result)
+    plt.close()
+
+
+def test_fixed_parameters():
+    """Check that pipeline runs with fixed parameters."""
+
+    # define problem
+    problem = rosenbrock_fixed_problem()
+
+    # optimization
+    optimizer = pypesto.ScipyOptimizer(options={'maxiter': 10})
+    result = pypesto.minimize(problem, n_starts=3, optimizer=optimizer)
+
+    # define sampler
+    sampler = pypesto.AdaptiveParallelTemperingSampler(
+        internal_sampler=pypesto.AdaptiveMetropolisSampler(), n_chains=5)
 
     # sampling
     result = pypesto.sample(


### PR DESCRIPTION
Initialization of the MCMC sampling from the pypesto results was insensitive to the presence of fixed parameters leading to error (would take the full parameter vector instead of the reduced one).
This is fixed in this PR