### PR TITLE
Fix startpoint sampling for PEtab-derived problems with fixed parameters

### DIFF
--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -989,7 +989,9 @@ class PetabStartpoints(CheckedStartpoints):
             pypesto_problem.x_free_indices
         ]
         petab_free_ids = parameter_df.index[parameter_df[ESTIMATE] == 1]
-        if np.all(current_free_ids == petab_free_ids):
+        if len(current_free_ids) == len(petab_free_ids) and np.all(
+            current_free_ids == petab_free_ids
+        ):
             # no fixed parameters - good as is
             return startpoints
 

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -977,7 +977,7 @@ class PetabStartpoints(CheckedStartpoints):
         if (
             self._priors is not None
             and len(current_free_ids) == len(self._free_ids)
-            and current_free_ids == self._free_ids
+            and np.all(current_free_ids == self._free_ids)
         ):
             # no need to update
             return

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -967,7 +967,7 @@ class PetabStartpoints(CheckedStartpoints):
     ):
         """Update priors if necessary.
 
-        Check if ``problem.x_free_indices`` changed since last, and if so,
+        Check if ``problem.x_free_indices`` changed since last call, and if so,
         get the corresponding priors from PEtab.
         """
         current_free_ids = np.asarray(pypesto_problem.x_names)[

--- a/test/petab/test_petab_import.py
+++ b/test/petab/test_petab_import.py
@@ -72,7 +72,28 @@ class PetabImportTest(unittest.TestCase):
 
             self.assertTrue(np.isfinite(ret))
 
-    def test_3_optimize(self):
+    def test_3_startpoints(self):
+        # test startpoint sampling
+        for obj_edatas, importer in zip(self.obj_edatas, self.petab_importers):
+            obj = obj_edatas[0]
+            problem = importer.create_problem(obj)
+
+            # test for original problem
+            original_dim = problem.dim
+            startpoints = problem.startpoint_method(
+                n_starts=2, problem=problem
+            )
+            self.assertEqual(startpoints.shape, (2, problem.dim))
+
+            # test with fixed parameters
+            problem.fix_parameters(0, 1)
+            self.assertEqual(problem.dim, original_dim - 1)
+            startpoints = problem.startpoint_method(
+                n_starts=2, problem=problem
+            )
+            self.assertEqual(startpoints.shape, (2, problem.dim))
+
+    def test_4_optimize(self):
         # run optimization
         for obj_edatas, importer in zip(self.obj_edatas, self.petab_importers):
             obj = obj_edatas[0]

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ envlist =
 # Base-environment
 
 [testenv]
+passenv = AMICI_PARALLEL_COMPILE
 
 # Sub-environments
 #  inherit settings defined in the base


### PR DESCRIPTION
Startpoint sampling for `PetabImporter`-derived problems didn't work correctly in case any parameters were fixed in addition to those marked `estimate=0` in the underlying PEtab problem.

Fixing any parameters after the construction of the `pypesto.Problem` and the corresponding startpoint method would lead to errors during startpoint sampling because the list of fixed parameters was never updated.

In order to fix that, we need to have the current `pypesto.Problem` available for startpoint sampling to get access to the currently fixed parameters. Accessing `pypesto.Problem` is not compatible with the current `FunctionStartpoints`. Therefore, we derive a new `PetabStartpoints` class from `CheckedStartpoints.sample` that will allow forwarding/accessing the `Problem`.