### PR TITLE
Fix waterfall plot limits for non-offsetted log-plots

### DIFF
--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -234,8 +234,10 @@ def waterfall_lowlevel(
     y_min, y_max = ax.get_ylim()
     if scale_y == 'log10':
         if np.log10(y_max) - np.log10(y_min) < 1.0:
-            y_mean = 0.5 * (np.log10(y_min) + np.log10(y_max))
-            ax.set_ylim(10.0 ** (y_mean - 0.5), 10.0 ** (y_mean + 0.5))
+            ax.set_ylim(
+                ax.dataLim.y0 - 0.001 * abs(ax.dataLim.y0),
+                ax.dataLim.y1 + 0.001 * abs(ax.dataLim.y1),
+            )
     else:
         if y_max - y_min < 1.0:
             y_mean = 0.5 * (y_min + y_max)


### PR DESCRIPTION
Turns
![waterfall_tmp_bad](https://user-images.githubusercontent.com/18048784/180641406-2f892574-aa81-4826-ab2c-d1d1d7f29fe3.png)

into

![waterfall_tmp](https://user-images.githubusercontent.com/18048784/180641490-2bd81b0f-dbdc-4be1-80d7-91e7e27f9cb3.png)

