### PR TITLE
Various fixes: GHA, rerunfailues, ipopt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         file: ./coverage.xml
 
   optimize:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.8]
@@ -99,7 +99,7 @@ jobs:
         key: ${{ runner.os }}-ci-optimize
 
     - name: Install dependencies
-      run: .github/workflows/install_deps.sh mpi
+      run: .github/workflows/install_deps.sh mpi ipopt
 
     - name: Run tests
       timeout-minutes: 5
@@ -171,7 +171,7 @@ jobs:
       run: tox -e doc
 
   notebooks1:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.8]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-ci-optimize
 
     - name: Install dependencies
-      run: .github/workflows/install_deps.sh mpi ipopt
+      run: .github/workflows/install_deps.sh ipopt
 
     - name: Run tests
       timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       timeout-minutes: 1
       run: tox -e project,flake8
 
-    - name: Run pre-commits
+    - name: Run pre-commit hooks
       run: pre-commit run --all-files
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         key: ${{ runner.os }}-ci-optimize
 
     - name: Install dependencies
-      run: .github/workflows/install_deps.sh
+      run: .github/workflows/install_deps.sh mpi
 
     - name: Run tests
       timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       run: tox -e doc
 
   notebooks1:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-ci-quality
 
     - name: Install dependencies
-      run: pip install -r ./requirements-dev.txt
+      run: pip install tox pre-commit
 
     - name: Check repository size
       run: tox -e size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       run: .github/workflows/install_deps.sh mpi ipopt
 
     - name: Run tests
-      timeout-minutes: 5
+      timeout-minutes: 7
       run: tox -e optimize
 
     - name: Coverage
@@ -133,7 +133,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-ci-quality
 
     - name: Install dependencies
-      run: .github/workflows/install_deps.sh
+      run: pip install -r requirements-dev.txt
 
     - name: Check repository size
       run: tox -e size
@@ -141,6 +141,9 @@ jobs:
     - name: Run quality checks
       timeout-minutes: 1
       run: tox -e project,flake8
+
+    - name: Run pre-commits
+      run: pre-commit run --all-files
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-ci-quality
 
     - name: Install dependencies
-      run: pip install -r requirements-dev.txt
+      run: pip install -r ./requirements-dev.txt
 
     - name: Check repository size
       run: tox -e size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         file: ./coverage.xml
 
   optimize:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-ci-base
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-base
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici
@@ -62,7 +62,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-ci-petab
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-petab
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici pysb
@@ -96,7 +96,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-ci-optimize
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-optimize
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh mpi ipopt
@@ -130,7 +130,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-ci-quality
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-quality
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh
@@ -161,7 +161,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-ci-docs
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-docs
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh doc amici
@@ -189,7 +189,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-ci-notebooks1
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-notebooks1
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici ipopt
@@ -217,7 +217,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-ci-notebooks2
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-notebooks2
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         key: ${{ runner.os }}-ci-optimize
 
     - name: Install dependencies
-      run: .github/workflows/install_deps.sh ipopt
+      run: .github/workflows/install_deps.sh
 
     - name: Run tests
       timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       run: .github/workflows/install_deps.sh mpi ipopt
 
     - name: Run tests
-      timeout-minutes: 7
+      timeout-minutes: 10
       run: tox -e optimize
 
     - name: Coverage

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -9,6 +9,9 @@ pip install wheel setuptools
 # Used to create local test environments
 pip install tox
 
+# Update apt
+sudo apt-get update
+
 # Check arguments
 for par in "$@"; do
   case $par in
@@ -43,7 +46,7 @@ for par in "$@"; do
 
     mpi)
       # mpi
-      sudo apt install libopenmpi-dev
+      sudo apt-get install libopenmpi-dev
     ;;
 
     *)

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -13,9 +13,9 @@ from .result import OptimizerResult
 from ..objective.constants import MODE_FUN, FVAL, GRAD
 
 try:
-    import ipopt
+    import cyipopt
 except ImportError:
-    ipopt = None
+    cyipopt = None
 
 try:
     import dlib
@@ -441,7 +441,7 @@ class IpoptOptimizer(Optimizer):
         Parameters
         ----------
         options:
-            Options are directly passed on to `ipopt.minimize_ipopt`.
+            Options are directly passed on to `cyipopt.minimize_ipopt`.
         """
         super().__init__()
         self.options = options
@@ -457,7 +457,7 @@ class IpoptOptimizer(Optimizer):
             history_options: HistoryOptions = None,
     ) -> OptimizerResult:
 
-        if ipopt is None:
+        if cyipopt is None:
             raise ImportError(
                 "This optimizer requires an installation of ipopt. You can "
                 "install ipopt via `pip install ipopt`."
@@ -467,7 +467,7 @@ class IpoptOptimizer(Optimizer):
 
         bounds = np.array([problem.lb, problem.ub]).T
 
-        ret = ipopt.minimize_ipopt(
+        ret = cyipopt.minimize_ipopt(
             fun=objective.get_fval,
             x0=x0,
             method=None,  # ipopt does not use this argument for anything

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,8 @@ amici =
 petab =
     petab >= 0.1.14
 ipopt =
-    ipopt >= 0.1.9
+    # pypi has incomplete build
+    git+https://github.com/mechmotum/cyipopt.git
 dlib =
     dlib >= 19.19.0
 nlopt =
@@ -108,6 +109,7 @@ test =
     pytest >= 5.4.3
     pytest-cov >= 2.10.0
     gitpython >= 3.1.7
+    pytest-rerunfailures >= 9.1.1
 test_petab =
     petabtests >= 0.0.0a6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ petab =
     petab >= 0.1.14
 ipopt =
     # pypi has incomplete build
-    "git+https://github.com/mechmotum/cyipopt.git"
+    cyipopt @ git+https://github.com/mechmotum/cyipopt.git@master
 dlib =
     dlib >= 19.19.0
 nlopt =

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ petab =
     petab >= 0.1.14
 ipopt =
     # pypi has incomplete build
-    git+https://github.com/mechmotum/cyipopt.git
+    "git+https://github.com/mechmotum/cyipopt.git"
 dlib =
     dlib >= 19.19.0
 nlopt =

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -211,52 +211,41 @@ def test_mpipoolengine():
     """
     Test the MPIPoolEngine by calling an example script with mpiexec.
     """
-    # get the path to this file:
-    path = os.path.dirname(__file__)
-    # run the example file.
-    subprocess.check_call(  # noqa: S603,S607
-        ['mpiexec', '-np', '2', 'python', '-m', 'mpi4py.futures',
-         f'{path}/../../doc/example/example_MPIPool.py'])
+    try:
+        # get the path to this file:
+        path = os.path.dirname(__file__)
+        # run the example file.
+        subprocess.check_call(  # noqa: S603,S607
+            ['mpiexec', '-np', '2', 'python', '-m', 'mpi4py.futures',
+            f'{path}/../../doc/example/example_MPIPool.py'])
 
-    # read results
-    opt_result_reader = OptimizationResultHDF5Reader('temp_result.h5')
-    result1 = opt_result_reader.read()
-    # set optimizer
-    optimizer = optimize.FidesOptimizer(verbose=0)
-    # initialize problem with x_guesses and objective
-    objective = pypesto.Objective(fun=sp.optimize.rosen,
-                                  grad=sp.optimize.rosen_der,
-                                  hess=sp.optimize.rosen_hess)
-    x_guesses = np.array([result1.optimize_result.list[i]['x0']
-                          for i in range(2)])
-    problem = pypesto.Problem(objective=objective,
-                              ub=result1.problem.ub,
-                              lb=result1.problem.lb,
-                              x_guesses=x_guesses)
-    result2 = optimize.minimize(problem=problem,
-                                optimizer=optimizer,
-                                n_starts=2,
-                                engine=pypesto.engine.MultiProcessEngine())
+        # read results
+        opt_result_reader = OptimizationResultHDF5Reader('temp_result.h5')
+        result1 = opt_result_reader.read()
+        # set optimizer
+        optimizer = optimize.FidesOptimizer(verbose=0)
+        # initialize problem with x_guesses and objective
+        objective = pypesto.Objective(fun=sp.optimize.rosen,
+                                      grad=sp.optimize.rosen_der,
+                                      hess=sp.optimize.rosen_hess)
+        x_guesses = np.array([result1.optimize_result.list[i]['x0']
+                              for i in range(2)])
+        problem = pypesto.Problem(objective=objective,
+                                  ub=result1.problem.ub,
+                                  lb=result1.problem.lb,
+                                  x_guesses=x_guesses)
+        result2 = optimize.minimize(problem=problem,
+                                    optimizer=optimizer,
+                                    n_starts=2,
+                                    engine=pypesto.engine.MultiProcessEngine())
 
-    if(result1.optimize_result.list[0]['id'] ==
-            result2.optimize_result.list[0]['id']):
-        assert_almost_equal(result1.optimize_result.list[0]['x'],
-                            result2.optimize_result.list[0]['x'],
-                            err_msg='The final parameter values '
-                                    'do not agree for the engines.')
-        assert_almost_equal(result1.optimize_result.list[1]['x'],
-                            result2.optimize_result.list[1]['x'],
-                            err_msg='The final parameter values '
-                                    'do not agree for the engines.')
-    else:
-        assert_almost_equal(result1.optimize_result.list[0]['x'],
-                            result2.optimize_result.list[1]['x'],
-                            err_msg='The final parameter values '
-                                    'do not agree for the engines.')
-        assert_almost_equal(result1.optimize_result.list[1]['x'],
-                            result2.optimize_result.list[0]['x'],
-                            err_msg='The final parameter values '
-                                    'do not agree for the engines.')
+        for ix in range(2):
+            assert_almost_equal(result1.optimize_result.list[ix]['x'],
+                                result2.optimize_result.list[ix]['x'],
+                                err_msg='The final parameter values '
+                                        'do not agree for the engines.')
 
-    # delete data
-    os.remove('temp_result.h5')
+    finally:
+        if os.path.exists('temp_result.h5'):
+            # delete data
+            os.remove('temp_result.h5')

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -217,7 +217,7 @@ def test_mpipoolengine():
         # run the example file.
         subprocess.check_call(  # noqa: S603,S607
             ['mpiexec', '-np', '2', 'python', '-m', 'mpi4py.futures',
-            f'{path}/../../doc/example/example_MPIPool.py'])
+             f'{path}/../../doc/example/example_MPIPool.py'])
 
         # read results
         opt_result_reader = OptimizationResultHDF5Reader('temp_result.h5')

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -156,7 +156,7 @@ def test_ground_truth():
 
     result = optimize.minimize(problem)
 
-    result = sample.sample(problem, n_samples=10000,
+    result = sample.sample(problem, n_samples=5000,
                            result=result, sampler=sampler)
 
     # get samples of first chain
@@ -444,6 +444,7 @@ def test_empty_prior():
     assert (logprior_trace == 0.).all()
 
 
+@pytest.mark.flaky(reruns=2)
 def test_prior():
     """Check that priors are defined for sampling."""
     # define negative log posterior

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ description =
     Test PEtab functionality
 
 [testenv:optimize]
-extras = test,dlib,pyswarm,cmaes,ipopt,nlopt,fides,mpi
+extras = test,dlib,pyswarm,cmaes,nlopt,fides,mpi
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize -s

--- a/tox.ini
+++ b/tox.ini
@@ -65,10 +65,8 @@ description =
     Test PEtab functionality
 
 [testenv:optimize]
-extras = test,dlib,pyswarm,cmaes,nlopt,fides,mpi
+extras = test,dlib,pyswarm,cmaes,ipopt,nlopt,fides,mpi
 commands =
-    pip install cython  # required by ipopt
-    pip install 'ipopt >= 0.1.9'
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize -s
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -65,10 +65,8 @@ description =
     Test PEtab functionality
 
 [testenv:optimize]
-extras = test,dlib,pyswarm,cmaes,nlopt,fides,mpi
+extras = test,dlib,pyswarm,cmaes,ipopt,nlopt,fides,mpi
 commands =
-    pip install cython  # required by ipopt
-    pip install 'ipopt >= 0.1.9'
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize -s
 description =
@@ -76,10 +74,8 @@ description =
 
 [testenv:notebooks1]
 allowlist_externals = bash
-extras = example,amici,petab,pyswarm,pymc3,cmaes,nlopt,fides
+extras = example,amici,petab,pyswarm,pymc3,cmaes,ipopt,nlopt,fides
 commands =
-    pip install cython  # required by ipopt
-    pip install 'ipopt >= 0.1.9'
     bash test/run_notebook.sh 1
 description =
     Run notebooks 1

--- a/tox.ini
+++ b/tox.ini
@@ -65,9 +65,8 @@ description =
     Test PEtab functionality
 
 [testenv:optimize]
-extras = test,dlib,pyswarm,cmaes,nlopt,fides,mpi
+extras = test,dlib,pyswarm,cmaes,nlopt,fides,ipopt,mpi
 commands =
-    pip install .[ipopt]
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize -s
 description =
@@ -75,7 +74,7 @@ description =
 
 [testenv:notebooks1]
 allowlist_externals = bash
-extras = example,amici,petab,pyswarm,pymc3,cmaes,ipopt,nlopt,fides
+extras = example,amici,petab,pyswarm,pymc3,cmaes,nlopt,fides,ipopt
 commands =
     bash test/run_notebook.sh 1
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -65,8 +65,9 @@ description =
     Test PEtab functionality
 
 [testenv:optimize]
-extras = test,dlib,pyswarm,cmaes,ipopt,nlopt,fides,mpi
+extras = test,dlib,pyswarm,cmaes,nlopt,fides,mpi
 commands =
+    pip install .[ipopt]
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize -s
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,8 @@ description =
 [testenv:optimize]
 extras = test,dlib,pyswarm,cmaes,nlopt,fides,mpi
 commands =
+    pip install cython  # required by ipopt
+    pip install 'ipopt >= 0.1.9'
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize -s
 description =


### PR DESCRIPTION
* Fix GHA for Ubuntu latest==20.04 (forget cache)
* Update aptitude package lists
* Add pytest-rerunfailures for often failing tests (to be extended if tests fail regularly)
* Simplify ipopt installation from latest master, use preferred name "cyipopt"
* Test pre-commit hooks