### PR TITLE
fix n_res size for error output with parameter dependent sigma

### DIFF
--- a/pypesto/objective/amici_util.py
+++ b/pypesto/objective/amici_util.py
@@ -343,6 +343,8 @@ def get_error_output(
             data.nt() if data.nt() else amici_model.nt() for data in edatas
         )
     n_res = nt * amici_model.nytrue
+    if amici_model.getAddSigmaResiduals():
+        n_res *= 2
 
     nllh, snllh, s2nllh, chi2, res, sres = init_return_values(
         sensi_orders, mode, dim, True


### PR DESCRIPTION
fixes incorrect residual size in error output for models with "error residuals" that account for parameter dependent sigmas. 

For `ls_trf` this leads to termination of optimization when integration succeeds for `res` but fails for `sres` at the initial point. Optimization can't continue anyways, but this way there is some potential (we currently still end up with an `start X failed: array must not contain infs or NaNs`) to provide a more meaningful error messages (and potentially avoid trouble with other, more stringent optimizers).