### PR TITLE
Fix set of keys to aggregate results

### DIFF
--- a/pypesto/objective/aggregated.py
+++ b/pypesto/objective/aggregated.py
@@ -122,7 +122,7 @@ def aggregate_results(rvals: Sequence[ResultDict]) -> ResultDict:
     result = {
         key: sum(rval[key] for rval in rvals)
         for key in [FVAL, CHI2, SCHI2, GRAD, HESS, HESSP]
-        if all([key in rval for rval in rvals])
+        if all(key in rval for rval in rvals)
     }
 
     # extract rdatas and flatten

--- a/pypesto/objective/aggregated.py
+++ b/pypesto/objective/aggregated.py
@@ -118,9 +118,7 @@ def aggregate_results(rvals: Sequence[ResultDict]) -> ResultDict:
     rvals:
         results to aggregate
     """
-    # rvals are guaranteed to be consistent as _check_sensi_orders checks
-    # whether each objective can be called with the respective
-    # sensi_orders/mode
+
     keys = []
     for rval in rvals:
         rval_keys = []
@@ -132,7 +130,7 @@ def aggregate_results(rvals: Sequence[ResultDict]) -> ResultDict:
 
     # sum over fval/grad/hess
     result = {
-        key: sum(rval[key] for rval in rvals)
+        key: sum(np.array(rval[key]) for rval in rvals)
         for key in key_set
     }
 

--- a/pypesto/objective/aggregated.py
+++ b/pypesto/objective/aggregated.py
@@ -121,12 +121,19 @@ def aggregate_results(rvals: Sequence[ResultDict]) -> ResultDict:
     # rvals are guaranteed to be consistent as _check_sensi_orders checks
     # whether each objective can be called with the respective
     # sensi_orders/mode
+    keys = []
+    for rval in rvals:
+        rval_keys = []
+        for key, value in rval.items():
+            if value is not None:
+                rval_keys.append(key)
+        keys.append(rval_keys)
+    key_set = set.intersection(*[set(rval_keys) for rval_keys in keys])
 
     # sum over fval/grad/hess
     result = {
         key: sum(rval[key] for rval in rvals)
-        for key in [FVAL, CHI2, SCHI2, GRAD, HESS, HESSP]
-        if rvals[0].get(key, None) is not None
+        for key in key_set
     }
 
     # extract rdatas and flatten

--- a/pypesto/objective/aggregated.py
+++ b/pypesto/objective/aggregated.py
@@ -122,7 +122,7 @@ def aggregate_results(rvals: Sequence[ResultDict]) -> ResultDict:
     result = {
         key: sum(rval[key] for rval in rvals)
         for key in [FVAL, CHI2, SCHI2, GRAD, HESS, HESSP]
-        if all([rval.get(key, None) is not None for rval in rvals])
+        if all([key in rval for rval in rvals])
     }
 
     # extract rdatas and flatten

--- a/pypesto/objective/aggregated.py
+++ b/pypesto/objective/aggregated.py
@@ -118,20 +118,11 @@ def aggregate_results(rvals: Sequence[ResultDict]) -> ResultDict:
     rvals:
         results to aggregate
     """
-
-    keys = []
-    for rval in rvals:
-        rval_keys = []
-        for key, value in rval.items():
-            if value is not None:
-                rval_keys.append(key)
-        keys.append(rval_keys)
-    key_set = set.intersection(*[set(rval_keys) for rval_keys in keys])
-
-    # sum over fval/grad/hess
+    # sum over fval/grad/hess, if available in all rvals
     result = {
-        key: sum(np.array(rval[key]) for rval in rvals)
-        for key in key_set
+        key: sum(rval[key] for rval in rvals)
+        for key in [FVAL, CHI2, SCHI2, GRAD, HESS, HESSP]
+        if all([rval.get(key, None) is not None for rval in rvals])
     }
 
     # extract rdatas and flatten


### PR DESCRIPTION
Calling an `AmiciObjective` with `sensi-order=(1,)` returns a dictionary with keys `fval, radta, grad`, but a `pypesto.Objective` will just return a dictionary with keys `grad`. So an aggregated objective build by a combination of both will fail if called with `sensi-orders=(1,)`, if the `Amici.Objective` is the first partial objective. This also means the `.get_grad` function will fail and one cannot perfom optimization. 
This can be fixed by taking the intersection of the keys of all results instead of just taking the keys of the first partial objective. 