### PR TITLE
fix #839

### DIFF
--- a/pypesto/ensemble/util.py
+++ b/pypesto/ensemble/util.py
@@ -316,9 +316,7 @@ def read_ensemble_prediction_from_h5(
                 bounds[key] = np.array(bounds[key])
                 continue
             x_names = decode_array(f[f'{key}/{X_NAMES}'][()])
-            condition_ids = np.array(
-                decode_array(f[f'{key}/condition_ids'][()])
-            )
+            condition_ids = decode_array(f[f'{key}/condition_ids'][()])
             pred_cond_res_list = []
             for id, _ in enumerate(condition_ids):
                 output = f[f'{key}/{id}/{OUTPUT}'][:]
@@ -348,4 +346,4 @@ def decode_array(array: np.ndarray) -> np.ndarray:
     """Decode array of bytes to string."""
     for i in range(len(array)):
         array[i] = array[i].decode()
-    return array
+    return list(array)

--- a/pypesto/ensemble/util.py
+++ b/pypesto/ensemble/util.py
@@ -322,8 +322,9 @@ def read_ensemble_prediction_from_h5(
             pred_cond_res_list = []
             for id, _ in enumerate(condition_ids):
                 output = f[f'{key}/{id}/{OUTPUT}'][:]
-                output_ids = tuple(decode_array(f[f'{key}/{id}'
-                                                  f'/{OUTPUT_IDS}'][:]))
+                output_ids = tuple(
+                    decode_array(f[f'{key}/{id}' f'/{OUTPUT_IDS}'][:])
+                )
                 timepoints = f[f'{key}/{id}/{TIMEPOINTS}'][:]
                 pred_cond_res_list.append(
                     PredictionConditionResult(

--- a/pypesto/ensemble/util.py
+++ b/pypesto/ensemble/util.py
@@ -323,7 +323,7 @@ def read_ensemble_prediction_from_h5(
             for id, _ in enumerate(condition_ids):
                 output = f[f'{key}/{id}/{OUTPUT}'][:]
                 output_ids = tuple(decode_array(f[f'{key}/{id}'
-                                                 f'/{OUTPUT_IDS}'][:]))
+                                                  f'/{OUTPUT_IDS}'][:]))
                 timepoints = f[f'{key}/{id}/{TIMEPOINTS}'][:]
                 pred_cond_res_list.append(
                     PredictionConditionResult(

--- a/pypesto/ensemble/util.py
+++ b/pypesto/ensemble/util.py
@@ -322,7 +322,8 @@ def read_ensemble_prediction_from_h5(
             pred_cond_res_list = []
             for id, _ in enumerate(condition_ids):
                 output = f[f'{key}/{id}/{OUTPUT}'][:]
-                output_ids = decode_array(f[f'{key}/{id}/{OUTPUT_IDS}'][:])
+                output_ids = tuple(decode_array(f[f'{key}/{id}'
+                                                 f'/{OUTPUT_IDS}'][:]))
                 timepoints = f[f'{key}/{id}/{TIMEPOINTS}'][:]
                 pred_cond_res_list.append(
                     PredictionConditionResult(
@@ -348,5 +349,4 @@ def decode_array(array: np.ndarray) -> np.ndarray:
     """Decode array of bytes to string."""
     for i in range(len(array)):
         array[i] = array[i].decode()
-    # return list(array)
     return array

--- a/pypesto/ensemble/util.py
+++ b/pypesto/ensemble/util.py
@@ -303,6 +303,8 @@ def read_ensemble_prediction_from_h5(
         pred_res_list = []
         bounds = {}
         for key in f.keys():
+            if key.startswith(SUMMARY):
+                continue
             if key == PREDICTION_ID:
                 prediction_id = f[key][()].decode()
                 continue
@@ -315,8 +317,8 @@ def read_ensemble_prediction_from_h5(
                 ]
                 bounds[key] = np.array(bounds[key])
                 continue
-            x_names = decode_array(f[f'{key}/{X_NAMES}'][()])
-            condition_ids = decode_array(f[f'{key}/condition_ids'][()])
+            x_names = list(decode_array(f[f'{key}/{X_NAMES}'][()]))
+            condition_ids = list(decode_array(f[f'{key}/condition_ids'][()]))
             pred_cond_res_list = []
             for id, _ in enumerate(condition_ids):
                 output = f[f'{key}/{id}/{OUTPUT}'][:]
@@ -346,4 +348,5 @@ def decode_array(array: np.ndarray) -> np.ndarray:
     """Decode array of bytes to string."""
     for i in range(len(array)):
         array[i] = array[i].decode()
-    return list(array)
+    # return list(array)
+    return array


### PR DESCRIPTION
fixes #839 
Reading ensemble_predictions from hdf5 files can lead to some issues since the read IDs are saved as numpy.arrays instead of lists, which is used in the original creation of the ensemble_prediction. This will be fixed with this PR. 