### PR TITLE
distinguish between scalar and vector values in Hdf5History._get_hdf5…

### DIFF
--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1130,12 +1130,13 @@ class Hdf5History(History):
 
             for iteration in ix:
                 try:
-                    entry = np.array(
-                        f[
-                            f'history/{self.id}/trace'
-                            f'/{str(iteration)}/{entry_id}'
-                        ]
-                    )
+                    dataset = f[
+                        f'history/{self.id}/trace/{str(iteration)}/{entry_id}'
+                    ]
+                    if dataset.shape == ():
+                        entry = dataset[()]  # scalar
+                    else:
+                        entry = np.array(dataset)
                     trace_result.append(entry)
                 except KeyError:
                     trace_result.append(None)


### PR DESCRIPTION
…_entries

This was an issue when I tried to read result from file (`optimize.load.read_result_from_file`).

Here time value was of type `np.array`. 
https://github.com/ICB-DCM/pyPESTO/blob/78a7556e32bbbd545018931669b5115955d5619c/pypesto/optimize/load.py#L141

which later on became an issue when I tried to save the result
https://github.com/ICB-DCM/pyPESTO/blob/78a7556e32bbbd545018931669b5115955d5619c/pypesto/store/save_to_hdf5.py#L163-L164
