### PR TITLE
Fix hdf5 result mismatch

### DIFF
--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1367,6 +1367,7 @@ class OptimizerHistory:
             Optimizer exitflag to be saved.
         """
         self.history.finalize(message=message, exitflag=exitflag)
+        self._compute_vals_from_trace()
 
     def _update_vals(self, x: np.ndarray, result: ResultDict):
         """Update initial and best function values."""

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -1367,7 +1367,8 @@ class OptimizerHistory:
             Optimizer exitflag to be saved.
         """
         self.history.finalize(message=message, exitflag=exitflag)
-        self._compute_vals_from_trace()
+        if isinstance(self.history, (Hdf5History, MemoryHistory, CsvHistory)):
+            self._compute_vals_from_trace()
 
     def _update_vals(self, x: np.ndarray, result: ResultDict):
         """Update initial and best function values."""


### PR DESCRIPTION
should fix #743. Ran the `test_result_from_hdf5_history` test 1000 times and it was successful every time.

Potentially we could remove the `_update` function of `OptimizerHistory`?