### PR TITLE
Allow problem=None in read_result_from_file

### DIFF
--- a/pypesto/optimize/load.py
+++ b/pypesto/optimize/load.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Union
+from typing import Optional
 
 import h5py
 import numpy as np
@@ -115,7 +115,7 @@ def fill_result_from_history(
 
 
 def read_result_from_file(
-    problem: Union[Problem, None],
+    problem: Optional[Problem],
     history_options: HistoryOptions,
     identifier: str,
 ) -> OptimizerResult:

--- a/pypesto/optimize/load.py
+++ b/pypesto/optimize/load.py
@@ -125,7 +125,8 @@ def read_result_from_file(
     ----------
     problem:
         The problem to find optimal parameters for.
-        If ``None``, bounds will be set to [-inf, inf].
+        If ``None``, bounds will be assumed to be [-inf, inf] for checking for
+        admissible points.
     identifier:
         Multistart id.
     history_options:


### PR DESCRIPTION
Allows loading some result without having the corresponding `Problem` around.