### PR TITLE
Fix 636

### DIFF
--- a/pypesto/store/read_from_hdf5.py
+++ b/pypesto/store/read_from_hdf5.py
@@ -207,7 +207,11 @@ class SamplingResultHDF5Reader:
             for key in f['/sampling/results'].attrs:
                 sample_result[key] = \
                     f['/sampling/results'].attrs[key]
-        self.results.sample_result = McmcPtResult(**sample_result)
+        try:
+            self.results.sample_result = McmcPtResult(**sample_result)
+        except TypeError:
+            logger.warning("Warning: You tried loading a non existent "
+                           "sampling result.")
 
         return self.results
 

--- a/pypesto/store/read_from_hdf5.py
+++ b/pypesto/store/read_from_hdf5.py
@@ -210,7 +210,7 @@ class SamplingResultHDF5Reader:
         try:
             self.results.sample_result = McmcPtResult(**sample_result)
         except TypeError:
-            logger.warning("Warning: You tried loading a non existent "
+            logger.warning("Warning: You tried loading a non-existent "
                            "sampling result.")
 
         return self.results

--- a/pypesto/store/save_to_hdf5.py
+++ b/pypesto/store/save_to_hdf5.py
@@ -186,6 +186,8 @@ class SamplingResultHDF5Writer:
         Write HDF5 sampling file from pyPESTO result object.
         """
         # if there is no sample available, log a warning and return
+        # SampleResult is only a dummy class created by the Result class
+        # and always indicates the lack of a sampling result.
         if(isinstance(result.sample_result, SampleResult)):
             logger.warning("Warning: There is no sampling_result, "
                            "which you tried to save to hdf5.")

--- a/pypesto/store/save_to_hdf5.py
+++ b/pypesto/store/save_to_hdf5.py
@@ -185,7 +185,7 @@ class SamplingResultHDF5Writer:
         """
         Write HDF5 sampling file from pyPESTO result object.
         """
-        # if there is no sample available, raise a warning and return
+        # if there is no sample available, log a warning and return
         if(isinstance(result.sample_result, SampleResult)):
             logger.warning("Warning: There is no sampling_result, "
                            "which you tried to save to hdf5.")

--- a/pypesto/store/save_to_hdf5.py
+++ b/pypesto/store/save_to_hdf5.py
@@ -311,8 +311,5 @@ def write_result(result: Result,
         pypesto_profile_writer.write(result, overwrite=overwrite)
 
     if sample:
-        try:
-            pypesto_sample_writer = SamplingResultHDF5Writer(filename)
-            pypesto_sample_writer.write(result, overwrite=overwrite)
-        except:
-            print('stop')
+        pypesto_sample_writer = SamplingResultHDF5Writer(filename)
+        pypesto_sample_writer.write(result, overwrite=overwrite)

--- a/pypesto/store/save_to_hdf5.py
+++ b/pypesto/store/save_to_hdf5.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Union
 from numbers import Integral
 
@@ -6,7 +7,9 @@ import h5py
 import numpy as np
 
 from .hdf5 import write_array, write_float_array
-from ..result import Result
+from ..result import Result, SampleResult
+
+logger = logging.getLogger(__name__)
 
 
 def check_overwrite(f: Union[h5py.File, h5py.Group],
@@ -182,6 +185,11 @@ class SamplingResultHDF5Writer:
         """
         Write HDF5 sampling file from pyPESTO result object.
         """
+        # if there is no sample available, raise a warning and return
+        if(isinstance(result.sample_result, SampleResult)):
+            logger.warning("Warning: There is no sampling_result, "
+                           "which you tried to save to hdf5.")
+            return
 
         # Create destination directory
         if isinstance(self.storage_filename, str):
@@ -303,5 +311,8 @@ def write_result(result: Result,
         pypesto_profile_writer.write(result, overwrite=overwrite)
 
     if sample:
-        pypesto_sample_writer = SamplingResultHDF5Writer(filename)
-        pypesto_sample_writer.write(result, overwrite=overwrite)
+        try:
+            pypesto_sample_writer = SamplingResultHDF5Writer(filename)
+            pypesto_sample_writer.write(result, overwrite=overwrite)
+        except:
+            print('stop')


### PR DESCRIPTION
Fixes Issue #636.

I did not include a try...except for each case as the sampling is special in the sense that the Class of `result.sampling_result` changes from `SampleResult` to `McmcPtResult` when sampling is performed. This created the error.