### PR TITLE
Fix pyPESTO Select test; Update to stable black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,12 @@
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 22.1.0
   hooks:
   - id: black
     description: The uncompromising code formatter
 - repo: https://github.com/pycqa/isort
-  rev: 5.8.0
+  rev: 5.10.1
   hooks:
   - id: isort
     name: isort (python)
@@ -34,7 +34,7 @@ repos:
     args: [--py36-plus]
   - id: nbqa-isort
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v4.1.0
   hooks:
   - id: check-yaml
     description: Check yaml files for parseable syntax

--- a/doc/example/amici_import.ipynb
+++ b/doc/example/amici_import.ipynb
@@ -386,13 +386,13 @@
     "\n",
     "# set standard deviations to optimal values found in the benchmark collection\n",
     "edata.setObservedDataStdDev(\n",
-    "    amici.DoubleVector(np.array(16 * [10 ** 0.585755271])), 0\n",
+    "    amici.DoubleVector(np.array(16 * [10**0.585755271])), 0\n",
     ")\n",
     "edata.setObservedDataStdDev(\n",
-    "    amici.DoubleVector(np.array(16 * [10 ** 0.818982819])), 1\n",
+    "    amici.DoubleVector(np.array(16 * [10**0.818982819])), 1\n",
     ")\n",
     "edata.setObservedDataStdDev(\n",
-    "    amici.DoubleVector(np.array(16 * [10 ** 0.498684404])), 2\n",
+    "    amici.DoubleVector(np.array(16 * [10**0.498684404])), 2\n",
     ")"
    ]
   },

--- a/pypesto/ensemble/ensemble.py
+++ b/pypesto/ensemble/ensemble.py
@@ -330,7 +330,7 @@ class EnsemblePrediction:
             summary[MEDIAN] = np.median(tmp_array, axis=-1)
             if tmp_sigmas is not None:
                 summary[WEIGHTED_SIGMA] = np.sqrt(
-                    np.average(tmp_sigmas ** 2, axis=-1, weights=weights)
+                    np.average(tmp_sigmas**2, axis=-1, weights=weights)
                 )
             for perc in percentiles_list:
                 summary[get_percentile_label(perc)] = np.percentile(

--- a/pypesto/objective/finite_difference.py
+++ b/pypesto/objective/finite_difference.py
@@ -715,7 +715,7 @@ def fd_nabla_2(
         else:
             raise ValueError(f"Method {fd_method} not recognized.")
 
-        nabla_2[ix1][ix1] = (f2p + f2m - 2 * fc) / delta1_val ** 2
+        nabla_2[ix1][ix1] = (f2p + f2m - 2 * fc) / delta1_val**2
 
         # off-diagonals
         for ix2 in range(ix1):

--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -304,20 +304,20 @@ def get_parameter_prior_dict(
 
         def log_f_log10(x_log10):
             """Log-prior for log10-parameters."""
-            return log_f(10 ** x_log10)
+            return log_f(10**x_log10)
 
         def d_log_f_log10(x_log10):
             """Rerivative of log-prior w.r.t. log10-parameters."""
-            return d_log_f_dx(10 ** x_log10) * log10 * 10 ** x_log10
+            return d_log_f_dx(10**x_log10) * log10 * 10**x_log10
 
         def dd_log_f_log10(x_log10):
             """Second derivative of log-prior w.r.t. log10-parameters."""
             return (
-                log10 ** 2
-                * 10 ** x_log10
+                log10**2
+                * 10**x_log10
                 * (
-                    dd_log_f_ddx(10 ** x_log10) * 10 ** x_log10
-                    + d_log_f_dx(10 ** x_log10)
+                    dd_log_f_ddx(10**x_log10) * 10**x_log10
+                    + d_log_f_dx(10**x_log10)
                 )
             )
 
@@ -326,14 +326,14 @@ def get_parameter_prior_dict(
 
             def res_log(x_log10):
                 """Residual-prior for log10-parameters."""
-                return res(10 ** x_log10)
+                return res(10**x_log10)
 
         d_res_log = None
         if d_res_dx is not None:
 
             def d_res_log(x_log10):
                 """Residual-prior for log10-parameters."""
-                return d_res_dx(10 ** x_log10) * log10 * 10 ** x_log10
+                return d_res_dx(10**x_log10) * log10 * 10**x_log10
 
         return {
             'index': index,
@@ -454,7 +454,7 @@ def _prior_densities(
 
         mean = prior_parameters[0]
         sigma = prior_parameters[1]
-        sigma2 = sigma ** 2
+        sigma2 = sigma**2
 
         def log_f(x):
             return -np.log(2 * np.pi * sigma2) / 2 - (x - mean) ** 2 / (
@@ -508,15 +508,15 @@ def _prior_densities(
 
         def log_f(x):
             return -np.log(sqrt2_pi * sigma * x) - (np.log(x) - mean) ** 2 / (
-                2 * sigma ** 2
+                2 * sigma**2
             )
 
         def d_log_f_dx(x):
-            return -1 / x - (np.log(x) - mean) / (sigma ** 2 * x)
+            return -1 / x - (np.log(x) - mean) / (sigma**2 * x)
 
         def dd_log_f_ddx(x):
-            return 1 / (x ** 2) - (1 - np.log(x) + mean) / (
-                sigma ** 2 * x ** 2
+            return 1 / (x**2) - (1 - np.log(x) + mean) / (
+                sigma**2 * x**2
             )
 
         return log_f, d_log_f_dx, dd_log_f_ddx, None, None

--- a/pypesto/sample/auto_correlation.py
+++ b/pypesto/sample/auto_correlation.py
@@ -35,7 +35,7 @@ def autocorrelation_sokal(chain: np.ndarray) -> np.ndarray:
     # Get the imaginary part
     xi = np.imag(x)
 
-    xr = xr ** 2 + xi ** 2
+    xr = xr**2 + xi**2
     # First value to zero
     xr[0, :] = 0.0
     # Calculate the fast Fourier transform

--- a/setup.cfg
+++ b/setup.cfg
@@ -136,7 +136,7 @@ select =
     networkx >= 2.5.1
     %(petab)s
     # End remove
-    petab-select >= 0.0.5
+    petab-select >= 0.0.8
 test =
     pytest >= 5.4.3
     pytest-cov >= 2.10.0

--- a/test/base/test_objective.py
+++ b/test/base/test_objective.py
@@ -139,7 +139,7 @@ def test_finite_difference_checks():
     x = sp.Symbol('x')
 
     # Setup single-parameter objective function
-    fun_expr = x ** 10
+    fun_expr = x**10
     grad_expr = fun_expr.diff()
     theta = 0.1
 

--- a/test/base/test_prior.py
+++ b/test/base/test_prior.py
@@ -192,6 +192,6 @@ def scaled_to_lin(x: float, scale: str):
     elif scale == 'log':
         return math.exp(x)
     elif scale == 'log10':
-        return 10 ** x
+        return 10**x
     else:
         ValueError(f'Unknown scale {scale}')

--- a/test/select/test_select.py
+++ b/test/select/test_select.py
@@ -167,14 +167,14 @@ def test_problem_select_to_completion(pypesto_select_problem):
     # Expected models were calibrated during the search.
     assert test_history_subspace_ids == expected_history_subspace_ids
 
-    expected_best_model_subspace_ids = ['M1_0', 'M1_1']
+    expected_best_model_subspace_ids = ['M1_0', 'M1_1', 'M1_7']
     test_best_model_subspace_ids = [
         model.model_subspace_id for model in best_models
     ]
     # Expected best models were found.
     assert test_best_model_subspace_ids == expected_best_model_subspace_ids
 
-    expected_best_model_criterion_values = [36.921, -4.017]
+    expected_best_model_criterion_values = [36.767, -4.592, -4.889]
     test_best_model_criterion_values = [
         model.get_criterion(Criterion.BIC) for model in best_models
     ]


### PR DESCRIPTION
PEtab Select changed its calculation of the number of priors in a problem, to only include PEtab `objectivePrior`s.

This results in a difference in the BIC of calibrated models, hence the different test result.