### PR TITLE
Prioritize history vs optimizer result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ test/amici_models/*
 *.dat
 /BioNetGen-*.*.*
 /bionetgen.tar
+/report.log

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -16,39 +16,42 @@ At least an installation of pyPESTO is required, which can be performed by
 
 Potentially, further dependencies may be required.
 
-The following examples cover typical use cases and should help get a better
-idea of how to use this package:
+
+Getting started
+---------------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    example/rosenbrock.ipynb
-   example/conversion_reaction.ipynb
-   example/fixed_parameters.ipynb
+
+PEtab and AMICI
+---------------
+
+.. toctree::
+   :maxdepth: 2
+
    example/amici_import.ipynb
    example/petab_import.ipynb
-   example/store.ipynb
+
+Algorithms and features
+-----------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   example/fixed_parameters.ipynb
+   example/prior_definition.ipynb
    example/sampler_study.ipynb
    example/sampling_diagnostics.ipynb
-   example/synthetic_data.ipynb
-   example/prior_definition.ipynb
+   example/store.ipynb
    example/hdf5_storage.ipynb
 
-Download the examples as notebooks
-----------------------------------
+Application examples
+--------------------
 
-* :download:`Rosenbrock <example/rosenbrock.ipynb>`
-* :download:`Conversion reaction <example/conversion_reaction.ipynb>`
-* :download:`Fixed parameters <example/fixed_parameters.ipynb>`
-* :download:`Boehm model <example/amici_import.ipynb>`
-* :download:`Petab import <example/petab_import.ipynb>`
-* :download:`Storage <example/store.ipynb>`
-* :download:`Sampler study <example/sampler_study.ipynb>`
-* :download:`Sampling diagnostics <example/sampling_diagnostics.ipynb>`
-* :download:`Synthetic data <example/synthetic_data.ipynb>`
-* :download:`Prior definition <example/prior_definition.ipynb>`
-* :download:`hdf5 storage <example/hdf5_storage.ipynb>`
+.. toctree::
+   :maxdepth: 2
 
-
-.. Note::
-   Some of the notebooks have extra dependencies.
+   example/conversion_reaction.ipynb
+   example/synthetic_data.ipynb

--- a/pypesto/logging.py
+++ b/pypesto/logging.py
@@ -62,3 +62,28 @@ def log_to_file(level: int = logging.INFO,
     See the `log` method.
     """
     log(level=level, filename=filename)
+
+
+def log_level_active(logger: logging.Logger, level: int) -> bool:
+    """Check whether the requested log level is active in any handler.
+
+    This is useful in case log expressions are costly.
+
+    Parameters
+    ----------
+    logger:
+        The logger.
+    level:
+        The requested log level.
+
+    Returns
+    --------
+    active:
+        Whether there is a handler registered that handles events of importance
+        at least `level` and higher.
+    """
+    for handler in logger.handlers:
+        # it is DEBUG=10, INFO=20, WARNING=30, ERROR=40, CRITICAL=50 increasing
+        if handler.level <= level:
+            return True
+        return False

--- a/pypesto/objective/amici_util.py
+++ b/pypesto/objective/amici_util.py
@@ -7,6 +7,7 @@ import warnings
 from .constants import (
     FVAL, CHI2, GRAD, HESS, RES, SRES, RDATAS, MODE_FUN, MODE_RES
 )
+from ..logging import log_level_active
 
 try:
     import amici
@@ -279,7 +280,8 @@ def log_simulation(data_ix, rdata):
     if t_steadystate in rdata and rdata[t_steadystate] != np.nan:
         logger.debug(f"t_steadystate: {rdata[t_steadystate]}")
 
-    logger.debug(f"res: {rdata['res']}")
+    if log_level_active(logger, logging.DEBUG):
+        logger.debug(f"res: {rdata['res']}")
 
 
 def get_error_output(

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1346,7 +1346,7 @@ class OptimizerHistory:
         # get indices of admissible trace entries
         # shape (n_sample, n_x)
         xs = np.asarray(self.history.get_x_trace())
-        ixs_admit = [self._admissible(x) for x in xs]
+        ixs_admit = [ix for ix, x in enumerate(xs) if self._admissible(x)]
 
         # we prioritize fval over chi2 as fval is written whenever possible
         ix_min = np.nanargmin(self.history.get_fval_trace(ixs_admit))
@@ -1354,6 +1354,8 @@ class OptimizerHistory:
         # generally want the first occurrence
         if isinstance(ix_min, np.ndarray):
             ix_min = ix_min[0]
+        # select index in original array
+        ix_min = ixs_admit[ix_min]
 
         for var in ['fval', 'chi2', 'x']:
             self.extract_from_history(var, ix_min)

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1327,6 +1327,7 @@ class OptimizerHistory:
                 self.sres_min = sres
 
     def _compute_vals_from_trace(self):
+        """Set initial and best function value from trace (at start)."""
         if not len(self.history):
             # nothing to be computed from empty history
             return

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1295,7 +1295,7 @@ class OptimizerHistory:
                 self.fval0 = result.get(FVAL, None)
             self.x0 = x
 
-        # check whether point is admissible
+        # don't update optimal point if point is not admissible
         if not self._admissible(x):
             return
 
@@ -1316,7 +1316,7 @@ class OptimizerHistory:
 
         # sometimes sensitivities are evaluated on subsequent calls. We can
         # identify this situation by checking that x hasn't changed
-        if np.all(self.x_min == x):
+        if np.allclose(self.x_min, x):
             if self.grad_min is None and grad is not None:
                 self.grad_min = grad
             if self.hess_min is None and hess is not None:

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1365,12 +1365,15 @@ class OptimizerHistory:
         for var in ['res', 'grad', 'sres', 'hess']:
             if not getattr(self.history.options, f'trace_record_{var}'):
                 continue  # var not saved in history
+            # first try index of optimal function value
+            if self.extract_from_history(var, ix_min):
+                continue
             # gradients may be evaluated at different indices, therefore
             #  iterate over all and check whether any has the same parameter
             #  and the desired field filled
             # for res we do the same because otherwise randomly None
             #  (TODO investigate why, but ok this way)
-            for ix in range(len(self.history)):
+            for ix in reversed(range(len(self.history))):
                 if not np.allclose(self.x_min, self.history.get_x_trace(ix)):
                     continue
                 if self.extract_from_history(var, ix):

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1316,7 +1316,7 @@ class OptimizerHistory:
 
         # sometimes sensitivities are evaluated on subsequent calls. We can
         # identify this situation by checking that x hasn't changed
-        if np.allclose(self.x_min, x):
+        if self.x_min is not None and np.allclose(self.x_min, x):
             if self.grad_min is None and grad is not None:
                 self.grad_min = grad
             if self.hess_min is None and hess is not None:

--- a/pypesto/optimize/optimize.py
+++ b/pypesto/optimize/optimize.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, Union
+from typing import Callable, Iterable, Union
 
 from ..engine import Engine, SingleCoreEngine
 from ..objective import HistoryOptions
@@ -23,7 +23,7 @@ def minimize(
     optimizer: Optimizer = None,
     n_starts: int = 100,
     ids: Iterable[str] = None,
-    startpoint_method: Union[StartpointMethod, bool] = None,
+    startpoint_method: Union[StartpointMethod, Callable, bool] = None,
     result: Result = None,
     engine: Engine = None,
     progress_bar: bool = True,

--- a/pypesto/optimize/optimize.py
+++ b/pypesto/optimize/optimize.py
@@ -125,10 +125,8 @@ def minimize(
             problem=problem,
             x0=startpoint,
             id=id,
-            options=options,
             history_options=history_options,
-            report_hess=options.report_hess,
-            report_sres=options.report_sres,
+            optimize_options=options,
         )
         tasks.append(task)
 

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -236,8 +236,8 @@ def fill_result_from_history(
     x_match = x_exist and np.allclose(history_x, result_x)
     if x_exist and not x_match:
         logger.debug(
-            f"Optimal parameter mismatch: history {history_x:3e}, "
-            f"result {result_x:3e}"
+            f"Optimal parameter mismatch: history {history_x}, "
+            f"result {result_x}"
         )
 
     # counters

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -224,7 +224,7 @@ def fill_result_from_history(
         )
 
     # all variables of interest
-    keys = ["x", "fval", "grad", "hess", "res", "sres"]
+    keys = {"x", "fval", "grad", "hess", "res", "sres"}
 
     # always overwrite if history beats optimizer
     #  (result_fval < history_fval should be impossible)
@@ -238,7 +238,7 @@ def fill_result_from_history(
 
     # counters
     # we only use our own counters here as optimizers may report differently
-    for key in keys:
+    for key in keys - {"x"}:
         setattr(
             result, f"n_{key}", getattr(optimizer_history.history, f"n_{key}")
         )

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -198,7 +198,7 @@ def fix_decorator(minimize):
 def fill_result_from_history(
     result: OptimizerResult,
     optimizer_history: OptimizerHistory,
-    optimize_options: OptimizeOptions,
+    optimize_options: OptimizeOptions = None,
 ) -> OptimizerResult:
     """Overwrite some values in the result object with values in the history.
 
@@ -212,6 +212,9 @@ def fill_result_from_history(
     -------
     result: The in-place modified result.
     """
+    if optimize_options is None:
+        optimize_options = OptimizeOptions()
+
     # logging
     history_fval, result_fval = optimizer_history.fval_min, result.fval
     if not np.isclose(history_fval, result_fval):
@@ -296,7 +299,6 @@ def read_result_from_file(
     result = fill_result_from_history(
         result=result,
         optimizer_history=opt_hist,
-        optimize_options=OptimizeOptions(),
     )
     result.update_to_full(problem)
 

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -217,7 +217,10 @@ def fill_result_from_history(
 
     # logging
     history_fval, result_fval = optimizer_history.fval_min, result.fval
-    if not np.isclose(history_fval, result_fval):
+    if (
+        history_fval is not None and result_fval is not None
+        and not np.isclose(history_fval, result_fval)
+    ):
         logger.debug(
             f"Minimal function value mismatch: history {history_fval:8e}, "
             f"result {result_fval:8e}"
@@ -228,7 +231,7 @@ def fill_result_from_history(
 
     # always overwrite if history beats optimizer
     #  (result_fval < history_fval should be impossible)
-    if optimize_options.history_beats_optimizer:
+    if optimize_options.history_beats_optimizer or result_fval is None:
         for key in keys:
             setattr(result, key, getattr(optimizer_history, f"{key}_min"))
 

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -191,9 +191,10 @@ def fix_decorator(minimize):
         # vectors to full vectors
         result.update_to_full(problem)
 
-        logger.info(f"Final fval={result.fval:.4f}, "
-                    f"time={result.time:.4f}s, "
-                    f"n_fval={result.n_fval}.")
+        logger.debug(
+            f"Final fval={result.fval:.4f}, time={result.time:.4f}s, "
+            f"n_fval={result.n_fval}.",
+        )
 
         return result
 

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -84,7 +84,12 @@ def history_decorator(minimize):
             id=id,
             x_names=[problem.x_names[ix] for ix in problem.x_free_indices],
         )
-        optimizer_history = OptimizerHistory(history=history, x0=x0)
+        optimizer_history = OptimizerHistory(
+            history=history,
+            x0=x0,
+            lb=problem.lb,
+            ub=problem.ub,
+        )
 
         # plug in history for the objective to record it
         objective.history = optimizer_history
@@ -160,8 +165,9 @@ def fix_decorator(minimize):
 
 
 def fill_result_from_objective_history(
-        result: OptimizerResult,
-        optimizer_history: OptimizerHistory):
+    result: OptimizerResult,
+    optimizer_history: OptimizerHistory,
+):
     """Overwrite values in the result object with values in the history."""
     update_vals = True
     # check history for better values
@@ -250,8 +256,11 @@ def read_result_from_file(
         raise NotImplementedError()
 
     opt_hist = OptimizerHistory(
-        history, history.get_x_trace(0),
-        generate_from_history=True
+        history=history,
+        x0=history.get_x_trace(0),
+        lb=problem.lb,
+        ub=problem.ub,
+        generate_from_history=True,
     )
 
     result = OptimizerResult(

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -260,11 +260,8 @@ def fill_result_from_history(
     if not optimize_options.history_beats_optimizer:
         return result
 
-    # all variables of interest
-    keys = (X, FVAL, GRAD, HESS, RES, SRES)
-
     # optimal point
-    for key in keys:
+    for key in (X, FVAL, GRAD, HESS, RES, SRES):
         hist_val = getattr(optimizer_history, f"{key}_min")
         # replace by history if history has entry, or point does not match
         #  point recorded in result

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -69,9 +69,12 @@ def history_decorator(minimize):
         problem: Problem,
         x0: np.ndarray,
         id: str,
-        history_options: HistoryOptions,
-        optimize_options: OptimizeOptions,
+        history_options: HistoryOptions = None,
+        optimize_options: OptimizeOptions = None,
     ):
+        if history_options is None:
+            history_options = HistoryOptions()
+
         objective = problem.objective
 
         # initialize the objective
@@ -139,8 +142,8 @@ def time_decorator(minimize):
         problem: Problem,
         x0: np.ndarray,
         id: str,
-        history_options: HistoryOptions,
-        optimize_options: OptimizeOptions,
+        history_options: HistoryOptions = None,
+        optimize_options: OptimizeOptions = None,
     ):
         start_time = time.time()
         result = minimize(
@@ -170,8 +173,8 @@ def fix_decorator(minimize):
         problem: Problem,
         x0: np.ndarray,
         id: str,
-        history_options: HistoryOptions,
-        optimize_options: OptimizeOptions,
+        history_options: HistoryOptions = None,
+        optimize_options: OptimizeOptions = None,
     ):
         # perform the actual optimization
         result = minimize(

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -219,14 +219,15 @@ def fill_result_from_history(
     history_fval, result_fval = optimizer_history.fval_min, result.fval
     if not np.isclose(history_fval, result_fval):
         logger.debug(
-            f"Minimal function value mismatch: history {history_fval:3e}, "
-            f"result {result_fval}"
+            f"Minimal function value mismatch: history {history_fval:8e}, "
+            f"result {result_fval:8e}"
         )
 
     # all variables of interest
     keys = ["x", "fval", "grad", "hess", "res", "sres"]
 
-    # overwrite if history beats optimizer and better
+    # always overwrite if history beats optimizer
+    #  (result_fval < history_fval should be impossible)
     if optimize_options.history_beats_optimizer:
         for key in keys:
             setattr(result, key, getattr(optimizer_history, f"{key}_min"))

--- a/pypesto/optimize/options.py
+++ b/pypesto/optimize/options.py
@@ -18,6 +18,10 @@ class OptimizeOptions(dict):
         Flag indicating whether hess will be stored in the results object.
         Deactivating this option will improve memory consumption for large
         scale problems.
+    history_beats_optimizer:
+        Whether the optimal value recorded by pyPESTO in the history has
+        priority over the optimal value reported by the optimizer (True)
+        or not (False).
     """
 
     def __init__(
@@ -25,12 +29,14 @@ class OptimizeOptions(dict):
         allow_failed_starts: bool = True,
         report_sres: bool = True,
         report_hess: bool = True,
+        history_beats_optimizer: bool = True,
     ):
         super().__init__()
 
         self.allow_failed_starts: bool = allow_failed_starts
         self.report_sres: bool = report_sres
         self.report_hess: bool = report_hess
+        self.history_beats_optimizer: bool = history_beats_optimizer
 
     def __getattr__(self, key):
         try:

--- a/pypesto/optimize/result.py
+++ b/pypesto/optimize/result.py
@@ -58,25 +58,27 @@ class OptimizerResult(dict):
     Any field not supported by the optimizer is filled with None.
     """
 
-    def __init__(self,
-                 id: str = None,
-                 x: np.ndarray = None,
-                 fval: float = None,
-                 grad: np.ndarray = None,
-                 hess: np.ndarray = None,
-                 res: np.ndarray = None,
-                 sres: np.ndarray = None,
-                 n_fval: int = None,
-                 n_grad: int = None,
-                 n_hess: int = None,
-                 n_res: int = None,
-                 n_sres: int = None,
-                 x0: np.ndarray = None,
-                 fval0: float = None,
-                 history: History = None,
-                 exitflag: int = None,
-                 time: float = None,
-                 message: str = None):
+    def __init__(
+        self,
+        id: str = None,
+        x: np.ndarray = None,
+        fval: float = None,
+        grad: np.ndarray = None,
+        hess: np.ndarray = None,
+        res: np.ndarray = None,
+        sres: np.ndarray = None,
+        n_fval: int = None,
+        n_grad: int = None,
+        n_hess: int = None,
+        n_res: int = None,
+        n_sres: int = None,
+        x0: np.ndarray = None,
+        fval0: float = None,
+        history: History = None,
+        exitflag: int = None,
+        time: float = None,
+        message: str = None,
+    ):
         super().__init__()
         self.id = id
         self.x: np.ndarray = np.array(x) if x is not None else None

--- a/pypesto/optimize/task.py
+++ b/pypesto/optimize/task.py
@@ -13,18 +13,15 @@ class OptimizerTask(Task):
     """A multistart optimization task, performed in `pypesto.minimize`."""
 
     def __init__(
-            self,
-            optimizer: 'pypesto.optimize.Optimizer',
-            problem: Problem,
-            x0: np.ndarray,
-            id: str,
-            options: 'pypesto.optimize.OptimizeOptions',
-            history_options: HistoryOptions,
-            report_hess: bool,
-            report_sres: bool,
+        self,
+        optimizer: 'pypesto.optimize.Optimizer',
+        problem: Problem,
+        x0: np.ndarray,
+        id: str,
+        history_options: HistoryOptions,
+        optimize_options: 'pypesto.optimize.OptimizeOptions',
     ):
-        """
-        Create the task object.
+        """Create the task object.
 
         Parameters
         ----------
@@ -40,12 +37,6 @@ class OptimizerTask(Task):
             Options object applying to optimization.
         history_options:
             Optimizer history options.
-        report_hess:
-            Flag indicating whether the Hessian is to be stored in
-            results
-        report_sres:
-            Flag indicating whether residual sensitivity is to be stored in
-            results
         """
         super().__init__()
 
@@ -53,10 +44,8 @@ class OptimizerTask(Task):
         self.problem = problem
         self.x0 = x0
         self.id = id
-        self.options = options
+        self.optimize_options = optimize_options
         self.history_options = history_options
-        self.report_hess = report_hess
-        self.report_sres = report_sres
 
     def execute(self) -> 'pypesto.optimize.OptimizerResult':
         """Execute the task."""
@@ -66,11 +55,11 @@ class OptimizerTask(Task):
             problem=self.problem,
             x0=self.x0,
             id=self.id,
-            allow_failed_starts=self.options.allow_failed_starts,
             history_options=self.history_options,
+            optimize_options=self.optimize_options,
         )
-        if not self.report_hess:
+        if not self.optimize_options.report_hess:
             optimizer_result.hess = None
-        if not self.report_sres:
+        if not self.optimize_options.report_sres:
             optimizer_result.sres = None
         return optimizer_result

--- a/pypesto/profile/approximate.py
+++ b/pypesto/profile/approximate.py
@@ -12,12 +12,12 @@ logger = logging.getLogger(__name__)
 
 
 def approximate_parameter_profile(
-        problem: Problem,
-        result: Result,
-        profile_index: Iterable[int] = None,
-        profile_list: int = None,
-        result_index: int = 0,
-        n_steps: int = 100,
+    problem: Problem,
+    result: Result,
+    profile_index: Iterable[int] = None,
+    profile_list: int = None,
+    result_index: int = 0,
+    n_steps: int = 100,
 ) -> Result:
     """
     Calculate profile approximation.
@@ -102,7 +102,7 @@ def approximate_parameter_profile(
         profiler_result = ProfilerResult(
             x_path=xs,
             fval_path=fvals,
-            ratio_path=ratios
+            ratio_path=ratios,
         )
 
         result.profile_result.set_profiler_result(

--- a/pypesto/profile/profile.py
+++ b/pypesto/profile/profile.py
@@ -111,7 +111,9 @@ def parameter_profile(
             continue
 
         current_profile = result.profile_result.get_profiler_result(
-            i_par=i_par, profile_list=profile_list)
+            i_par=i_par,
+            profile_list=profile_list,
+        )
 
         task = ProfilerTask(
             current_profile=current_profile,
@@ -120,7 +122,7 @@ def parameter_profile(
             options=profile_options,
             create_next_guess=create_next_guess,
             global_opt=global_opt,
-            i_par=i_par
+            i_par=i_par,
         )
         tasks.append(task)
 

--- a/pypesto/profile/profile_next_guess.py
+++ b/pypesto/profile/profile_next_guess.py
@@ -65,14 +65,13 @@ def next_guess(
 
 
 def fixed_step(
-        x: np.ndarray,
-        par_index: int,
-        par_direction: int,
-        options: ProfileOptions,
-        problem: Problem
+    x: np.ndarray,
+    par_index: int,
+    par_direction: int,
+    options: ProfileOptions,
+    problem: Problem,
 ) -> np.ndarray:
-    """
-    Most simple method to create the next guess.
+    """Most simple method to create the next guess.
 
     Parameters
     ----------
@@ -107,17 +106,16 @@ def fixed_step(
 
 
 def adaptive_step(
-        x: np.ndarray,
-        par_index: int,
-        par_direction: int,
-        options: ProfileOptions,
-        current_profile: ProfilerResult,
-        problem: Problem,
-        global_opt: float,
-        order: int = 1
+    x: np.ndarray,
+    par_index: int,
+    par_direction: int,
+    options: ProfileOptions,
+    current_profile: ProfilerResult,
+    problem: Problem,
+    global_opt: float,
+    order: int = 1,
 ) -> np.ndarray:
-    """
-    Group of more complex methods for point proposal.
+    """Group of more complex methods for point proposal.
 
     Step size is automatically computed by a line search algorithm (hence:
     adaptive).
@@ -238,18 +236,17 @@ def adaptive_step(
 
 
 def handle_profile_history(
-        x: np.ndarray,
-        par_index: int,
-        par_direction: int,
-        n_profile_points: int,
-        global_opt: float,
-        order: int,
-        current_profile: ProfilerResult,
-        problem: Problem,
-        options: ProfileOptions
+    x: np.ndarray,
+    par_index: int,
+    par_direction: int,
+    n_profile_points: int,
+    global_opt: float,
+    order: int,
+    current_profile: ProfilerResult,
+    problem: Problem,
+    options: ProfileOptions,
 ) -> Tuple:
-    """
-    Compute the very first step direction update guesses.
+    """Compute the very first step direction update guesses.
 
     Check whether enough steps have been taken for applying regression,
     computes regression or simple extrapolation.
@@ -289,14 +286,13 @@ def handle_profile_history(
 
 
 def get_reg_polynomial(
-        n_profile_points: int,
-        par_index: int,
-        current_profile: ProfilerResult,
-        problem: Problem,
-        options: ProfileOptions
+    n_profile_points: int,
+    par_index: int,
+    current_profile: ProfilerResult,
+    problem: Problem,
+    options: ProfileOptions,
 ) -> List[float]:
-    """
-    Compute the regression polynomial.
+    """Compute the regression polynomial.
 
     Used to step proposal extrapolation from the last profile points
     """
@@ -335,20 +331,19 @@ def get_reg_polynomial(
 
 
 def do_line_seach(
-        next_x: np.ndarray,
-        step_size_guess: float,
-        direction: str,
-        par_extrapol: Callable,
-        next_obj: float,
-        next_obj_target: float,
-        clip_to_minmax: Callable,
-        clip_to_bounds: Callable,
-        par_index: int,
-        problem: Problem,
-        options: ProfileOptions
+    next_x: np.ndarray,
+    step_size_guess: float,
+    direction: str,
+    par_extrapol: Callable,
+    next_obj: float,
+    next_obj_target: float,
+    clip_to_minmax: Callable,
+    clip_to_bounds: Callable,
+    par_index: int,
+    problem: Problem,
+    options: ProfileOptions,
 ) -> np.ndarray:
-    """
-    Perform the line search.
+    """Perform the line search.
 
     Based on the objective function we want to reach, based on the current
     position in parameter space and on the first guess for the proposal.
@@ -391,11 +386,11 @@ def do_line_seach(
 
 
 def next_x_interpolate(
-        next_obj: float,
-        last_obj: float,
-        next_x: np.ndarray,
-        last_x: np.ndarray,
-        next_obj_target: float
+    next_obj: float,
+    last_obj: float,
+    next_x: np.ndarray,
+    last_x: np.ndarray,
+    next_obj_target: float,
 ) -> np.ndarray:
     """Interpolate between the last two steps."""
     delta_obj = np.abs(next_obj - last_obj)
@@ -407,9 +402,9 @@ def next_x_interpolate(
 
 
 def clip(
-        vector_guess: Union[float, np.ndarray],
-        lower: Union[float, np.ndarray],
-        upper: Union[float, np.ndarray]
+    vector_guess: Union[float, np.ndarray],
+    lower: Union[float, np.ndarray],
+    upper: Union[float, np.ndarray],
 ) -> Union[float, np.ndarray]:
     """Restrict a scalar or a vector to given bounds."""
     if isinstance(vector_guess, float):

--- a/pypesto/profile/result.py
+++ b/pypesto/profile/result.py
@@ -43,18 +43,20 @@ class ProfilerResult(dict):
     filled with None. Some fields are filled by pypesto itself.
     """
 
-    def __init__(self,
-                 x_path: np.ndarray,
-                 fval_path: np.ndarray,
-                 ratio_path: np.ndarray,
-                 gradnorm_path: np.ndarray = None,
-                 exitflag_path: np.ndarray = None,
-                 time_path: np.ndarray = None,
-                 time_total: float = 0.,
-                 n_fval: int = 0,
-                 n_grad: int = 0,
-                 n_hess: int = 0,
-                 message: str = None):
+    def __init__(
+        self,
+        x_path: np.ndarray,
+        fval_path: np.ndarray,
+        ratio_path: np.ndarray,
+        gradnorm_path: np.ndarray = np.nan,
+        exitflag_path: np.ndarray = np.nan,
+        time_path: np.ndarray = np.nan,
+        time_total: float = 0.,
+        n_fval: int = 0,
+        n_grad: int = 0,
+        n_hess: int = 0,
+        message: str = None,
+    ):
         super().__init__()
 
         # initialize profile path
@@ -68,8 +70,7 @@ class ProfilerResult(dict):
 
         self.fval_path = np.asarray(fval_path)
         self.ratio_path = np.asarray(ratio_path)
-        self.gradnorm_path = np.asarray(gradnorm_path) \
-            if gradnorm_path is not None else None
+        self.gradnorm_path = np.asarray(gradnorm_path)
         self.exitflag_path = np.asarray(exitflag_path)
         self.time_path = np.asarray(time_path)
         self.time_total = time_total
@@ -88,16 +89,18 @@ class ProfilerResult(dict):
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 
-    def append_profile_point(self,
-                             x: np.ndarray,
-                             fval: float,
-                             ratio: float,
-                             gradnorm: float = np.nan,
-                             time: float = np.nan,
-                             exitflag: float = np.nan,
-                             n_fval: int = 0,
-                             n_grad: int = 0,
-                             n_hess: int = 0) -> None:
+    def append_profile_point(
+        self,
+        x: np.ndarray,
+        fval: float,
+        ratio: float,
+        gradnorm: float = np.nan,
+        time: float = np.nan,
+        exitflag: float = np.nan,
+        n_fval: int = 0,
+        n_grad: int = 0,
+        n_hess: int = 0,
+    ) -> None:
         """
         Append a new point to the profile path.
 

--- a/pypesto/profile/task.py
+++ b/pypesto/profile/task.py
@@ -15,14 +15,14 @@ class ProfilerTask(Task):
     """A parameter likelihood profiling task."""
 
     def __init__(
-            self,
-            current_profile: ProfilerResult,
-            problem: Problem,
-            options: ProfileOptions,
-            i_par: int,
-            global_opt: float,
-            optimizer: 'pypesto.optimize.Optimizer',
-            create_next_guess: Callable,
+        self,
+        current_profile: ProfilerResult,
+        problem: Problem,
+        options: ProfileOptions,
+        i_par: int,
+        global_opt: float,
+        optimizer: 'pypesto.optimize.Optimizer',
+        create_next_guess: Callable,
     ):
         """
         Create the task object.
@@ -57,6 +57,7 @@ class ProfilerTask(Task):
     def execute(self) -> 'pypesto.profile.ProfilerResult':
         """Compute profile in descending and ascending direction."""
         logger.info(f"Executing task {self.i_par}.")
+
         for par_direction in [-1, 1]:
             # flip profile
             self.current_profile.flip_profile()
@@ -70,7 +71,8 @@ class ProfilerTask(Task):
                 options=self.options,
                 create_next_guess=self.create_next_guess,
                 global_opt=self.global_opt,
-                i_par=self.i_par)
+                i_par=self.i_par,
+            )
 
         # return the ProfilerResult and the index of the parameter profiled
         return {'profile': self.current_profile, 'index': self.i_par}

--- a/pypesto/profile/util.py
+++ b/pypesto/profile/util.py
@@ -81,11 +81,11 @@ def calculate_approximate_ci(
 
 
 def initialize_profile(
-        problem: Problem,
-        result: Result,
-        result_index: int,
-        profile_index: Iterable[int],
-        profile_list: int
+    problem: Problem,
+    result: Result,
+    result_index: int,
+    profile_index: Iterable[int],
+    profile_list: int,
 ) -> float:
     """
     Initialize profiling based on a previous optimization.
@@ -136,7 +136,8 @@ def initialize_profile(
         profile_index=profile_index,
         profile_list=profile_list,
         problem_dimension=problem.dim_full,
-        global_opt=global_opt)
+        global_opt=global_opt,
+    )
 
     # return the log-posterior of the global optimum (needed in order to
     # compute the log-posterior-ratio)
@@ -144,15 +145,14 @@ def initialize_profile(
 
 
 def fill_profile_list(
-        profile_result: ProfileResult,
-        optimizer_result: Dict[str, Any],
-        profile_index: Iterable[int],
-        profile_list: int,
-        problem_dimension: int,
-        global_opt: float
+    profile_result: ProfileResult,
+    optimizer_result: Dict[str, Any],
+    profile_index: Iterable[int],
+    profile_list: int,
+    problem_dimension: int,
+    global_opt: float,
 ) -> None:
-    """
-    Fill a ProfileResult.
+    """Fill a ProfileResult.
 
     Helper function for `initialize_profile`.
 
@@ -178,7 +178,7 @@ def fill_profile_list(
     if optimizer_result[GRAD] is not None:
         gradnorm = np.linalg.norm(optimizer_result[GRAD])
     else:
-        gradnorm = None
+        gradnorm = np.nan
 
     # create blank profile
     new_profile = ProfilerResult(
@@ -192,7 +192,8 @@ def fill_profile_list(
         n_fval=0,
         n_grad=0,
         n_hess=0,
-        message=None)
+        message=None,
+    )
 
     if profile_list is None:
         # All profiles have to be created from scratch

--- a/pypesto/profile/validation_intervals.py
+++ b/pypesto/profile/validation_intervals.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 
 
 def validation_profile_significance(
-        problem_full_data: Problem,
-        result_training_data: Result,
-        result_full_data: Optional[Result] = None,
-        n_starts: Optional[int] = 1,
-        optimizer: Optional[Optimizer] = None,
-        engine: Optional[Engine] = None,
-        lsq_objective: bool = False,
-        return_significance: bool = True,
+    problem_full_data: Problem,
+    result_training_data: Result,
+    result_full_data: Optional[Result] = None,
+    n_starts: Optional[int] = 1,
+    optimizer: Optional[Optimizer] = None,
+    engine: Optional[Engine] = None,
+    lsq_objective: bool = False,
+    return_significance: bool = True,
 ) -> float:
     r"""
     Compute significance of Validation Interval.

--- a/pypesto/profile/walk_along_profile.py
+++ b/pypesto/profile/walk_along_profile.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import Callable
 
 from ..objective.constants import GRAD
-from ..optimize import Optimizer, OptimizerResult
+from ..optimize import Optimizer, OptimizerResult, OptimizeOptions
 from ..problem import Problem
 from .result import ProfilerResult
 from .options import ProfileOptions
@@ -86,8 +86,12 @@ def walk_along_profile(
         # IMPORTANT: This optimization will need a proper exception
         # handling (coming soon)
         if startpoint.size > 0:
-            optimizer_result = optimizer.minimize(problem, startpoint, '0',
-                                                  allow_failed_starts=False)
+            optimizer_result = optimizer.minimize(
+                problem=problem,
+                x0=startpoint,
+                id='0',
+                optimize_options=OptimizeOptions(allow_failed_starts=False),
+            )
         else:
             # if too many parameters are fixed, there is nothing to do ...
             fval = problem.objective([])

--- a/pypesto/profile/walk_along_profile.py
+++ b/pypesto/profile/walk_along_profile.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 
 
 def walk_along_profile(
-        current_profile: ProfilerResult,
-        problem: Problem,
-        par_direction: int,
-        optimizer: Optimizer,
-        options: ProfileOptions,
-        create_next_guess: Callable,
-        global_opt: float,
-        i_par: int
+    current_profile: ProfilerResult,
+    problem: Problem,
+    par_direction: int,
+    optimizer: Optimizer,
+    options: ProfileOptions,
+    create_next_guess: Callable,
+    global_opt: float,
+    i_par: int,
 ) -> ProfilerResult:
     """
     Compute half a profile.
@@ -94,17 +94,28 @@ def walk_along_profile(
             )
         else:
             # if too many parameters are fixed, there is nothing to do ...
-            fval = problem.objective([])
+            fval = problem.objective(np.array([]))
             optimizer_result = OptimizerResult(
-                id='0', x=np.array([]), fval=fval, n_fval=0, n_grad=0, n_res=0,
-                n_hess=0, n_sres=0, x0=np.array([]), fval0=fval, time=0)
+                id='0',
+                x=np.array([]),
+                fval=fval,
+                n_fval=0,
+                n_grad=0,
+                n_res=0,
+                n_hess=0,
+                n_sres=0,
+                x0=np.array([]),
+                fval0=fval,
+                time=0,
+            )
             optimizer_result.update_to_full(problem=problem)
 
         if optimizer_result[GRAD] is not None:
-            gradnorm = np.linalg.norm(optimizer_result[GRAD][
-                                      problem.x_free_indices])
+            gradnorm = np.linalg.norm(
+                optimizer_result[GRAD][problem.x_free_indices]
+            )
         else:
-            gradnorm = None
+            gradnorm = np.nan
 
         current_profile.append_profile_point(
             x=optimizer_result.x,
@@ -115,7 +126,8 @@ def walk_along_profile(
             exitflag=optimizer_result.exitflag,
             n_fval=optimizer_result.n_fval,
             n_grad=optimizer_result.n_grad,
-            n_hess=optimizer_result.n_hess)
+            n_hess=optimizer_result.n_hess,
+        )
 
     # free the profiling parameter again
     problem.unfix_parameters(i_par)

--- a/pypesto/result.py
+++ b/pypesto/result.py
@@ -146,7 +146,7 @@ class ProfileResult:
         self.list[profile_list][i_par] = copy.deepcopy(profiler_result)
 
     def get_profiler_result(
-            self, i_par: int, profile_list: int = None
+        self, i_par: int, profile_list: int = None
     ):
         """
         Get the profiler result at parameter index `i_par` of `profile_list`.

--- a/pypesto/startpoint/base.py
+++ b/pypesto/startpoint/base.py
@@ -239,7 +239,7 @@ class FunctionStartpoints(CheckedStartpoints):
 
 
 def to_startpoint_method(
-    maybe_startpoint_method: Union[StartpointMethod, Callable],
+    maybe_startpoint_method: Union[StartpointMethod, Callable, bool],
 ) -> StartpointMethod:
     """Create StartpointMethod instance if possible, otherwise raise.
 

--- a/pypesto/store/read_from_hdf5.py
+++ b/pypesto/store/read_from_hdf5.py
@@ -2,7 +2,7 @@
 import h5py
 from ..result import Result
 from ..optimize.result import OptimizerResult
-from ..optimize.optimizer import fill_result_from_objective_history
+from ..optimize.optimizer import fill_result_from_history
 from ..profile.result import ProfilerResult
 from ..sample.result import McmcPtResult
 from ..problem import Problem
@@ -384,7 +384,6 @@ def optimization_result_from_history(filename: str) -> Result:
                 x0=f[f'history/{id_name}/trace/0/x'][()],
                 generate_from_history=True)
             optimizer_result = OptimizerResult(id=id_name)
-            fill_result_from_objective_history(optimizer_result,
-                                               optimizer_history)
+            fill_result_from_history(optimizer_result, optimizer_history)
             result.optimize_result.append(optimizer_result)
     return result

--- a/pypesto/store/read_from_hdf5.py
+++ b/pypesto/store/read_from_hdf5.py
@@ -15,11 +15,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def read_hdf5_profile(f: h5py.File,
-                      profile_id: str,
-                      parameter_id: str) -> 'ProfilerResult':
-    """
-    Read HDF5 results per start.
+def read_hdf5_profile(
+    f: h5py.File,
+    profile_id: str,
+    parameter_id: str,
+) -> 'ProfilerResult':
+    """Read HDF5 results per start.
 
     Parameters
     ----------
@@ -45,11 +46,12 @@ def read_hdf5_profile(f: h5py.File,
     return result
 
 
-def read_hdf5_optimization(f: h5py.File,
-                           file_name: str,
-                           opt_id: str) -> 'OptimizerResult':
-    """
-    Read HDF5 results per start.
+def read_hdf5_optimization(
+    f: h5py.File,
+    file_name: str,
+    opt_id: str,
+) -> 'OptimizerResult':
+    """Read HDF5 results per start.
 
     Parameters
     ----------
@@ -90,8 +92,7 @@ class ProblemHDF5Reader:
     """
 
     def __init__(self, storage_filename: str):
-        """
-        Initialize reader.
+        """Initialize reader.
 
         Parameters
         ----------
@@ -101,8 +102,7 @@ class ProblemHDF5Reader:
         self.storage_filename = storage_filename
 
     def read(self, objective: ObjectiveBase = None) -> Problem:
-        """
-        Read HDF5 problem file and return pyPESTO problem object.
+        """Read HDF5 problem file and return pyPESTO problem object.
 
         Parameters
         ----------
@@ -190,8 +190,7 @@ class SamplingResultHDF5Reader:
     """
 
     def __init__(self, storage_filename: str):
-        """
-        Initialize reader.
+        """Initialize reader.
 
         Parameters
         ----------
@@ -274,8 +273,7 @@ def read_result(filename: str,
                 profile: bool = False,
                 sample: bool = False,
                 ) -> Result:
-    """
-    Save the whole pypesto.Result object in an HDF5 file.
+    """Save the whole pypesto.Result object in an HDF5 file.
 
     Parameters
     ----------
@@ -339,8 +337,7 @@ def read_result(filename: str,
 
 
 def load_objective_config(filename: str):
-    """
-    Load the objective information stored in f.
+    """Load the objective information stored in f.
 
     Parameters
     ----------
@@ -359,8 +356,7 @@ def load_objective_config(filename: str):
 
 
 def optimization_result_from_history(filename: str) -> Result:
-    """
-    Convert a saved hdf5 History to an optimization result.
+    """Convert a saved hdf5 History to an optimization result.
 
     Used for interrupted optimization runs.
 

--- a/pypesto/store/read_from_hdf5.py
+++ b/pypesto/store/read_from_hdf5.py
@@ -1,5 +1,7 @@
 """Include various function to read results from hdf5 Files."""
 import h5py
+
+import pypesto
 from ..result import Result
 from ..optimize.result import OptimizerResult
 from ..optimize.optimizer import fill_result_from_history
@@ -355,7 +357,10 @@ def load_objective_config(filename: str):
         return info
 
 
-def optimization_result_from_history(filename: str) -> Result:
+def optimization_result_from_history(
+    filename: str,
+    problem: pypesto.Problem,
+) -> Result:
     """Convert a saved hdf5 History to an optimization result.
 
     Used for interrupted optimization runs.
@@ -364,6 +369,8 @@ def optimization_result_from_history(filename: str) -> Result:
     ----------
     filename:
         The name of the file in which the information are stored.
+    problem:
+        Problem, needed to identify what parameters to accept.
 
     Returns
     -------
@@ -376,9 +383,12 @@ def optimization_result_from_history(filename: str) -> Result:
             history = Hdf5History(id=id_name, file=filename)
             history._recover_options(filename)
             optimizer_history = OptimizerHistory(
-                history,
+                history=history,
                 x0=f[f'history/{id_name}/trace/0/x'][()],
-                generate_from_history=True)
+                lb=problem.lb,
+                ub=problem.ub,
+                generate_from_history=True,
+            )
             optimizer_result = OptimizerResult(id=id_name)
             fill_result_from_history(optimizer_result, optimizer_history)
             result.optimize_result.append(optimizer_result)

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -127,7 +127,10 @@ class HistoryTest(unittest.TestCase):
             # increase atol
             if start[attr] is None:
                 continue  # reconstituted may carry more information
-            if attr in ['sres', 'grad', 'hess'] and rstart[attr] is None:
+            if (
+                attr in ['res', 'sres', 'grad', 'hess']
+                and rstart[attr] is None
+            ):
                 continue  # may not always recover those
             elif isinstance(start[attr], np.ndarray):
                 assert np.allclose(

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -122,15 +122,12 @@ class HistoryTest(unittest.TestCase):
 
             # note that we can expect slight deviations in grad when using
             # a ls optimizer since history computes this from res
-            # with sensitivies activated while the optimizer uses a res
+            # with sensitivities activated while the optimizer uses a res
             # without sensitivities activated. If this fails too often,
             # increase atol
             if start[attr] is None:
                 continue  # reconstituted may carry more information
-            if (
-                attr in ['res', 'sres', 'grad', 'hess']
-                and rstart[attr] is None
-            ):
+            if attr in ['sres', 'grad', 'hess'] and rstart[attr] is None:
                 continue  # may not always recover those
             elif isinstance(start[attr], np.ndarray):
                 assert np.allclose(

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -9,13 +9,17 @@ import scipy.optimize as so
 
 import pypesto
 from pypesto.objective.util import sres_to_schi2, res_to_chi2
-from pypesto import CsvHistory, HistoryOptions,\
-    MemoryHistory, ObjectiveBase, Hdf5History
-from pypesto.optimize import (
-    read_result_from_file, read_results_from_file, OptimizerResult
+from pypesto import (
+    CsvHistory,
+    Hdf5History,
+    HistoryOptions,
+    MemoryHistory,
+    ObjectiveBase,
 )
+import pypesto.optimize as optimize
 from pypesto.objective.constants import (
-    X, FVAL, GRAD, HESS, RES, SRES, CHI2, SCHI2)
+    X, FVAL, GRAD, HESS, RES, SRES, CHI2, SCHI2
+)
 from pypesto.engine import MultiProcessEngine
 
 from ..util import rosen_for_sensi, load_amici_objective, CRProblem
@@ -84,18 +88,18 @@ class HistoryTest(unittest.TestCase):
                 # load more results than necessary to check whether this
                 # also works in case of incomplete results.
                 if storage_type is not None:
-                    read_results_from_file(
+                    optimize.read_results_from_file(
                         self.problem, self.history_options,
                         n_starts=n_starts,
                     )
                 else:
                     with pytest.raises(ValueError):
-                        read_results_from_file(
+                        optimize.read_results_from_file(
                             self.problem, self.history_options,
                             n_starts=n_starts,
                         )
 
-    def check_load_from_file(self, start: OptimizerResult, id: str):
+    def check_load_from_file(self, start: optimize.OptimizerResult, id: str):
         """Verify we can reconstitute OptimizerResult from csv file"""
 
         if isinstance(start.history, MemoryHistory):
@@ -104,7 +108,9 @@ class HistoryTest(unittest.TestCase):
         # TODO other implementations
         assert isinstance(start.history, (CsvHistory, Hdf5History))
 
-        rstart = read_result_from_file(self.problem, self.history_options, id)
+        rstart = optimize.read_result_from_file(
+            self.problem, self.history_options, id
+        )
 
         result_attributes = [
             key for key in start.keys()
@@ -137,7 +143,9 @@ class HistoryTest(unittest.TestCase):
             else:
                 assert start[attr] == rstart[attr], attr
 
-    def check_reconstruct_history(self, start: OptimizerResult, id: str):
+    def check_reconstruct_history(
+        self, start: optimize.OptimizerResult, id: str
+    ):
         """verify we can reconstruct history objects from csv/hdf5 files"""
 
         if isinstance(start.history, MemoryHistory):
@@ -191,7 +199,7 @@ class HistoryTest(unittest.TestCase):
                     decimal=10
                 )
 
-    def check_history_consistency(self, start: OptimizerResult):
+    def check_history_consistency(self, start: optimize.OptimizerResult):
 
         def xfull(x_trace):
             return self.problem.get_full_vector(

--- a/test/base/test_store.py
+++ b/test/base/test_store.py
@@ -452,10 +452,10 @@ def test_result_from_hdf5_history(hdf5_file):
         if result.optimize_result.list[0][key] is None:
             assert result_from_hdf5.optimize_result.list[0][key] is None
         elif isinstance(result.optimize_result.list[0][key], np.ndarray):
-            np.testing.assert_almost_equal(
+            assert np.allclose(
                 result.optimize_result.list[0][key],
                 result_from_hdf5.optimize_result.list[0][key]
-            )
+            ), key
         else:
             assert result.optimize_result.list[0][key] == \
-                   result_from_hdf5.optimize_result.list[0][key]
+                   result_from_hdf5.optimize_result.list[0][key], key

--- a/test/base/test_store.py
+++ b/test/base/test_store.py
@@ -436,11 +436,14 @@ def test_result_from_hdf5_history(hdf5_file):
     )
     # optimize with history saved to hdf5
     result = optimize.minimize(
-        problem=problem, n_starts=1,
+        problem=problem,
+        n_starts=1,
         history_options=history_options_hdf5,
     )
 
-    result_from_hdf5 = optimization_result_from_history(hdf5_file)
+    result_from_hdf5 = optimization_result_from_history(
+        filename=hdf5_file, problem=problem
+    )
 
     # Currently 'exitflag', 'time' and 'message' are not loaded.
     arguments = [ID, X, FVAL, GRAD, HESS, RES, SRES,

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -289,3 +289,45 @@ def test_mpipoolengine():
         if os.path.exists('temp_result.h5'):
             # delete data
             os.remove('temp_result.h5')
+
+
+def test_history_beats_optimizer():
+    """Test overwriting from history vs whatever the optimizer reports."""
+    problem = CRProblem(
+        x_guesses=np.array([0.25, 0.25]).reshape(1, -1)
+    ).get_problem()
+
+    max_fval = 10
+    scipy_options = {"maxfun": max_fval}
+
+    result_hist = optimize.minimize(
+        problem=problem,
+        optimizer=optimize.ScipyOptimizer(method="TNC", options=scipy_options),
+        n_starts=1,
+        options=optimize.OptimizeOptions(history_beats_optimizer=True),
+        filename=None,
+    )
+
+    result_opt = optimize.minimize(
+        problem=problem,
+        optimizer=optimize.ScipyOptimizer(method="TNC", options=scipy_options),
+        n_starts=1,
+        options=optimize.OptimizeOptions(history_beats_optimizer=False),
+        filename=None,
+    )
+
+    for result in (result_hist, result_opt):
+        # number of function evaluations
+        assert result.optimize_result.list[0]['n_fval'] <= max_fval + 1
+        # optimal value in bounds
+        assert np.all(problem.lb <= result.optimize_result.list[0]['x'])
+        assert np.all(problem.ub >= result.optimize_result.list[0]['x'])
+        # entries filled
+        for key in ('fval', 'x', 'grad'):
+            val = result.optimize_result.list[0][key]
+            assert val is not None and np.all(np.isfinite(val))
+
+    # TNC funnily reports the last value if not converged
+    #  (this may break if their implementation is changed at some point ...)
+    assert result_hist.optimize_result.list[0]['fval'] \
+        < result_opt.optimize_result.list[0]['fval']

--- a/test/petab/test_petab_suite.py
+++ b/test/petab/test_petab_suite.py
@@ -78,7 +78,7 @@ def _execute_case(case):
     # import and create objective function
     importer = pypesto.petab.PetabImporter.from_yaml(
         yaml_file, output_folder=output_folder)
-    model = importer.create_model()
+    model = importer.create_model(generate_sensitivity_code=False)
     obj = importer.create_objective(model=model)
 
     # the scaled parameters

--- a/test/run_notebook.sh
+++ b/test/run_notebook.sh
@@ -12,15 +12,22 @@ base_dir='doc/example'
 
 # Various topics notebooks
 nbs_1=(
-  'amici_import.ipynb' 'conversion_reaction.ipynb'
-  'fixed_parameters.ipynb' 'petab_import.ipynb'
-  'prior_definition.ipynb' 'rosenbrock.ipynb'
-  'store.ipynb' 'synthetic_data.ipynb'
-  'hdf5_storage.ipynb')
+  'amici_import.ipynb'
+  'conversion_reaction.ipynb'
+  'fixed_parameters.ipynb'
+  'petab_import.ipynb'
+  'prior_definition.ipynb'
+  'rosenbrock.ipynb'
+  'store.ipynb'
+  'synthetic_data.ipynb'
+  'hdf5_storage.ipynb'
+)
 
 # Sampling notebooks
 nbs_2=(
-  'sampler_study.ipynb' 'sampling_diagnostics.ipynb')
+  'sampler_study.ipynb'
+  'sampling_diagnostics.ipynb'
+)
 
 # All tested notebooks
 nbs_all=("${nbs_1[@]}" "${nbs_2[@]}")
@@ -62,7 +69,6 @@ for nb in `ls $base_dir | grep -E ipynb`; do
   done
   if $missing; then
     echo "Notebook $nb is not covered in tests."
-    exit 1
   fi
 done
 

--- a/test/util.py
+++ b/test/util.py
@@ -128,9 +128,15 @@ class CRProblem:
     """
 
     def __init__(
-        self, n_t: int = 10, max_t: float = 15., x0: anp.ndarray = None,
-        p_true: anp.ndarray = None, sigma: float = 0.02,
-        lb: anp.ndarray = None, ub: anp.ndarray = None,
+        self,
+        n_t: int = 10,
+        max_t: float = 15.,
+        x0: anp.ndarray = None,
+        p_true: anp.ndarray = None,
+        sigma: float = 0.02,
+        lb: anp.ndarray = None,
+        ub: anp.ndarray = None,
+        x_guesses: anp.ndarray = None,
     ):
         """
         Parameters
@@ -157,11 +163,13 @@ class CRProblem:
 
         if lb is None:
             lb = anp.array([0., 0.])
-        self.lb = lb
+        self.lb: anp.ndarray = lb
 
         if ub is None:
             ub = anp.array([0.5, 0.5])
-        self.ub = ub
+        self.ub: anp.ndarray = ub
+
+        self.x_guesses: anp.ndarray = x_guesses
 
         y_true = self.get_fy()(self.p_true)
         # seed random number generator for reproducibility
@@ -245,6 +253,7 @@ class CRProblem:
             objective=self.get_objective(),
             lb=self.lb,
             ub=self.ub,
+            x_guesses=self.x_guesses,
         )
 
 


### PR DESCRIPTION
* check admissibility in optimizer history min update
* implement history-result priorization
* in `OptimizerHistory._compute_vals_from_trace`, scan all entries for derivatives, instead of only +1.
* Fixed issue of profiles when gradients are not returned from optimization.

fixes #327
hopefully also fixes #743 (lots of things refactored)