### PR TITLE
fix hierarchical branch x_guesses

### DIFF
--- a/pypesto/hierarchical/solver.py
+++ b/pypesto/hierarchical/solver.py
@@ -130,7 +130,7 @@ class NumericalInnerSolver(InnerSolver):
         pypesto_problem = Problem(objective, lb=lb, ub=ub, x_names=x_names)
 
         if self.x_guesses is not None:
-            pypesto_problem.x_guesses = self.x_guesses
+            pypesto_problem.x_guesses_full = self.x_guesses[:,pypesto_problem.x_free_indices]
 
         # perform the actual optimization
         result = minimize(pypesto_problem, n_starts=self.n_starts)


### PR DESCRIPTION
This fixed things a while ago, but looking at it again now, maybe it should be the following in general? In any case, `pypesto_problem.x_guesses` shouldn't be used, as it is an `@property`.
```python
pypesto_problem.x_guesses_full[:,pypesto_problem.x_free_indices] = self.x_guesses[:,pypesto_problem.x_free_indices]
```