### PR TITLE
Fix flaky test CRFunModeHistoryTest.test_trace_all

### DIFF
--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -209,10 +209,8 @@ class HistoryTest(unittest.TestCase):
                     assert reconst_trace[iteration] is None
                 if np.isnan(original_trace[iteration]).all():
                     assert np.isnan(reconst_trace[iteration]).all()
-                np.testing.assert_array_almost_equal(
-                    reconst_trace[iteration],
-                    original_trace[iteration],
-                    decimal=10,
+                np.testing.assert_array_almost_equal_nulp(
+                    reconst_trace[iteration], original_trace[iteration], nulp=2
                 )
 
     def check_history_consistency(self, start: pypesto.OptimizerResult):

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -209,8 +209,11 @@ class HistoryTest(unittest.TestCase):
                     assert reconst_trace[iteration] is None
                 if np.isnan(original_trace[iteration]).all():
                     assert np.isnan(reconst_trace[iteration]).all()
-                np.testing.assert_array_almost_equal_nulp(
-                    reconst_trace[iteration], original_trace[iteration], nulp=2
+                np.testing.assert_allclose(
+                    reconst_trace[iteration],
+                    original_trace[iteration],
+                    rtol=1e-14,
+                    atol=1e-14,
                 )
 
     def check_history_consistency(self, start: pypesto.OptimizerResult):


### PR DESCRIPTION
The previous check did not handle large values too well. Failed here: https://github.com/ICB-DCM/pyPESTO/runs/7724332758?check_suite_focus=true