### PR TITLE
Fix hdf5 history overwrite

### DIFF
--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1229,10 +1229,13 @@ class Hdf5History(History):
             false if the history is a loaded one to prevent overwriting.
 
         """
-        with h5py.File(file, 'r') as f:
-            return file, (
-                'history' not in f.keys() or self.id not in f['history']
-            )
+        try:
+            with h5py.File(file, 'r') as f:
+                return file, (
+                    'history' not in f.keys() or self.id not in f['history']
+                )
+        except OSError:  # if the file is non-existent, return editable = True
+            return file, True
 
 
 class OptimizerHistory:

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -937,7 +937,10 @@ class Hdf5History(History):
     ) -> None:
         """See `History` docstring."""
         if not self.editable:
-            raise ValueError('This id is already used in the history file.')
+            raise ValueError(
+                f'ID "{self.id}" is already used'
+                f' in history file "{self.file}".'
+            )
         super().update(x, sensi_orders, mode, result)
         self._update_trace(x, sensi_orders, mode, result)
 
@@ -1215,14 +1218,20 @@ class Hdf5History(History):
         ----------
         file:
             HDF5 file name.
+
+        Returns
+        -------
+        file:
+            HDF5 file name.
+        editable:
+            Boolean, whether this hdf5 file should be editable. Returns
+            false if the history is a loaded one to prevent overwriting.
+
         """
-        with h5py.File(file, 'a') as f:
-            editable = True
-            if 'history' not in f.keys():
-                return file, editable
-            if self.id in f['history']:
-                editable = False
-            return file, editable
+        with h5py.File(file, 'r') as f:
+            return file, (
+                'history' not in f.keys() or self.id not in f['history']
+            )
 
 
 class OptimizerHistory:

--- a/pypesto/result/optimize.py
+++ b/pypesto/result/optimize.py
@@ -217,13 +217,14 @@ class OptimizeResult:
         summary = (
             "## Optimization Result \n\n"
             f"* number of starts: {len(self)} \n"
+            f"* best value: {self[0]['fval']}, "
+            f"worst value: {self[-1]['fval']} \n"
+            f"* number of non-finite values: {np.logical_not(np.isfinite(self.fval)).sum()}\n\n"
             f"* execution time summary: {times_message}\n"
             f"* summary of optimizer messages:\n{counter_message}\n"
             f"* best value found (approximately) {clustsize[0]} time(s) \n"
             f"* number of plateaus found: "
             f"{1 + max(clust) - sum(clustsize == 1)} \n"
-            f"* best value: {self[0]['fval']}, "
-            f"worst value: {self[-1]['fval']} \n\n"
             f"A summary of the best run:\n\n{self[0].summary()}"
         )
         return summary

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -189,6 +189,7 @@ class HistoryTest(unittest.TestCase):
                 'start_time',
                 '_trace',
                 'x_names',
+                'editable',
             ]
         ]
         for attr in history_attributes:


### PR DESCRIPTION
For now, not allowing to write into the history file on already existing id's.