### PR TITLE
Limit number of function evaluations in notebooks in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ amici_models/*
 test/doc/example/tmp/benchmark-models/
 test/amici_models/*
 *.hdf5
+*.h5
 *.dat
 /BioNetGen-*.*.*
 /bionetgen.tar

--- a/pypesto/C.py
+++ b/pypesto/C.py
@@ -131,4 +131,5 @@ RGBA_BLACK = (RGBA_MIN, RGBA_MIN, RGBA_MIN, RGBA_MAX)  # black as an RGBA color
 ###############################################################################
 # Environment variables
 
+PYPESTO_MAX_N_STARTS: str = "PYPESTO_MAX_N_STARTS"
 PYPESTO_MAX_N_SAMPLES: str = "PYPESTO_MAX_N_SAMPLES"

--- a/pypesto/C.py
+++ b/pypesto/C.py
@@ -126,3 +126,9 @@ RGBA_MAX = 1  # max value for an RGBA element
 RGBA_ALPHA = 3  # zero-indexed fourth element in RGBA
 RGBA_WHITE = (RGBA_MAX, RGBA_MAX, RGBA_MAX, RGBA_MAX)  # white as an RGBA color
 RGBA_BLACK = (RGBA_MIN, RGBA_MIN, RGBA_MIN, RGBA_MAX)  # black as an RGBA color
+
+
+###############################################################################
+# Environment variables
+
+PYPESTO_MAX_N_SAMPLES: str = "PYPESTO_MAX_N_SAMPLES"

--- a/pypesto/optimize/optimize.py
+++ b/pypesto/optimize/optimize.py
@@ -10,7 +10,11 @@ from ..store import autosave
 from .optimizer import Optimizer, ScipyOptimizer
 from .options import OptimizeOptions
 from .task import OptimizerTask
-from .util import postprocess_hdf5_history, preprocess_hdf5_history
+from .util import (
+    bound_n_starts_from_env,
+    postprocess_hdf5_history,
+    preprocess_hdf5_history,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +76,9 @@ def minimize(
     # optimizer
     if optimizer is None:
         optimizer = ScipyOptimizer()
+
+    # number of starts
+    n_starts = bound_n_starts_from_env(n_starts)
 
     # startpoint method
     if startpoint_method is None:

--- a/pypesto/optimize/util.py
+++ b/pypesto/optimize/util.py
@@ -1,14 +1,19 @@
 """Utility functions for :py:func:`pypesto.optimize.minimize`."""
 
+import logging
+import os
 from pathlib import Path
 from typing import List
 
 import h5py
 
+from ..C import PYPESTO_MAX_N_STARTS
 from ..engine import Engine, SingleCoreEngine
 from ..objective import HistoryOptions
 from ..store.save_to_hdf5 import get_or_create_group
 from .optimizer import OptimizerResult
+
+logger = logging.getLogger(__name__)
 
 
 def preprocess_hdf5_history(
@@ -105,3 +110,32 @@ def postprocess_hdf5_history(
 
     # reset storage file (undo preprocessing changes)
     history_options.storage_file = storage_file
+
+
+def bound_n_starts_from_env(n_starts: int):
+    """Bound number of optimization starts from environment variable.
+
+    Uses environment variable `PYPESTO_MAX_N_STARTS`.
+    This is used to speed up testing, while in application it should not
+    be used.
+
+    Parameters
+    ----------
+    n_starts: Number of starts desired.
+
+    Returns
+    -------
+    n_starts_new:
+        The original number of starts, or the minimum with the environment
+        variable, if exists.
+    """
+    if PYPESTO_MAX_N_STARTS not in os.environ:
+        return n_starts
+    n_starts_new = min(n_starts, int(os.environ[PYPESTO_MAX_N_STARTS]))
+
+    logger.info(
+        f"Bounding number of samples from {n_starts} to {n_starts_new} via "
+        f"environment variable {PYPESTO_MAX_N_STARTS}"
+    )
+
+    return n_starts_new

--- a/pypesto/sample/sample.py
+++ b/pypesto/sample/sample.py
@@ -9,6 +9,7 @@ from ..result import Result
 from ..store import autosave
 from .adaptive_metropolis import AdaptiveMetropolisSampler
 from .sampler import Sampler
+from .util import bound_n_samples_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,9 @@ def sample(
     # prepare result object
     if result is None:
         result = Result(problem)
+
+    # number of samples
+    n_samples = bound_n_samples_from_env(n_samples)
 
     # try to find initial parameters
     if x0 is None:

--- a/pypesto/sample/util.py
+++ b/pypesto/sample/util.py
@@ -1,9 +1,11 @@
 """A set of helper functions."""
 import logging
+import os
 from typing import Tuple
 
 import numpy as np
 
+from ..C import PYPESTO_MAX_N_SAMPLES
 from ..result import Result
 from .diagnostics import geweke_test
 
@@ -93,3 +95,32 @@ def calculate_ci(
     # Upper and lower bounds
     lb, ub = np.percentile(values, percentiles, **kwargs)
     return lb, ub
+
+
+def bound_n_samples_from_env(n_samples: int):
+    """Bound number of samples from environment variable.
+
+    Uses environment variable `PYPESTO_MAX_N_SAMPLES`.
+    This is used to speed up testing, while in application it should not
+    be used.
+
+    Parameters
+    ----------
+    n_samples: Number of samples desired.
+
+    Returns
+    -------
+    n_samples_new:
+        The original number of samples, or the minimum with the environment
+        variable, if exists.
+    """
+    if PYPESTO_MAX_N_SAMPLES not in os.environ:
+        return n_samples
+    n_samples_new = min(n_samples, int(os.environ[PYPESTO_MAX_N_SAMPLES]))
+
+    logger.info(
+        f"Bounding number of samples from {n_samples} to {n_samples_new} via "
+        f"environment variable {PYPESTO_MAX_N_SAMPLES}"
+    )
+
+    return n_samples_new

--- a/test/run_notebook.sh
+++ b/test/run_notebook.sh
@@ -6,6 +6,7 @@
 
 # Environment
 
+export PYPESTO_MAX_N_STARTS=20
 export PYPESTO_MAX_N_SAMPLES=1000
 
 base_dir='doc/example'

--- a/test/run_notebook.sh
+++ b/test/run_notebook.sh
@@ -4,11 +4,14 @@
 #  Arguments 1, 2 specify a part of the models to run.
 #  If nothing is specified, all are run.
 
-# When adding notebooks, make sure the load is balanced.
+# Environment
+
+export PYPESTO_MAX_N_SAMPLES=1000
 
 base_dir='doc/example'
 
 # Split notebooks up to parallelize execution
+# When adding notebooks, make sure the load is balanced.
 
 # Various topics notebooks
 nbs_1=(


### PR DESCRIPTION
* Add environment variables set in `test/run_notebooks.sh` to limit the numbers of multistarts and samples
* Especially for sampling, this gives a substantial reduction