### PR TITLE
Fix CITATION.cff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,9 @@ jobs:
     - name: Install dependencies
       run: .github/workflows/install_deps.sh doc amici
 
+    - name: Validate CITATION.cff
+      run: pip install cffconvert && cffconvert --validate
+
     - name: Build doc
       timeout-minutes: 5
       run: tox -e doc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,3 +1,4 @@
+message: If you use this software, please cite it using these metadata.
 authors:
    -
       family-names: "Schälte"
@@ -70,6 +71,5 @@ authors:
 title: "pyPESTO - Parameter EStimation TOolbox for python"
 url: "https://github.com/ICB-DCM/pyPESTO"
 doi: 10.5281/zenodo.2553546
-version: 0.2.7
 date-released: 2021-03-08
 cff-version: 1.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -71,5 +71,4 @@ authors:
 title: "pyPESTO - Parameter EStimation TOolbox for python"
 url: "https://github.com/ICB-DCM/pyPESTO"
 doi: 10.5281/zenodo.2553546
-date-released: 2021-03-08
 cff-version: 1.2.0


### PR DESCRIPTION
* Remove `version` attribute which messes up Zenodo metadata if not updated on every release
* Add required `message`
* Auto-validate via GHA