### PR TITLE
Remove benchmark-models-petab requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -149,7 +149,6 @@ test =
     autograd >= 1.3
 test_petab =
     petabtests >= 0.0.0a6
-    benchmark-models-petab @ git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python
 
 [bdist_wheel]
 # Requires Python 3

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ description =
 
 [testenv:base]
 extras = test,test_petab,amici,petab,emcee,mltools,aesara,pymc
+deps =
+    git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/base \
@@ -60,6 +62,8 @@ description =
 
 [testenv:petab]
 extras = test,test_petab,amici,petab,pyswarm
+deps =
+    git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python
 commands =
     # install pysb
     pip install \


### PR DESCRIPTION
Packages that require packages from GitHub cannot be uploaded to PyPI, therefore install benchmark-models-petab, which is only required for testing, via tox.