### PR TITLE
Compatibility with newer versions of theano

### DIFF
--- a/pypesto/sample/theano.py
+++ b/pypesto/sample/theano.py
@@ -5,7 +5,11 @@ from ..problem import Problem
 
 try:
     import theano.tensor as tt
-    from theano.gof.null_type import NullType
+    try:
+        from theano.graph.null_type import NullType
+    except ImportError:
+        # for older versions of theano
+        from theano.gof.null_type import NullType
 except ImportError:
     tt = NullType = None
 


### PR DESCRIPTION
Fixes an `ImportError` due to a change in the module structure inside `theano` (or more precisely its PyMC3 fork, since the original `theano` is now discontinued).