### PR TITLE
Fix FD deepcopy

### DIFF
--- a/pypesto/objective/base.py
+++ b/pypesto/objective/base.py
@@ -55,8 +55,8 @@ class ObjectiveBase(abc.ABC):
 
     def __deepcopy__(self, memodict=None) -> 'ObjectiveBase':
         other = type(self)()  # maintain type for derived classes
-        for attr in self.__dict__:
-            other.__dict__[attr] = copy.deepcopy(self.__dict__[attr])
+        for attr, val in self.__dict__.items():
+            other.__dict__[attr] = copy.deepcopy(val)
         return other
 
     # The following has_ properties can be used to find out what values

--- a/pypesto/objective/finite_difference.py
+++ b/pypesto/objective/finite_difference.py
@@ -323,8 +323,8 @@ class FD(ObjectiveBase):
         memodict: Dict = None,
     ) -> 'FD':
         other = self.__class__.__new__(self.__class__)
-        for attr in self.__dict__:
-            other.__dict__[attr] = copy.deepcopy(self.__dict__[attr])
+        for attr, val in self.__dict__.items():
+            other.__dict__[attr] = copy.deepcopy(val)
         return other
 
     @property

--- a/pypesto/objective/finite_difference.py
+++ b/pypesto/objective/finite_difference.py
@@ -317,6 +317,15 @@ class FD(ObjectiveBase):
                 f"Method must be one of {FD.METHODS}.",
             )
 
+    def __deepcopy__(
+        self,
+        memodict: Dict = None,
+    ) -> 'FD':
+        other = self.__class__.__new__(self.__class__)
+        for attr in self.__dict__:
+            other.__dict__[attr] = copy.deepcopy(self.__dict__[attr])
+        return other
+
     @property
     def has_fun(self) -> bool:
         return self.obj.has_fun

--- a/pypesto/objective/finite_difference.py
+++ b/pypesto/objective/finite_difference.py
@@ -1,6 +1,7 @@
 """Finite differences."""
 
-from typing import Callable, List, Tuple, Union
+import copy
+from typing import Callable, Dict, List, Tuple, Union
 import numpy as np
 import logging
 


### PR DESCRIPTION
Resolves the following error produced by the following snippet.

```python
pypesto_petab_importer = pypesto.petab.PetabImporter(petab_problem)
amici_objective = pypesto_petab_importer.create_objective()
fd_objective = pypesto.objective.FD(amici_objective, grad=True)
pypesto_problem = pypesto_petab_importer.create_problem(fd_objective)
```

```
Traceback (most recent call last):
  File "error.py", line 116, in <module>
    pypesto_problem = pypesto_petab_importer.create_problem(fd_objective)
  File "pyPESTO/pypesto/petab/importer.py", line 525, in create_problem
    problem = Problem(
  File "pyPESTO/pypesto/problem.py", line 99, in __init__
    self.objective = copy.deepcopy(objective)
  File "/usr/lib/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "pyPESTO/pypesto/objective/base.py", line 57, in __deepcopy__
    other = type(self)()  # maintain type for derived classes
TypeError: __init__() missing 1 required positional argument: 'obj'
```