### PR TITLE
Fix typehint for 'filename' in optimize.minimize

### DIFF
--- a/pypesto/optimize/optimize.py
+++ b/pypesto/optimize/optimize.py
@@ -27,7 +27,7 @@ def minimize(
     progress_bar: bool = True,
     options: OptimizeOptions = None,
     history_options: HistoryOptions = None,
-    filename: str = "Auto"
+    filename: Union[str, None] = "Auto"
 ) -> Result:
     """
     Do multistart optimization.


### PR DESCRIPTION
`None` is required to switch off auto-saving, but not allowed as per typehint