### PR TITLE
Updated the profile, minimize, sample and added overwrite as argument.

### DIFF
--- a/pypesto/optimize/optimize.py
+++ b/pypesto/optimize/optimize.py
@@ -32,6 +32,7 @@ def minimize(
     options: OptimizeOptions = None,
     history_options: HistoryOptions = None,
     filename: Union[str, Callable, None] = "Auto",
+    overwrite: bool = False,
 ) -> Result:
     """
     Do multistart optimization.
@@ -68,6 +69,8 @@ def minimize(
         `year_month_day_optimization_result.hdf5`. Deactivate saving by
         setting filename to `None`.
         Optionally a method, see docs for `pypesto.store.auto.autosave`.
+    overwrite:
+        Boolean, whether to potentially overwrite the existing file `filename`.
 
     Returns
     -------
@@ -154,6 +157,11 @@ def minimize(
     # if history file provided, set storage file to that one
     if filename == "Auto" and history_file is not None:
         filename = history_file
-    autosave(filename=filename, result=result, store_type="optimize")
+    autosave(
+        filename=filename,
+        result=result,
+        store_type="optimize",
+        overwrite=overwrite,
+    )
 
     return result

--- a/pypesto/optimize/optimize.py
+++ b/pypesto/optimize/optimize.py
@@ -70,7 +70,8 @@ def minimize(
         setting filename to `None`.
         Optionally a method, see docs for `pypesto.store.auto.autosave`.
     overwrite:
-        Boolean, whether to potentially overwrite the existing file `filename`.
+        Whether to overwrite `result/optimization` in the autosave file
+        if it already exists.
 
     Returns
     -------

--- a/pypesto/profile/profile.py
+++ b/pypesto/profile/profile.py
@@ -68,7 +68,8 @@ def parameter_profile(
         setting filename to `None`.
         Optionally a method, see docs for `pypesto.store.auto.autosave`.
     overwrite:
-        Boolean, whether to potentially overwrite the existing file `filename`.
+        Whether to overwrite `result/profiling` in the autosave file
+        if it already exists.
 
     Returns
     -------

--- a/pypesto/profile/profile.py
+++ b/pypesto/profile/profile.py
@@ -26,6 +26,7 @@ def parameter_profile(
     profile_options: ProfileOptions = None,
     progress_bar: bool = True,
     filename: Union[str, Callable, None] = "Auto",
+    overwrite: bool = False,
 ) -> Result:
     """
     Call to do parameter profiling.
@@ -66,6 +67,8 @@ def parameter_profile(
         `year_month_day_profiling_result.hdf5`. Deactivate saving by
         setting filename to `None`.
         Optionally a method, see docs for `pypesto.store.auto.autosave`.
+    overwrite:
+        Boolean, whether to potentially overwrite the existing file `filename`.
 
     Returns
     -------
@@ -155,6 +158,11 @@ def parameter_profile(
             indexed_profile['index']
         ] = indexed_profile['profile']
 
-    autosave(filename=filename, result=result, store_type="profile")
+    autosave(
+        filename=filename,
+        result=result,
+        store_type="profile",
+        overwrite=overwrite,
+    )
 
     return result

--- a/pypesto/sample/sample.py
+++ b/pypesto/sample/sample.py
@@ -50,7 +50,8 @@ def sample(
         setting filename to `None`.
         Optionally a method, see docs for `pypesto.store.auto.autosave`.
     overwrite:
-        Boolean, whether to potentially overwrite the existing file `filename`.
+        Whether to overwrite `result/sampling` in the autosave file
+        if it already exists.
 
     Returns
     -------

--- a/pypesto/sample/sample.py
+++ b/pypesto/sample/sample.py
@@ -21,6 +21,7 @@ def sample(
     x0: Union[np.ndarray, List[np.ndarray]] = None,
     result: Result = None,
     filename: Union[str, Callable, None] = "Auto",
+    overwrite: bool = False,
 ) -> Result:
     """
     Call to do parameter sampling.
@@ -48,6 +49,8 @@ def sample(
         `year_month_day_sampling_result.hdf5`. Deactivate saving by
         setting filename to `None`.
         Optionally a method, see docs for `pypesto.store.auto.autosave`.
+    overwrite:
+        Boolean, whether to potentially overwrite the existing file `filename`.
 
     Returns
     -------
@@ -92,6 +95,11 @@ def sample(
     # record results
     result.sample_result = sampler_result
 
-    autosave(filename=filename, result=result, store_type="sample")
+    autosave(
+        filename=filename,
+        result=result,
+        store_type="sample",
+        overwrite=overwrite,
+    )
 
     return result


### PR DESCRIPTION
I added `overwrite` to the three main functions as argument. Currently `autosave` has the potential argument overwrite but it is never used. This is so that people can overwrite their results without having to save it manually. Is set to false by default, so should be fine. 


If it is not wanted to have many arguments in minimise, could potentially add **kwargs to it?