### PR TITLE
Fix use of indices in waterfall plot

### DIFF
--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -241,7 +241,7 @@ def waterfall_lowlevel(
         # parse data for plotting
         color = colors[start_indices.index(j)]
         fval = fvals[start_indices.index(j)]
-        if j == 0:
+        if j == start_indices[0]:
             tmp_legend = legend_text
         else:
             tmp_legend = None

--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -222,7 +222,7 @@ def waterfall_lowlevel(
 
     start_indices = [i for i, fval in enumerate(fvals) if fval is not None]
     fvals = [fvals[i] for i in start_indices]
-    if colors.ndim == 2 and colors.shape[0] > 1:
+    if colors is not None and colors.ndim == 2 and colors.shape[0] > 1:
         colors = [colors[i] for i in start_indices]
 
     # assign colors

--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -222,6 +222,8 @@ def waterfall_lowlevel(
 
     start_indices = [i for i, fval in enumerate(fvals) if fval is not None]
     fvals = [fvals[i] for i in start_indices]
+    if colors.ndim == 2 and colors.shape[0] > 1:
+        colors = [colors[i] for i in start_indices]
 
     # assign colors
     colors = assign_colors(fvals, colors=colors)
@@ -237,8 +239,8 @@ def waterfall_lowlevel(
     # plot points
     for j in start_indices:
         # parse data for plotting
-        color = colors[j]
-        fval = fvals[j]
+        color = colors[start_indices.index(j)]
+        fval = fvals[start_indices.index(j)]
         if j == 0:
             tmp_legend = legend_text
         else:


### PR DESCRIPTION
The values in `start_indices` correspond to the indexing of the original `fvals`, not the `fvals` with `None` removed.