### PR TITLE
Fix pymc>=5 aesara/pytensor issues

### DIFF
--- a/pypesto/sample/pymc.py
+++ b/pypesto/sample/pymc.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import logging
 from typing import Union
 
-import aesara.tensor as at
 import arviz as az
 import numpy as np
 import pymc
+import pytensor.tensor as pt
 
 from ..history import MemoryHistory
 from ..objective import ObjectiveBase
@@ -21,11 +21,11 @@ logger = logging.getLogger(__name__)
 # https://www.pymc.io/projects/examples/en/latest/case_studies/blackbox_external_likelihood_numpy.html
 
 
-class PymcObjectiveOp(at.Op):
-    """Aesara wrapper around a (non-normalized) log-probability function."""
+class PymcObjectiveOp(pt.Op):
+    """PyTensor wrapper around a (non-normalized) log-probability function."""
 
-    itypes = [at.dvector]  # expects a vector of parameter values when called
-    otypes = [at.dscalar]  # outputs a single scalar value (the log prob)
+    itypes = [pt.dvector]  # expects a vector of parameter values when called
+    otypes = [pt.dscalar]  # outputs a single scalar value (the log prob)
 
     def create_instance(objective: ObjectiveBase, beta: float = 1.0):
         """Create an instance of this Op (factory method).
@@ -58,7 +58,7 @@ class PymcObjectiveOp(at.Op):
 
 
 class PymcObjectiveWithGradientOp(PymcObjectiveOp):
-    """Aesara objective wrapper with gradient."""
+    """PyTensor objective wrapper with gradient."""
 
     def __init__(self, objective: ObjectiveBase, beta: float = 1.0):
         super().__init__(objective, beta)
@@ -73,11 +73,11 @@ class PymcObjectiveWithGradientOp(PymcObjectiveOp):
         return [g[0] * self._log_prob_grad(theta)]
 
 
-class PymcGradientOp(at.Op):
-    """Aesara wrapper around a (non-normalized) log-probability gradient."""
+class PymcGradientOp(pt.Op):
+    """PyTensor wrapper around a (non-normalized) log-probability gradient."""
 
-    itypes = [at.dvector]  # expects a vector of parameter values when called
-    otypes = [at.dvector]  # outputs a vector (the log prob grad)
+    itypes = [pt.dvector]  # expects a vector of parameter values when called
+    otypes = [pt.dvector]  # outputs a vector (the log prob grad)
 
     def __init__(self, objective: ObjectiveBase, beta: float):
         self._objective: ObjectiveBase = objective
@@ -190,8 +190,8 @@ class PymcSampler(Sampler):
                 )
             ]
 
-            # convert parameters to aesara tensor variable
-            theta = at.as_tensor_variable(_k)
+            # convert parameters to PyTensor tensor variable
+            theta = pt.as_tensor_variable(_k)
 
             # define distribution with log-posterior as density
             pymc.Potential("potential", log_post(theta))


### PR DESCRIPTION
pymc switched graph backend from aesara to pytensor (https://github.com/pymc-devs/pymc/releases/tag/v5.0.0), so we need to adapt.

Fixes #982

Note: If have no idea where `pypesto/objective/aesara` is used and whether that should also change to pytensor