### PR TITLE
Small censoring initialize fix

### DIFF
--- a/pypesto/hierarchical/optimal_scaling/parameter.py
+++ b/pypesto/hierarchical/optimal_scaling/parameter.py
@@ -88,4 +88,5 @@ class OptimalScalingParameter(InnerParameter):
 
     def initialize(self):
         """Initialize."""
-        self.value = self.dummy_value
+        if self.censoring_type is None:
+            self.value = self.dummy_value


### PR DESCRIPTION
Censoring bounds should not be reinitialized when calculators are reinitialized.