### PR TITLE
Doc: Cross-reference fides options documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,6 +81,7 @@ intersphinx_mapping = {
         None,
     ),
     'amici': ('https://amici.readthedocs.io/en/latest/', None),
+    'fides': ('https://fides-optimizer.readthedocs.io/en/latest/', None),
 }
 
 bibtex_bibfiles = ["using_pypesto.bib"]

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -1215,10 +1215,11 @@ class FidesOptimizer(Optimizer):
         Parameters
         ----------
         options:
-            Optimizer options.
+            Optimizer options. See :meth:`fides.minimize.Optimizer.minimize`
+            and :class:`fides.constants.Options` for details.
         hessian_update:
-            Hessian update strategy. If this is None, a hybrid approximation
-            that switches from the problem.objective provided Hessian (
+            Hessian update strategy. If this is ``None``, a hybrid approximation
+            that switches from the ``problem.objective`` provided Hessian (
             approximation) to a BFGS approximation will be used.
         """
         super().__init__()


### PR DESCRIPTION
Makes it easier to find supported optimizer options...

:eyes: [`https://pypesto--1152.org.readthedocs.build/en/1152/api/pypesto.optimize.html#pypesto.optimize.FidesOptimizer.__init__`](https://pypesto--1152.org.readthedocs.build/en/1152/api/pypesto.optimize.html#pypesto.optimize.FidesOptimizer.__init__)