### PR TITLE
Fix `HierarchicalAmiciCalculator.__call__` not setting 'hess' in result

### DIFF
--- a/pypesto/hierarchical/calculator.py
+++ b/pypesto/hierarchical/calculator.py
@@ -15,6 +15,7 @@ from ..C import (
     AMICI_SIGMAY,
     AMICI_Y,
     GRAD,
+    HESS,
     INNER_PARAMETERS,
     INNER_RDATAS,
     RDATAS,
@@ -115,9 +116,12 @@ class HierarchicalAmiciCalculator(AmiciCalculator):
         if any(rdata.status != amici.AMICI_SUCCESS for rdata in inner_rdatas):
             # if the gradient was requested, we need to provide some value
             # for it
+            dim = len(x_ids)
             if 1 in sensi_orders:
-                inner_result[GRAD] = np.full(
-                    shape=len(x_ids), fill_value=np.nan
+                inner_result[GRAD] = np.full(shape=dim, fill_value=np.nan)
+            if 2 in sensi_orders:
+                inner_result[HESS] = np.full(
+                    shape=(dim, dim), fill_value=np.nan
                 )
             return inner_result
 


### PR DESCRIPTION
`HierarchicalAmiciCalculator.__call__` needs to set `'hess'` in the returned dict, also in case of simulation failures.

Closes #1160