### PR TITLE
Feature fix sorting of optimization results in presence of nan values, fixes #484

### DIFF
--- a/pypesto/result.py
+++ b/pypesto/result.py
@@ -8,6 +8,7 @@ optimization, profiling, sampling.
 
 """
 import pandas as pd
+import numpy as np
 import copy
 from typing import Sequence, TYPE_CHECKING
 
@@ -44,8 +45,10 @@ class OptimizeResult:
         """
         Sort the optimizer results by function value fval (ascending).
         """
+        def get_fval(res):
+            return res.fval if not np.isnan(res.fval) else np.inf
 
-        self.list = sorted(self.list, key=lambda res: res.fval)
+        self.list = sorted(self.list, key=get_fval)
 
     def as_dataframe(self, keys=None) -> pd.DataFrame:
         """


### PR DESCRIPTION
Sorting of optimization values failed, when the objective function value is `nan`. `nan` is now treated as `inf`.