### PR TITLE
Other platform tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-mac
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-windows
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,11 @@ jobs:
 
     - name: Install dependencies
       run: |
+        pip install --upgrade pip
         pip install tox
 
     - name: Run tests
+      shell: bash
       timeout-minutes: 10
       run: tox -e windows
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,6 @@ jobs:
       timeout-minutes: 10
       run: tox -e windows
 
-    - name: Coverage
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-
   petab:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # update to 3.11 when numba allows (needed in umap)
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.11']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-mac
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-windows
-
     - name: Install dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # update to 3.11 when numba allows (needed in umap)
         python-version: ['3.9', '3.11']
 
     steps:
@@ -52,8 +51,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # update to 3.11 when numba allows (needed in umap)
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository
@@ -74,8 +72,43 @@ jobs:
       run: .github/workflows/install_deps.sh amici
 
     - name: Run tests
-      timeout-minutes: 25
+      timeout-minutes: 30
       run: tox -e base
+
+    - name: Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Prepare python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-mac
+
+    - name: Install dependencies
+      run: |
+        pip install tox
+
+    - name: Run tests
+      timeout-minutes: 10
+      run: tox -e windows
 
     - name: Coverage
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,41 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
 
+  mac:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # update to 3.11 when numba allows (needed in umap)
+        python-version: ['3.10']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Prepare python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache
+        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-mac
+
+    - name: Install dependencies
+      run: .github/workflows/install_deps.sh amici
+
+    - name: Run tests
+      timeout-minutes: 25
+      run: tox -e base
+
+    - name: Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+
   petab:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -9,8 +9,14 @@ pip install wheel setuptools
 # Used to create local test environments
 pip install tox
 
-# Update apt
-sudo apt-get update
+# Update package lists
+if [ "$(uname)" == "Darwin" ]; then
+  # MacOS
+  brew update
+else
+  # Linux
+  sudo apt-get update
+fi
 
 # Check arguments
 for par in "$@"; do
@@ -22,8 +28,12 @@ for par in "$@"; do
 
     amici)
       # for amici
-      sudo apt-get install \
-        swig libatlas-base-dev libhdf5-serial-dev
+      if [ "$(uname)" == "Darwin" ]; then
+        brew install swig hdf5 libomp
+      else
+        sudo apt-get install \
+          swig libatlas-base-dev libhdf5-serial-dev
+      fi
     ;;
 
     ipopt)

--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -173,10 +173,17 @@ class SacessOptimizer:
             tmp_result_filename = SacessWorker.get_temp_result_filename(
                 worker_idx
             )
-            tmp_result = read_result(
-                tmp_result_filename, problem=False, optimize=True
-            )
-            os.remove(tmp_result_filename)
+            try:
+                tmp_result = read_result(
+                    tmp_result_filename, problem=False, optimize=True
+                )
+            except FileNotFoundError:
+                # wait and retry, maybe the file wasn't found due to some filesystem latency issues
+                time.sleep(5)
+                tmp_result = read_result(
+                    tmp_result_filename, problem=False, optimize=True
+                )
+
             if result is None:
                 result = tmp_result
             else:
@@ -185,6 +192,13 @@ class SacessOptimizer:
                     sort=False,
                     prefix=f"{worker_idx}-",
                 )
+
+        # delete temporary files only after successful consolidation
+        for filename in map(
+            SacessWorker.get_temp_result_filename, range(self.num_workers)
+        ):
+            os.remove(filename)
+
         result.optimize_result.sort()
 
         result.problem = problem

--- a/test/base/test_workflow.py
+++ b/test/base/test_workflow.py
@@ -1,0 +1,123 @@
+"""Test a basic workflow, with minimum dependencies.
+
+These tests are not for correctness, but for basic functionality.
+"""
+
+import pypesto
+import pypesto.optimize as optimize
+import pypesto.profile as profile
+import pypesto.sample as sample
+import pypesto.visualize as visualize
+
+from ..util import CRProblem
+
+
+def test_objective():
+    """Test a simple objective function."""
+    crproblem = CRProblem()
+    obj = crproblem.get_objective()
+    p = crproblem.p_true
+
+    assert obj(p) == crproblem.get_fnllh()(p)
+    assert obj(p, sensi_orders=(0,)) == crproblem.get_fnllh()(p)
+    assert (obj(p, sensi_orders=(1,)) == crproblem.get_fsnllh()(p)).all()
+    assert (obj(p, sensi_orders=(2,)) == crproblem.get_fs2nllh()(p)).all()
+    fval, grad = obj(p, sensi_orders=(0, 1))
+    assert fval == crproblem.get_fnllh()(p)
+    assert (grad == crproblem.get_fsnllh()(p)).all()
+
+
+def test_optimize():
+    """Test a simple multi-start optimization."""
+    crproblem = CRProblem()
+    problem = pypesto.Problem(
+        objective=crproblem.get_objective(),
+        lb=crproblem.lb,
+        ub=crproblem.ub,
+    )
+    optimizer = optimize.ScipyOptimizer()
+    n_start = 20
+    result = optimize.minimize(
+        problem=problem,
+        optimizer=optimizer,
+        n_starts=n_start,
+    )
+
+    # check basic sanity
+    assert len(result.optimize_result.list) == n_start
+    assert len(result.optimize_result.fval) == n_start
+    assert len(result.optimize_result.x) == n_start
+
+    # check that the results are sorted
+    fvals = result.optimize_result.fval
+    assert fvals == sorted(fvals)
+
+    # check that optimization was successful
+    assert fvals[0] < crproblem.get_fnllh()(crproblem.p_true)
+
+    # visualize the results
+    visualize.waterfall(result)
+
+
+def test_profile():
+    """Test a simple profile calculation."""
+    crproblem = CRProblem()
+    problem = pypesto.Problem(
+        objective=crproblem.get_objective(),
+        lb=crproblem.lb,
+        ub=crproblem.ub,
+    )
+    optimizer = optimize.ScipyOptimizer()
+    n_starts = 5
+    result = optimize.minimize(
+        problem=problem,
+        optimizer=optimizer,
+        n_starts=n_starts,
+    )
+    profile_result = profile.parameter_profile(
+        problem=problem,
+        result=result,
+        optimizer=optimizer,
+        profile_index=[0],
+    )
+
+    # check basic sanity
+    assert len(profile_result.profile_result.list) == 1
+
+    # visualize the results
+    visualize.profiles(profile_result)
+
+
+def test_sample():
+    """Test a simple sampling."""
+    crproblem = CRProblem()
+    problem = pypesto.Problem(
+        objective=crproblem.get_objective(),
+        lb=crproblem.lb,
+        ub=crproblem.ub,
+    )
+    optimizer = optimize.ScipyOptimizer()
+    n_start = 5
+    result = optimize.minimize(
+        problem=problem,
+        optimizer=optimizer,
+        n_starts=n_start,
+    )
+    sampler = sample.AdaptiveMetropolisSampler()
+    n_samples = 500
+    sample_result = sample.sample(
+        problem=problem,
+        result=result,
+        sampler=sampler,
+        n_samples=n_samples,
+    )
+
+    # check basic sanity
+    assert sample_result.sample_result.trace_x.shape == (
+        1,
+        n_samples + 1,
+        len(crproblem.p_true),
+    )
+
+    # visualize the results
+    visualize.sampling_1d_marginals(sample_result)

--- a/test/base/test_workflow.py
+++ b/test/base/test_workflow.py
@@ -3,6 +3,10 @@
 These tests are not for correctness, but for basic functionality.
 """
 
+from functools import wraps
+
+import matplotlib.pyplot as plt
+
 import pypesto
 import pypesto.optimize as optimize
 import pypesto.profile as profile
@@ -10,6 +14,18 @@ import pypesto.sample as sample
 import pypesto.visualize as visualize
 
 from ..util import CRProblem
+
+
+def close_fig(fun):
+    """Close figure."""
+
+    @wraps(fun)
+    def wrapped_fun(*args, **kwargs):
+        ret = fun(*args, **kwargs)
+        plt.close('all')
+        return ret
+
+    return wrapped_fun
 
 
 def test_objective():
@@ -27,6 +43,7 @@ def test_objective():
     assert (grad == crproblem.get_fsnllh()(p)).all()
 
 
+@close_fig
 def test_optimize():
     """Test a simple multi-start optimization."""
     crproblem = CRProblem()
@@ -59,6 +76,7 @@ def test_optimize():
     visualize.waterfall(result)
 
 
+@close_fig
 def test_profile():
     """Test a simple profile calculation."""
     crproblem = CRProblem()
@@ -88,6 +106,7 @@ def test_profile():
     visualize.profiles(profile_result)
 
 
+@close_fig
 def test_sample():
     """Test a simple sampling."""
     crproblem = CRProblem()

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,16 @@ commands =
 description =
     Test basic functionality
 
+[testenv:windows]
+extrast = test,emcee,dynesty,mltools,aesara,pymc,jax
+commands =
+    pytest --cov=pypesto --cov-report=xml --cov-append \
+        test/base/test_objective.py \
+        test/base/test_problem.py \
+        test/base/test_store.py
+description =
+    Test basic functionality on Windows
+
 [testenv:petab]
 extras = test,amici,petab,pyswarm
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -64,10 +64,8 @@ description =
 [testenv:windows]
 extras = test
 commands =
-    pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/base/test_prior.py \
-        test/base/test_problem.py \
-        test/base/test_x_fixed.py \
+    pytest \
+        test/base/test_prior.py
 description =
     Test basic functionality on Windows
 

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ description =
     Test basic functionality
 
 [testenv:windows]
-extrast = test
+extras = test
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/base/test_logging.py \

--- a/tox.ini
+++ b/tox.ini
@@ -65,8 +65,9 @@ description =
 extras = test
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/base/test_logging.py \
-        test/base/test_prior.py
+        test/base/test_prior.py \
+        test/base/test_problem.py \
+        test/base/test_x_fixed.py \
 description =
     Test basic functionality on Windows
 

--- a/tox.ini
+++ b/tox.ini
@@ -62,12 +62,11 @@ description =
     Test basic functionality
 
 [testenv:windows]
-extrast = test,emcee,dynesty,mltools,aesara,pymc,jax
+extrast = test
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/base/test_objective.py \
-        test/base/test_problem.py \
-        test/base/test_store.py
+        test/base/test_logging.py \
+        test/base/test_prior.py
 description =
     Test basic functionality on Windows
 

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,9 @@ description =
 extras = test
 commands =
     pytest \
-        test/base/test_prior.py
+        test/base/test_prior.py \
+        test/base/test_problem.py \
+        test/base/test_workflow.py
 description =
     Test basic functionality on Windows
 


### PR DESCRIPTION
 * Also run the base test suite on half-eaten apples
 * Provide a very core suite of workflow tests for windows (to be extended if there is user demand; in particular an AMICI set up would require further work)
 
Aside:
* Run tests on Python 3.11 instead 3.10 as numba supports it now