### PR TITLE
Autosave filename method

### DIFF
--- a/pypesto/optimize/optimize.py
+++ b/pypesto/optimize/optimize.py
@@ -31,7 +31,7 @@ def minimize(
     progress_bar: bool = True,
     options: OptimizeOptions = None,
     history_options: HistoryOptions = None,
-    filename: Union[str, None] = "Auto",
+    filename: Union[str, Callable, None] = "Auto",
 ) -> Result:
     """
     Do multistart optimization.
@@ -67,6 +67,7 @@ def minimize(
         "Auto", in which case it will automatically generate a file named
         `year_month_day_optimization_result.hdf5`. Deactivate saving by
         setting filename to `None`.
+        Optionally a method, see docs for `pypesto.store.auto.autosave`.
 
     Returns
     -------

--- a/pypesto/profile/profile.py
+++ b/pypesto/profile/profile.py
@@ -25,7 +25,7 @@ def parameter_profile(
     next_guess_method: Union[Callable, str] = 'adaptive_step_regression',
     profile_options: ProfileOptions = None,
     progress_bar: bool = True,
-    filename: Union[str, None] = "Auto",
+    filename: Union[str, Callable, None] = "Auto",
 ) -> Result:
     """
     Call to do parameter profiling.
@@ -65,6 +65,7 @@ def parameter_profile(
         "Auto", in which case it will automatically generate a file named
         `year_month_day_profiling_result.hdf5`. Deactivate saving by
         setting filename to `None`.
+        Optionally a method, see docs for `pypesto.store.auto.autosave`.
 
     Returns
     -------

--- a/pypesto/sample/sample.py
+++ b/pypesto/sample/sample.py
@@ -1,6 +1,6 @@
 import logging
 from time import process_time
-from typing import List, Union
+from typing import Callable, List, Union
 
 import numpy as np
 
@@ -20,7 +20,7 @@ def sample(
     sampler: Sampler = None,
     x0: Union[np.ndarray, List[np.ndarray]] = None,
     result: Result = None,
-    filename: Union[str, None] = "Auto",
+    filename: Union[str, Callable, None] = "Auto",
 ) -> Result:
     """
     Call to do parameter sampling.
@@ -47,6 +47,7 @@ def sample(
         "Auto", in which case it will automatically generate a file named
         `year_month_day_sampling_result.hdf5`. Deactivate saving by
         setting filename to `None`.
+        Optionally a method, see docs for `pypesto.store.auto.autosave`.
 
     Returns
     -------

--- a/pypesto/store/auto.py
+++ b/pypesto/store/auto.py
@@ -3,13 +3,14 @@
 import binascii
 import datetime
 import os
+from typing import Callable, Union
 
 from ..result import Result
 from .save_to_hdf5 import write_result
 
 
 def autosave(
-    filename: str,
+    filename: Union[str, Callable, None],
     result: Result,
     store_type: str,
     overwrite: bool = False,
@@ -23,6 +24,9 @@ def autosave(
         Either the filename to save to or "Auto", in which case it will
         automatically generate a file named
         `year_month_day_{type}_result.hdf5`.
+        A method can also be provided. All input to the autosave method will
+        be passed to the filename method. The output should be the filename
+        (`str`).
     result:
         The result to be saved.
     store_type:
@@ -35,13 +39,28 @@ def autosave(
         return
 
     if filename == "Auto":
-        time = datetime.datetime.now().strftime("%Y_%d_%m_%H_%M_%S")
-        filename = (
-            time + f"_{store_type}_result_"
-            f"{binascii.b2a_hex(os.urandom(8)).decode()}.h5"
+        filename = default_filename
+    if not isinstance(filename, str):
+        filename = filename(
+            result=result,
+            store_type=store_type,
+            overwrite=overwrite,
         )
     # set the type to True and pass it on to write_result
     to_save = {store_type: True}
     write_result(
         result=result, overwrite=overwrite, filename=filename, **to_save
     )
+
+
+def default_filename(**kwargs) -> str:
+    """Create a filename when results will be autosaved.
+    
+    See :func:`autosave` for additional information.
+    """
+    time = datetime.datetime.now().strftime("%Y_%d_%m_%H_%M_%S")
+    filename = (
+        time + f"_{kwargs['store_type']}_result_"
+        f"{binascii.b2a_hex(os.urandom(8)).decode()}.h5"
+    )
+    return filename

--- a/pypesto/store/auto.py
+++ b/pypesto/store/auto.py
@@ -55,7 +55,7 @@ def autosave(
 
 def default_filename(**kwargs) -> str:
     """Create a filename when results will be autosaved.
-    
+
     See :func:`autosave` for additional information.
     """
     time = datetime.datetime.now().strftime("%Y_%d_%m_%H_%M_%S")


### PR DESCRIPTION
Autosaving now supports specifying the filename with a user-supplied method. Useful to organize autosave files when many such files are created. The previous `"Auto"` option is now implemented as such a method (should be backwards compatible).
e.g. following organizes autosave files neatly on a HPC with Slurm job arrays
```python
import os
from pathlib import Path


job_array_id = os.environ.get('SLURM_ARRAY_TASK_ID', 0)
autosave_path = Path('output') / 'autosave'


def filename(iteration=[0], **kwargs):
    iteration[0] += 1
    # `5` set arbitrarily here to provide sufficient padding.
    # Could use something like the following instead (untested).
    # padding = math.ceil(math.log10(os.environ.get['SLURM_ARRAY_TASK_MAX']))
    directory = autosave_path / kwargs['store_type'] / f'{job_array_id:0>5}'
    directory.mkdir(parents=True, exist_ok=True)
    name = f'{iteration[0]}.h5'
    return str(directory / name)


# Use, e.g. in optimization
pypesto.optimize.minimize(..., filename=filename)
```

The following should simply move the default autosave files to their own directory (untested)
```python
from pathlib import Path

from pypesto.store.auto import default_filename


def filename(**kwargs):
    directory = Path('autosave')
    name = default_filename(**kwargs)
    return str(directory / name)


# Use, e.g. in optimization
pypesto.optimize.minimize(..., filename=filename)
```