### PR TITLE
Fix pandas deprecation warning

### DIFF
--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -773,7 +773,7 @@ class CsvHistory(History):
                 row[(var, float('nan'))] = np.NaN
 
         self._trace = pd.concat(
-            (self._trace, row),
+            (self._trace, pd.DataFrame(row)),
         )
 
         # save trace to file

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -772,7 +772,9 @@ class CsvHistory(History):
             else:
                 row[(var, float('nan'))] = np.NaN
 
-        self._trace = self._trace.append(row)
+        self._trace = pd.concat(
+            (self._trace, row),
+        )
 
         # save trace to file
         self._save_trace()

--- a/pypesto/objective/history.py
+++ b/pypesto/objective/history.py
@@ -773,7 +773,7 @@ class CsvHistory(History):
                 row[(var, float('nan'))] = np.NaN
 
         self._trace = pd.concat(
-            (self._trace, pd.DataFrame(row)),
+            (self._trace, pd.DataFrame([row])),
         )
 
         # save trace to file


### PR DESCRIPTION
Fixes
```
test/base/test_history.py: 229 warnings
  /home/runner/work/pyPESTO/pyPESTO/pypesto/objective/history.py:775: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
    self._trace = self._trace.append(row)
```