### PR TITLE
Improve hdf5 history file lock

### DIFF
--- a/pypesto/C.py
+++ b/pypesto/C.py
@@ -28,6 +28,7 @@ N_GRAD = 'n_grad'  # number of gradient evaluations
 N_HESS = 'n_hess'  # number of Hessian evaluations
 N_RES = 'n_res'  # number of residual evaluations
 N_SRES = 'n_sres'  # number of residual sensitivity evaluations
+START_TIME = 'start_time'  # start time
 X = 'x'
 X0 = 'x0'
 ID = 'id'

--- a/pypesto/history/hdf5.py
+++ b/pypesto/history/hdf5.py
@@ -35,6 +35,29 @@ from .options import HistoryOptions
 from .util import MaybeArray, ResultDict, trace_wrap
 
 
+def with_h5_file(mode: str):
+    """Wrap function to work with hdf5 file.
+
+    Parameters
+    ----------
+    mode:
+        Access mode, see
+        https://docs.h5py.org/en/stable/high/file.html.
+    """
+
+    def decorator(fun):
+        def wrapper(self, *args, **kwargs):
+            with h5py.File(self.file, mode) as f:
+                self._f = f
+                ret = fun(self, *args, **kwargs)
+                self._f = None
+                return ret
+
+        return wrapper
+
+    return decorator
+
+
 class Hdf5History(HistoryBase):
     """
     Stores a representation of the history in an HDF5 file.
@@ -56,8 +79,15 @@ class Hdf5History(HistoryBase):
         self.id: str = id
         self.file: str = file
         self._start_time: float = time.time()
-        self.editable: bool = self._is_editable(file)
+
+        # check whether the file can be edited
+        self.editable: bool = self._editable()
+
+        # generate group for id
         self._generate_hdf5_group()
+
+        # filled during file access
+        self._f: Union[h5py.File, None] = None
 
     def update(
         self,
@@ -67,28 +97,30 @@ class Hdf5History(HistoryBase):
         result: ResultDict,
     ) -> None:
         """See `History` docstring."""
+        # check whether the file was marked as editable upon initialization
         if not self.editable:
             raise ValueError(
-                f'ID "{self.id}" is already used'
-                f' in history file "{self.file}".'
+                f'ID "{self.id}" is already used in history file '
+                f'"{self.file}".'
             )
         super().update(x, sensi_orders, mode, result)
         self._update_counts(sensi_orders, mode)
         self._update_trace(x, sensi_orders, mode, result)
 
+    @with_h5_file("a")
     def finalize(self, message: str = None, exitflag: str = None) -> None:
         """See `HistoryBase` docstring."""
         super().finalize()
 
         # add message and exitflag to trace
-        with h5py.File(self.file, 'a') as f:
-            if f'{HISTORY}/{self.id}/{MESSAGES}/' not in f:
-                f.create_group(f'{HISTORY}/{self.id}/{MESSAGES}/')
-            grp = f[f'{HISTORY}/{self.id}/{MESSAGES}/']
-            if message is not None:
-                grp.attrs[MESSAGE] = message
-            if exitflag is not None:
-                grp.attrs[EXITFLAG] = exitflag
+        f = self._f
+        if f'{HISTORY}/{self.id}/{MESSAGES}/' not in f:
+            f.create_group(f'{HISTORY}/{self.id}/{MESSAGES}/')
+        grp = f[f'{HISTORY}/{self.id}/{MESSAGES}/']
+        if message is not None:
+            grp.attrs[MESSAGE] = message
+        if exitflag is not None:
+            grp.attrs[EXITFLAG] = exitflag
 
     @staticmethod
     def load(
@@ -133,63 +165,64 @@ class Hdf5History(HistoryBase):
 
         return False
 
+    @with_h5_file("a")
     def _update_counts(self, sensi_orders: Tuple[int, ...], mode: ModeType):
         """Update the counters in the hdf5."""
-        with h5py.File(self.file, 'a') as f:
+        f = self._f
 
-            if mode == MODE_FUN:
-                if 0 in sensi_orders:
-                    f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_FVAL] += 1
-                if 1 in sensi_orders:
-                    f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_GRAD] += 1
-                if 2 in sensi_orders:
-                    f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_HESS] += 1
-            elif mode == MODE_RES:
-                if 0 in sensi_orders:
-                    f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_RES] += 1
-                if 1 in sensi_orders:
-                    f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_SRES] += 1
+        if mode == MODE_FUN:
+            if 0 in sensi_orders:
+                f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_FVAL] += 1
+            if 1 in sensi_orders:
+                f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_GRAD] += 1
+            if 2 in sensi_orders:
+                f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_HESS] += 1
+        elif mode == MODE_RES:
+            if 0 in sensi_orders:
+                f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_RES] += 1
+            if 1 in sensi_orders:
+                f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_SRES] += 1
 
+    @with_h5_file("r")
     def __len__(self) -> int:
         """Define length of history object."""
-        with h5py.File(self.file, 'r') as f:
-            return f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_ITERATIONS]
+        return self._f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_ITERATIONS]
 
     @property
+    @with_h5_file("r")
     def n_fval(self) -> int:
         """See `HistoryBase` docstring."""
-        with h5py.File(self.file, 'r') as f:
-            return f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_FVAL]
+        return self._f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_FVAL]
 
     @property
+    @with_h5_file("r")
     def n_grad(self) -> int:
         """See `HistoryBase` docstring."""
-        with h5py.File(self.file, 'r') as f:
-            return f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_GRAD]
+        return self._f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_GRAD]
 
     @property
+    @with_h5_file("r")
     def n_hess(self) -> int:
         """See `HistoryBase` docstring."""
-        with h5py.File(self.file, 'r') as f:
-            return f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_HESS]
+        return self._f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_HESS]
 
     @property
+    @with_h5_file("r")
     def n_res(self) -> int:
         """See `HistoryBase` docstring."""
-        with h5py.File(self.file, 'r') as f:
-            return f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_RES]
+        return self._f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_RES]
 
     @property
+    @with_h5_file("r")
     def n_sres(self) -> int:
         """See `HistoryBase` docstring."""
-        with h5py.File(self.file, 'r') as f:
-            return f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_SRES]
+        return self._f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_SRES]
 
     @property
+    @with_h5_file("r")
     def trace_save_iter(self) -> int:
         """After how many iterations to store the trace."""
-        with h5py.File(self.file, 'r') as f:
-            return f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[TRACE_SAVE_ITER]
+        return self._f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[TRACE_SAVE_ITER]
 
     @property
     def start_time(self) -> float:
@@ -198,23 +231,24 @@ class Hdf5History(HistoryBase):
         return self._start_time
 
     @property
+    @with_h5_file("r")
     def message(self) -> str:
         """Optimizer message in case of finished optimization."""
-        with h5py.File(self.file, 'r') as f:
-            try:
-                return f[f'{HISTORY}/{self.id}/{MESSAGES}/'].attrs[MESSAGE]
-            except KeyError:
-                return None
+        try:
+            return self._f[f'{HISTORY}/{self.id}/{MESSAGES}/'].attrs[MESSAGE]
+        except KeyError:
+            return None
 
     @property
+    @with_h5_file("r")
     def exitflag(self) -> str:
         """Optimizer exitflag in case of finished optimization."""
-        with h5py.File(self.file, 'r') as f:
-            try:
-                return f[f'{HISTORY}/{self.id}/{MESSAGES}/'].attrs[EXITFLAG]
-            except KeyError:
-                return None
+        try:
+            return self._f[f'{HISTORY}/{self.id}/{MESSAGES}/'].attrs[EXITFLAG]
+        except KeyError:
+            return None
 
+    @with_h5_file("a")
     def _update_trace(
         self,
         x: np.ndarray,
@@ -244,35 +278,35 @@ class Hdf5History(HistoryBase):
             TIME: used_time,
         }
 
-        with h5py.File(self.file, 'a') as f:
-            iteration = f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_ITERATIONS]
+        f = self._f
+        iteration = f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_ITERATIONS]
 
-            for key in values.keys():
-                if values[key] is not None:
-                    f[
-                        f'{HISTORY}/{self.id}/{TRACE}/{iteration}/{key}'
-                    ] = values[key]
+        for key in values.keys():
+            if values[key] is not None:
+                f[f'{HISTORY}/{self.id}/{TRACE}/{iteration}/{key}'] = values[
+                    key
+                ]
 
-            f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_ITERATIONS] += 1
+        f[f'{HISTORY}/{self.id}/{TRACE}/'].attrs[N_ITERATIONS] += 1
 
-    def _generate_hdf5_group(self, f: h5py.File = None) -> None:
+    @with_h5_file("a")
+    def _generate_hdf5_group(self) -> None:
         """Generate group in the hdf5 file, if it does not exist yet."""
-        try:
-            with h5py.File(self.file, 'a') as f:
-                if f'{HISTORY}/{self.id}/{TRACE}/' not in f:
-                    grp = f.create_group(f'{HISTORY}/{self.id}/{TRACE}/')
-                    grp.attrs[N_ITERATIONS] = 0
-                    grp.attrs[N_FVAL] = 0
-                    grp.attrs[N_GRAD] = 0
-                    grp.attrs[N_HESS] = 0
-                    grp.attrs[N_RES] = 0
-                    grp.attrs[N_SRES] = 0
-                    # TODO Y it makes no sense to save this here
-                    #  Also, we do not seem to evaluate this at all
-                    grp.attrs[TRACE_SAVE_ITER] = self.options.trace_save_iter
-        except OSError:
-            pass
+        if f'{HISTORY}/{self.id}/{TRACE}/' in self._f:
+            return
 
+        grp = self._f.create_group(f'{HISTORY}/{self.id}/{TRACE}/')
+        grp.attrs[N_ITERATIONS] = 0
+        grp.attrs[N_FVAL] = 0
+        grp.attrs[N_GRAD] = 0
+        grp.attrs[N_HESS] = 0
+        grp.attrs[N_RES] = 0
+        grp.attrs[N_SRES] = 0
+        # TODO Y it makes no sense to save this here
+        #  Also, we do not seem to evaluate this at all
+        grp.attrs[TRACE_SAVE_ITER] = self.options.trace_save_iter
+
+    @with_h5_file("r")
     def _get_hdf5_entries(
         self,
         entry_id: str,
@@ -297,19 +331,18 @@ class Hdf5History(HistoryBase):
             ix = range(len(self))
         trace_result = []
 
-        with h5py.File(self.file, 'r') as f:
-            for iteration in ix:
-                try:
-                    dataset = f[
-                        f'{HISTORY}/{self.id}/{TRACE}/{iteration}/{entry_id}'
-                    ]
-                    if dataset.shape == ():
-                        entry = dataset[()]  # scalar
-                    else:
-                        entry = np.array(dataset)
-                    trace_result.append(entry)
-                except KeyError:
-                    trace_result.append(None)
+        for iteration in ix:
+            try:
+                dataset = self._f[
+                    f'{HISTORY}/{self.id}/{TRACE}/{iteration}/{entry_id}'
+                ]
+                if dataset.shape == ():
+                    entry = dataset[()]  # scalar
+                else:
+                    entry = np.array(dataset)
+                trace_result.append(entry)
+            except KeyError:
+                trace_result.append(None)
 
         return trace_result
 
@@ -362,7 +395,8 @@ class Hdf5History(HistoryBase):
         """See `HistoryBase` docstring."""
         return self._get_hdf5_entries(TIME, ix)
 
-    def _is_editable(self, file: str) -> bool:
+    @with_h5_file("a")
+    def _editable(self) -> None:
         """
         Check whether the id is already existent in the file.
 
@@ -373,14 +407,11 @@ class Hdf5History(HistoryBase):
 
         Returns
         -------
-        editable:
-            Boolean, whether this hdf5 file should be editable.
-            Returns true if the file or the id entry does not exist yet.
+        True if the file is editable, False otherwise.
         """
-        try:
-            with h5py.File(file, 'a') as f:
-                # editable if the id entry does not exist
-                return 'history' not in f.keys() or self.id not in f['history']
-        except OSError:
-            # editable if the file does not exist
+        # editable if the id entry does not exist
+        f = self._f
+        if HISTORY not in f.keys() or self.id not in f[HISTORY]:
             return True
+
+        return False

--- a/pypesto/optimize/load.py
+++ b/pypesto/optimize/load.py
@@ -236,17 +236,21 @@ def optimization_result_from_history(
     """
     result = Result()
     with h5py.File(filename, 'r') as f:
-        for id_name in f[HISTORY].keys():
-            history = Hdf5History(id=id_name, file=filename)
-            history.recover_options(filename)
-            optimizer_history = OptimizerHistory(
-                history=history,
-                x0=f[f'{HISTORY}/{id_name}/{TRACE}/0/{X}'][()],
-                lb=problem.lb,
-                ub=problem.ub,
-                generate_from_history=True,
-            )
-            optimizer_result = OptimizerResult(id=id_name)
-            fill_result_from_history(optimizer_result, optimizer_history)
-            result.optimize_result.append(optimizer_result)
+        ids = list(f[HISTORY].keys())
+        x0s = [f[f'{HISTORY}/{id}/{TRACE}/0/{X}'][()] for id in ids]
+
+    for id, x0 in zip(ids, x0s):
+        history = Hdf5History(id=id, file=filename)
+        history.recover_options(filename)
+        optimizer_history = OptimizerHistory(
+            history=history,
+            x0=x0,
+            lb=problem.lb,
+            ub=problem.ub,
+            generate_from_history=True,
+        )
+        optimizer_result = OptimizerResult(id=id)
+        fill_result_from_history(optimizer_result, optimizer_history)
+        result.optimize_result.append(optimizer_result)
+
     return result


### PR DESCRIPTION
* Avoid claustrophobia from "with" contexts
* Add field for start_time in hdf5 attributes
* Remove broad OSError catches from initial check functions, as these may hide issues.