### PR TITLE
Fix HistoryOptions: allow .h5 as HDF5 file extension

### DIFF
--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -160,7 +160,7 @@ class HistoryOptions(dict):
             return CsvHistory(
                 x_names=x_names,
                 file=storage_file, options=self)
-        elif type == '.hdf5':
+        elif type in ['.hdf5', '.h5']:
             return Hdf5History(id=id, file=storage_file, options=self)
         else:
             raise ValueError(


### PR DESCRIPTION
`.h5` is the official HDF5 file extension and should therefore be allowed here.