### PR TITLE
Removed DeprecationWaning of NumPy

### DIFF
--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -18,7 +18,7 @@ from pypesto.sample.pymc import PymcSampler
 
 
 def gaussian_llh(x):
-    return float(norm.logpdf(x))
+    return float(norm.logpdf(x).item())
 
 
 def gaussian_problem():


### PR DESCRIPTION
Warning for example [here](https://github.com/ICB-DCM/pyPESTO/actions/runs/6640996267/job/18042534564#step:6:16261): 
```
test/sample/test_sample.py: 159569 warnings
  /home/runner/work/pyPESTO/pyPESTO/test/sample/test_sample.py:21: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    return float(norm.logpdf(x))
```

As noticeable, it is a warning occurring approx 160.000 times.