### PR TITLE
RTD: Remove alternative build formats

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,8 +26,3 @@ build:
     - swig
   tools:
     python: "3.10"
-
-# what to build
-formats:
-  - htmlzip
-  - pdf


### PR DESCRIPTION
 bc likely nobody uses those

Also to fix error "Build output directory for format "pdf" contains multiple files and it is not currently supported. Please, remove all the files but the "pdf" your want to upload."