### PR TITLE
Upgrade black to be compatible with latest click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     description: The uncompromising code formatter


### PR DESCRIPTION
Fixes `ImportError: cannot import name '_unicodefun' from 'click'`, currently occurring on RTD.

see https://github.com/psf/black/issues/2964