### PR TITLE
added option to trimm the trace to a monotonically decreasing one

### DIFF
--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -338,13 +338,7 @@ class HistoryBase(abc.ABC):
         decreasing history.
         """
         fval_trace = self.get_fval_trace()
-        indices = []
-        fval_current = np.inf
-        for iter_i, fval_i in enumerate(fval_trace):
-            if fval_i <= fval_current:
-                indices.append(iter_i)
-                fval_current = fval_i
-        return indices
+        return np.where(fval_trace <= np.minimum.accumulate(fval_trace))
 
 
 class History(HistoryBase):

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -338,7 +338,7 @@ class HistoryBase(abc.ABC):
         decreasing history.
         """
         fval_trace = self.get_fval_trace()
-        return np.where(fval_trace <= np.minimum.accumulate(fval_trace))
+        return np.where(fval_trace <= np.minimum.accumulate(fval_trace))[0]
 
 
 class History(HistoryBase):

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -338,7 +338,7 @@ class HistoryBase(abc.ABC):
         decreasing history.
         """
         fval_trace = self.get_fval_trace()
-        return np.where(fval_trace <= np.minimum.accumulate(fval_trace))[0]
+        return np.where(fval_trace <= np.fmin.accumulate(fval_trace))[0]
 
 
 class History(HistoryBase):

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -25,14 +25,14 @@ def trace_wrap(f):
     """
     def wrapped_f(
             self, ix: Union[Sequence[int], int, None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[Union[float, MaybeArray]], Union[float, MaybeArray]]:
         # whether to reduce the output
         reduce = isinstance(ix, numbers.Integral)
         # default: full list
         if ix is None:
             ix = np.arange(0, len(self), dtype=int)
-            if trimm:
+            if trim:
                 ix = self.get_trimmed_indices()
         # turn every input into an index list
         if reduce:
@@ -234,7 +234,7 @@ class HistoryBase(abc.ABC):
 
     def get_x_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[np.ndarray], np.ndarray]:
         """Parameters.
 
@@ -245,7 +245,7 @@ class HistoryBase(abc.ABC):
 
     def get_fval_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         """Function values.
 
@@ -256,7 +256,7 @@ class HistoryBase(abc.ABC):
 
     def get_grad_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         """Gradients.
 
@@ -267,7 +267,7 @@ class HistoryBase(abc.ABC):
 
     def get_hess_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         """Hessians.
 
@@ -278,7 +278,7 @@ class HistoryBase(abc.ABC):
 
     def get_res_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         """Residuals.
 
@@ -289,7 +289,7 @@ class HistoryBase(abc.ABC):
 
     def get_sres_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         """Residual sensitivities.
 
@@ -300,7 +300,7 @@ class HistoryBase(abc.ABC):
 
     def get_chi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         """Chi2 values.
 
@@ -311,7 +311,7 @@ class HistoryBase(abc.ABC):
 
     def get_schi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         """Chi2 sensitivities.
 
@@ -322,7 +322,7 @@ class HistoryBase(abc.ABC):
 
     def get_time_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         """Cumulative execution times.
 
@@ -482,63 +482,63 @@ class MemoryHistory(History):
     @trace_wrap
     def get_x_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[np.ndarray], np.ndarray]:
         return [self._trace[X][i] for i in ix]
 
     @trace_wrap
     def get_fval_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return [self._trace[FVAL][i] for i in ix]
 
     @trace_wrap
     def get_grad_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return [self._trace[GRAD][i] for i in ix]
 
     @trace_wrap
     def get_hess_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return [self._trace[HESS][i] for i in ix]
 
     @trace_wrap
     def get_res_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return [self._trace[RES][i] for i in ix]
 
     @trace_wrap
     def get_sres_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return [self._trace[SRES][i] for i in ix]
 
     @trace_wrap
     def get_chi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return [self._trace[CHI2][i] for i in ix]
 
     @trace_wrap
     def get_schi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return [self._trace[SCHI2][i] for i in ix]
 
     @trace_wrap
     def get_time_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return [self._trace[TIME][i] for i in ix]
 
@@ -731,63 +731,63 @@ class CsvHistory(History):
     @trace_wrap
     def get_x_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[np.ndarray], np.ndarray]:
         return list(self._trace[X].values[ix])
 
     @trace_wrap
     def get_fval_trace(
             self, ix: Union[int, Sequence[int], None],
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return list(self._trace[(FVAL, np.nan)].values[ix])
 
     @trace_wrap
     def get_grad_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return list(self._trace[GRAD].values[ix])
 
     @trace_wrap
     def get_hess_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return list(self._trace[(HESS, np.nan)].values[ix])
 
     @trace_wrap
     def get_res_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return list(self._trace[(RES, np.nan)].values[ix])
 
     @trace_wrap
     def get_sres_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return list(self._trace[(SRES, np.nan)].values[ix])
 
     @trace_wrap
     def get_chi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return list(self._trace[(CHI2, np.nan)].values[ix])
 
     @trace_wrap
     def get_schi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return list(self._trace[SCHI2].values[ix])
 
     @trace_wrap
     def get_time_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return list(self._trace[(TIME, np.nan)].values[ix])
 
@@ -1035,63 +1035,63 @@ class Hdf5History(History):
     @trace_wrap
     def get_x_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[np.ndarray], np.ndarray]:
         return self._get_hdf5_entries(X, ix)
 
     @trace_wrap
     def get_fval_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return self._get_hdf5_entries(FVAL, ix)
 
     @trace_wrap
     def get_grad_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return self._get_hdf5_entries(GRAD, ix)
 
     @trace_wrap
     def get_hess_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return self._get_hdf5_entries(HESS, ix)
 
     @trace_wrap
     def get_res_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return self._get_hdf5_entries(RES, ix)
 
     @trace_wrap
     def get_sres_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return self._get_hdf5_entries(SRES, ix)
 
     @trace_wrap
     def get_chi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return self._get_hdf5_entries(CHI2, ix)
 
     @trace_wrap
     def get_schi2_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[MaybeArray], MaybeArray]:
         return self._get_hdf5_entries(SCHI2, ix)
 
     @trace_wrap
     def get_time_trace(
             self, ix: Union[int, Sequence[int], None] = None,
-            trimm: bool = False
+            trim: bool = False
     ) -> Union[Sequence[float], float]:
         return self._get_hdf5_entries(TIME, ix)
 

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -31,9 +31,10 @@ def trace_wrap(f):
         reduce = isinstance(ix, numbers.Integral)
         # default: full list
         if ix is None:
-            ix = np.arange(0, len(self), dtype=int)
             if trim:
                 ix = self.get_trimmed_indices()
+            else:
+                ix = np.arange(0, len(self), dtype=int)
         # turn every input into an index list
         if reduce:
             ix = np.array([ix], dtype=int)

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -630,7 +630,7 @@ def test_trim_history():
     problem = CRProblem()
     pypesto_problem = problem.get_problem()
 
-    optimizer = pypesto.optimize.FidesOptimizer(verbose=0)
+    optimizer = pypesto.optimize.ScipyOptimizer()
     history_options = pypesto.HistoryOptions(trace_record=True)
     result = pypesto.optimize.minimize(
         problem=pypesto_problem, optimizer=optimizer,

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -620,3 +620,30 @@ def test_hdf5_history_mp():
                             np.testing.assert_array_equal(
                                 mem_entry_trace[iteration],
                                 hdf5_entry_trace[iteration])
+
+
+def test_trim_history():
+    """
+    Test whether the history gets correctly trimmed to be monotonically
+    decreasing.
+    """
+    problem = CRProblem()
+    pypesto_problem = problem.get_problem()
+
+    optimizer = pypesto.optimize.FidesOptimizer(verbose=0)
+    history_options = pypesto.HistoryOptions(trace_record=True)
+    result = pypesto.optimize.minimize(
+        problem=pypesto_problem, optimizer=optimizer,
+        n_starts=2, history_options=history_options,
+        engine=MultiProcessEngine()
+    )
+    fval_trace = result.optimize_result.list[0].history.get_fval_trace()
+    fval_trace_trimmed = \
+        result.optimize_result.list[0].history.get_fval_trace(trim=True)
+    fval_trimmed_man = []
+    fval_current = np.inf
+    for fval_i in fval_trace:
+        if fval_i <= fval_current:
+            fval_trimmed_man.append(fval_i)
+            fval_current = fval_i
+    assert fval_trace_trimmed == fval_trimmed_man

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -634,7 +634,7 @@ def test_trim_history():
     history_options = pypesto.HistoryOptions(trace_record=True)
     result = pypesto.optimize.minimize(
         problem=pypesto_problem, optimizer=optimizer,
-        n_starts=2, history_options=history_options,
+        n_starts=1, history_options=history_options,
         engine=MultiProcessEngine()
     )
     fval_trace = result.optimize_result.list[0].history.get_fval_trace()


### PR DESCRIPTION
I wrote a function to get only a monotonically decreasing history trace. This is meant for comparisons with e.g. test and training data but can obviously also be used for more.

It does not change any functionality from before.