### PR TITLE
Refactor docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 
 #documentation
 doc/_build
+doc/api
 
 # data
 data/raw

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,24 +1,27 @@
 API reference
 =============
 
-.. automodule:: pypesto.engine
-.. automodule:: pypesto.ensemble
-.. automodule:: pypesto.hierarchical
-.. automodule:: pypesto.hierarchical.optimal_scaling
-.. automodule:: pypesto.hierarchical.spline_approximation
-.. automodule:: pypesto.history
-.. automodule:: pypesto.logging
-.. automodule:: pypesto.objective
-.. automodule:: pypesto.objective.julia
-.. automodule:: pypesto.optimize
-.. automodule:: pypesto.petab
-.. automodule:: pypesto.predict
-.. automodule:: pypesto.problem
-.. automodule:: pypesto.profile
-.. automodule:: pypesto.result
-.. automodule:: pypesto.sample
-.. automodule:: pypesto.select
-.. automodule:: pypesto.startpoint
-.. automodule:: pypesto.store
-.. automodule:: pypesto.visualize
-.. automodule:: pypesto.visualize.model_fit
+.. autosummary::
+   :toctree: api
+
+   pypesto.engine
+   pypesto.ensemble
+   pypesto.hierarchical
+   pypesto.hierarchical.optimal_scaling
+   pypesto.hierarchical.spline_approximation
+   pypesto.history
+   pypesto.logging
+   pypesto.objective
+   pypesto.objective.julia
+   pypesto.optimize
+   pypesto.petab
+   pypesto.predict
+   pypesto.problem
+   pypesto.profile
+   pypesto.result
+   pypesto.sample
+   pypesto.select
+   pypesto.startpoint
+   pypesto.store
+   pypesto.visualize
+   pypesto.visualize.model_fit

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -2,24 +2,24 @@ Authors
 =======
 
 
-This package is mainly developed by:
+This package was mainly developed by:
 
 - Yannik Schälte
-- Jakob Vanhoefer
 - Fabian Fröhlich
-- Paul Stapor
-
-with major contributions by:
-
-- Dantong Wang
-- Daniel Weindl
-- Polina Lakrisenko
-- Elba Raimúndez
-- Leonard Schmiester
-- Dilan Pathirana
 - Paul Jonas Jost
-- Lorenzo Contento
-- Erika Dudkin
+- Jakob Vanhoefer
+
+with major contributions by (status 2023):
+
+- Daniel Weindl
+- Dilan Pathirana
+- Paul Stapor
+- Polina Lakrisenko
+- Dantong Wang
+- Elba Raimúndez
 - Simon Merkt
-- Carolin Loos
+- Leonard Schmiester
 - Philipp Städter
+- Stephan Grein
+- Erika Dudkin
+- Domagoj Doresic

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,12 +36,16 @@ extensions = [
     'sphinx.ext.autodoc',
     # generate autodoc summaries
     'sphinx.ext.autosummary',
+    # use mathjax for latex formulas
+    'sphinx.ext.mathjax',
     # link to code
     'sphinx.ext.viewcode',
     # link to other projects' docs
     'sphinx.ext.intersphinx',
     # support numpy and google style docstrings
     'sphinx.ext.napoleon',
+    # support todo items
+    'sphinx.ext.todo',
     # source parser for jupyter notebook files
     'nbsphinx',
     # code highlighting in jupyter cells
@@ -157,7 +161,15 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'collapse_navigation': False,
+    'navigation_depth': -1,
+}
+
+# Title
+html_title = "pyPESTO documentation"
+# Navigation bar title
+html_short_title = "pyPESTO"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -166,19 +178,6 @@ html_static_path = ['_static']
 
 # Favicon
 html_favicon = "logo/logo_favicon.png"
-
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-#
-# This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-    ]
-}
-
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -1,3 +1,5 @@
+.. _example:
+
 Examples
 ========
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,7 +137,7 @@ doc =
     sphinx >= 5.1.0
     nbsphinx >= 0.8.9
     nbconvert >= 6.5.0
-    sphinx-rtd-theme >= 1.0.0
+    sphinx-rtd-theme == 1.0.0
     sphinx-autodoc-typehints >= 1.18.3
     sphinxcontrib-bibtex >= 2.5.0
     ipython >= 8.4.0


### PR DESCRIPTION
* Add [+] expand buttons
* Use `autosummary` for a visual overview, and avoiding full expansion of all sub-modules
* Temporarily fixate `sphinx-rtd-theme == 1.1.0` as expansion stops working in 1.2.0