### PR TITLE
Read-only HDF5 file access for Hdf5History.__len__

### DIFF
--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -778,7 +778,7 @@ class Hdf5History(History):
         self._generate_hdf5_group()
 
     def __len__(self):
-        with h5py.File(self.file, 'a') as f:
+        with h5py.File(self.file, 'r') as f:
             return f[f'history/{self.id}/trace/'].attrs[
                         'n_iterations']
 


### PR DESCRIPTION
That function doesn't need write access to the history file and unnecessarily prevents parallel access.
Changing to read-only.