### PR TITLE
ProfileOptions: add some basic integrity checking

### DIFF
--- a/pypesto/profile/options.py
+++ b/pypesto/profile/options.py
@@ -91,3 +91,24 @@ class ProfileOptions(dict):
             return maybe_options
         options = ProfileOptions(**maybe_options)
         return options
+
+    def validate(self):
+        """Check if options are valid.
+
+        Raise ``ValueError`` if not.
+        """
+        if self.min_step_size <= 0:
+            raise ValueError("min_step_size must be > 0.")
+        if self.max_step_size <= 0:
+            raise ValueError("max_step_size must be > 0.")
+        if self.min_step_size > self.max_step_size:
+            raise ValueError("min_step_size must be <= max_step_size.")
+        if self.default_step_size <= 0:
+            raise ValueError("default_step_size must be > 0.")
+        if self.default_step_size > self.max_step_size:
+            raise ValueError("default_step_size must be <= max_step_size.")
+        if self.default_step_size < self.min_step_size:
+            raise ValueError("default_step_size must be >= min_step_size.")
+
+        if self.magic_factor_obj_value < 0 or self.magic_factor_obj_value >= 1:
+            raise ValueError("magic_factor_obj_value must be >= 0 and < 1.")

--- a/pypesto/profile/options.py
+++ b/pypesto/profile/options.py
@@ -97,7 +97,7 @@ class ProfileOptions(dict):
     def validate(self):
         """Check if options are valid.
 
-        Raise ``ValueError`` if not.
+        Raises ``ValueError`` if current settings aren't valid.
         """
         if self.min_step_size <= 0:
             raise ValueError("min_step_size must be > 0.")

--- a/pypesto/profile/options.py
+++ b/pypesto/profile/options.py
@@ -66,6 +66,8 @@ class ProfileOptions(dict):
         self.magic_factor_obj_value = magic_factor_obj_value
         self.whole_path = whole_path
 
+        self.validate()
+
     def __getattr__(self, key):
         """Allow usage of keys like attributes."""
         try:

--- a/pypesto/profile/profile.py
+++ b/pypesto/profile/profile.py
@@ -89,6 +89,7 @@ def parameter_profile(
     if profile_options is None:
         profile_options = ProfileOptions()
     profile_options = ProfileOptions.create_instance(profile_options)
+    profile_options.validate()
 
     # create a function handle that will be called later to get the next point
     if isinstance(next_guess_method, str):

--- a/test/profile/test_profile.py
+++ b/test/profile/test_profile.py
@@ -7,6 +7,7 @@ import warnings
 from copy import deepcopy
 
 import numpy as np
+import pytest
 from numpy.testing import assert_almost_equal
 
 import pypesto
@@ -412,3 +413,25 @@ def test_approximate_ci():
     # bound value
     assert np.isclose(lb, -3)
     assert np.isclose(ub, 9)
+
+
+def test_options_valid():
+    """Test ProfileOptions validity checks."""
+    # default settings are valid
+    profile.ProfileOptions()
+
+    # try to set invalid values
+    with pytest.raises(ValueError):
+        profile.ProfileOptions(default_step_size=-1)
+    with pytest.raises(ValueError):
+        profile.ProfileOptions(default_step_size=1, min_step_size=2)
+    with pytest.raises(ValueError):
+        profile.ProfileOptions(
+            default_step_size=2,
+            min_step_size=1,
+        )
+    with pytest.raises(ValueError):
+        profile.ProfileOptions(
+            min_step_size=2,
+            max_step_size=1,
+        )


### PR DESCRIPTION
I kept wondering why changing `min_step_size` did not change anything. Turned out it was nowhere checked whether `default_step_size` is below `min_step_size`...

Now `ProfileOptions.__init__` and `pypesto.profile.parameter_profile` check at least a subset of profiling options.