### PR TITLE
fix ensembles from optimization endpoints

### DIFF
--- a/pypesto/ensemble/ensemble.py
+++ b/pypesto/ensemble/ensemble.py
@@ -670,7 +670,7 @@ class Ensemble:
             # did not reach maximum size and the next value is still
             # lower than the cutoff value
             if start['fval'] <= abs_cutoff and len(x_vectors) < max_size:
-                x_vectors.append(start['x'])
+                x_vectors.append(start['x'][result.problem.x_free_indices])
 
                 # the vector tag will be a -1 to indicate it is the last step
                 vector_tags.append((int(start['id']), -1))


### PR DESCRIPTION
If only the names of free parameters are taken https://github.com/ICB-DCM/pyPESTO/blob/main/pypesto/ensemble/ensemble.py#L663, 
then maybe the same should be true for the parameter values