### PR TITLE
Hierarchical parameter plot fix

### DIFF
--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -272,19 +272,23 @@ def get_parameter_prior_dict(
                 + np.exp(x_log) * dd_log_f_ddx(np.exp(x_log))
             )
 
-        res_log = None
         if res is not None:
 
             def res_log(x_log):
                 """Residual-prior for log-parameters."""
                 return res(np.exp(x_log))
 
-        d_res_log = None
+        else:
+            res_log = None
+
         if d_res_dx is not None:
 
             def d_res_log(x_log):
                 """Residual-prior for log-parameters."""
                 return d_res_dx(np.exp(x_log)) * np.exp(x_log)
+
+        else:
+            d_res_log = None
 
         return {
             'index': index,

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -381,11 +381,10 @@ def handle_inputs(
         res.get(INNER_PARAMETERS, None) for res in result.optimize_result.list
     ]
     if any(inner_xs):
-        inner_xs_names = next(
-            list(inner_xs_idx.keys())
-            for inner_xs_idx in inner_xs
-            if inner_xs_idx is not None
-        )
+        for inner_xs_idx in inner_xs:
+            if inner_xs_idx is not None:
+                inner_xs_names = list(inner_xs_idx.keys())
+                break
         inner_xs = [
             [np.nan for i in range(len(inner_xs_names))]
             if inner_xs_idx is None

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -381,10 +381,12 @@ def handle_inputs(
         res.get(INNER_PARAMETERS, None) for res in result.optimize_result.list
     ]
     if any(inner_xs):
+        # search for first non-empty inner_xs to obtain inner_xs_names
         for inner_xs_idx in inner_xs:
             if inner_xs_idx is not None:
                 inner_xs_names = list(inner_xs_idx.keys())
                 break
+        # fill inner_xs with nan if no inner_xs are available
         inner_xs = [
             np.full(len(inner_xs_names), np.nan)
             if inner_xs_idx is None

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -386,7 +386,7 @@ def handle_inputs(
                 inner_xs_names = list(inner_xs_idx.keys())
                 break
         inner_xs = [
-            [np.nan for i in range(len(inner_xs_names))]
+            np.full(len(inner_xs_names), np.nan)
             if inner_xs_idx is None
             else list(inner_xs_idx.values())
             for inner_xs_idx in inner_xs

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -393,6 +393,7 @@ def handle_inputs(
             else list(inner_xs_idx.values())
             for inner_xs_idx in inner_xs
         ]
+        # set bounds for inner parameters
         inner_lb = np.full(len(inner_xs_names), -np.inf)
         inner_ub = np.full(len(inner_xs_names), np.inf)
     else:


### PR DESCRIPTION
The issue was that the parameter plot was not showing hierarchical parameters in some cases.

If, in any case (because some inner optimization failed, simulation failed, or some other reason) there is an `optimize_result`dictionary in `result.optmize_result.list` which doesn't contain the `INNER_PARAMETERS` key and its item, the parameter plot would fail at line [381](https://github.com/ICB-DCM/pyPESTO/blob/9a754573a7b77d30d5dc1f67a8dc1be6c29f1640/pypesto/visualize/parameters.py#L381). 

This is a fix to make it robust to this. If any of the `optimize_result` objects have an `INNER_PARAMETER` key, then the other ones will be filled with NaN values and plotted. 