### PR TITLE
Fix license_file SetuptoolsDeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ maintainer_email = yannik.schaelte@gmail.com,jakob.vanhoefer@uni-bonn.de,paul.jo
 
 # License information
 license = BSD-3-Clause
-license_file = LICENSE
+license_files = LICENSE
 
 # Search tags
 classifiers =


### PR DESCRIPTION
Fixes
```
pyPESTO/.tox/project/lib/python3.9/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
```

Usage is deprecated as of setuptools v56.0.0 https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v5600