### PR TITLE
Log traceback in case of exceptions during optimizations

### DIFF
--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -1337,11 +1337,8 @@ class FidesOptimizer(Optimizer):
         try:
             opt.minimize(x0)
             msg = self._convert_exitflag_to_message(opt)
-        except RuntimeError:
-            import sys
-            import traceback
-
-            msg = "\n".join(traceback.format_exception(*sys.exc_info()))
+        except RuntimeError as err:
+            msg = str(err)
 
         optimizer_result = OptimizerResult(
             x=opt.x_min,

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -94,7 +94,12 @@ def history_decorator(minimize):
             )
         except Exception as err:
             if optimize_options.allow_failed_starts:
-                logger.error(f'start {id} failed: {err}')
+                import sys
+                import traceback
+
+                trace = "\n".join(traceback.format_exception(*sys.exc_info()))
+
+                logger.error(f'start {id} failed:\n{trace}')
                 result = OptimizerResult(
                     x0=x0, exitflag=-1, message=str(err), id=id
                 )

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -1337,8 +1337,11 @@ class FidesOptimizer(Optimizer):
         try:
             opt.minimize(x0)
             msg = self._convert_exitflag_to_message(opt)
-        except RuntimeError as err:
-            msg = str(err)
+        except RuntimeError:
+            import sys
+            import traceback
+
+            msg = "\n".join(traceback.format_exception(*sys.exc_info()))
 
         optimizer_result = OptimizerResult(
             x=opt.x_min,


### PR DESCRIPTION
So far, with `minimize(..., OptimizeOptions(allow_failed_starts=True))`
only the exception message was stored/logged, which is not always sufficiently
informative (see #1147).

Now we log the full exception type / message / traceback.

Closes #1147