### PR TITLE
Temporarily fix jinja2 version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ keywords =
 
 [options]
 install_requires =
-    numpy >= 1.19.1, <= 1.21.5
+    numpy >= 1.19.1
     scipy >= 1.5.2
     pandas >= 1.2.0
     cloudpickle >= 1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     h5py >= 3.1.0
     tqdm >= 4.46.0
 
+
 python_requires = >=3.8
 include_package_data = True
 
@@ -129,6 +130,9 @@ doc =
     recommonmark >= 0.6.0
     ipython >= 7.18.1
     %(select)s
+    # https://github.com/spatialaudio/nbsphinx/issues/641
+    # https://github.com/apache/flink/pull/19238
+    Jinja2 == 3.0.3
 example =
     notebook >= 6.1.4
 select =

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ keywords =
 
 [options]
 install_requires =
-    numpy >= 1.19.1
+    numpy >= 1.19.1, <= 1.21.5
     scipy >= 1.5.2
     pandas >= 1.2.0
     cloudpickle >= 1.5.0


### PR DESCRIPTION
As similarly done for libpetab-python https://github.com/PEtab-dev/libpetab-python/pull/115