### PR TITLE
Fix #1108

### DIFF
--- a/pypesto/visualize/misc.py
+++ b/pypesto/visualize/misc.py
@@ -186,7 +186,7 @@ def process_y_limits(ax, y_limits):
                 )
 
             # set limits
-            ax.set_ylim(y_limits)
+        ax.set_ylim(y_limits)
 
     else:
         # No limits passed, but if we have a result list: check the limits

--- a/pypesto/visualize/misc.py
+++ b/pypesto/visualize/misc.py
@@ -185,7 +185,7 @@ def process_y_limits(ax, y_limits):
                     "log-scale. Using only upper bound."
                 )
 
-            # set limits
+        # set limits
         ax.set_ylim(y_limits)
 
     else:

--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -169,7 +169,7 @@ def waterfall(
     ax = handle_options(ax, max_len_fvals, refs, y_limits, offset_y)
     if inset_axes is not None:
         inset_axes = handle_options(
-            inset_axes, n_starts_to_zoom, refs, y_limits, offset_y
+            inset_axes, n_starts_to_zoom, refs, None, offset_y
         )
 
     if any(legends):


### PR DESCRIPTION
- enable setting the y limits of a waterfall plot by using the `y_limits` argument
- use default y limits for zoomed in starts
- fix #1108 