### PR TITLE
PetabImporter: Auto-regenerate AMICI models in case of version mismatch

### DIFF
--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -239,7 +239,7 @@ class PetabImporter(AmiciObjectBuilder):
         try:
             # importing will already raise an exception if version wrong
             importlib.import_module(self.model_name)
-        except ModuleNotFoundError:
+        except (ModuleNotFoundError, amici.AmiciVersionError):
             return True
 
         # no need to (re-)compile

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -239,7 +239,13 @@ class PetabImporter(AmiciObjectBuilder):
         try:
             # importing will already raise an exception if version wrong
             importlib.import_module(self.model_name)
-        except (ModuleNotFoundError, amici.AmiciVersionError):
+        except ModuleNotFoundError:
+            return True
+        except amici.AmiciVersionError as e:
+            logger.info(
+                "amici model will be re-imported due to version "
+                f"mismatch: {e}"
+            )
             return True
 
         # no need to (re-)compile


### PR DESCRIPTION
For models that were generated with amici>=0.11.27, this will automatically re-import AMICI models in case of AMICI version mismatch