### PR TITLE
Use cloudpickle for pickling dynesty sampler

### DIFF
--- a/pypesto/sample/dynesty.py
+++ b/pypesto/sample/dynesty.py
@@ -307,9 +307,9 @@ def get_mcmc_like_dynesty_samples(sampler) -> McmcPtResult:
 def setup_dynesty() -> None:
     """Import dynesty."""
     try:
-        import dill  # noqa: S403
+        import cloudpickle  # noqa: S403
         import dynesty.utils
 
-        dynesty.utils.pickle_module = dill
+        dynesty.utils.pickle_module = cloudpickle
     except ImportError:
         raise SamplerImportError("dynesty")

--- a/setup.cfg
+++ b/setup.cfg
@@ -123,7 +123,6 @@ jax =
 emcee =
     emcee >= 3.0.2
 dynesty =
-    dill >= 0.3.6
     dynesty >= 2.0.3
 mltools =
     umap-learn[plot] >= 0.5.3


### PR DESCRIPTION
Cloudpickle handles ABC-derived classes properly, whereas the latest dill version on pypi (0.3.6) does not (#1093).

Cloudpickle is already installed with pypesto, so there seems to be no need to get dill on top.