### PR TITLE
Unpin sympy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,8 +58,7 @@ extras = test,test_petab,amici,petab,pyswarm
 commands =
     # install pysb
     pip install \
-      git+https://github.com/pysb/pysb.git@85b6c8a2be6763609bc9f131f4eb6e493948ddbe#egg=pysb
-    pip install sympy<1.9
+      git+https://github.com/pysb/pysb.git@5cbb147527814770ffc42e8e7d96e91dcb2b9857#egg=pysb
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/petab -s
 description =


### PR DESCRIPTION
The issue has been resolved in pysb 1.13.1, which is now used for testing.

Closes #738 