### PR TITLE
Fix SSL Error of scipy

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,7 +74,7 @@ autodoc_mock_imports = ["amici"]
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/devdocs/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'scipy': ('http://scipy.github.io/devdocs/', None),
     'pandas': ('https://pandas.pydata.org/docs/', None),
     'petab': (
         'https://petab.readthedocs.io/projects/libpetab-python/en/latest/',


### PR DESCRIPTION
Building the docs continously threw an ssl error see for example [this action](https://github.com/ICB-DCM/pyPESTO/actions/runs/6887942276/job/18738115726)

```
Warning, treated as error:
failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.scipy.org/doc/scipy/objects.inv' not fetchable due to <class 'requests.exceptions.SSLError'>: HTTPSConnectionPool(host='docs.scipy.org', port=443): Max retries exceeded with url: /doc/scipy/objects.inv (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1006)')))
```

I guess this will be only a temporary bug. We could also set `tls_verify = False` which would deactivate any verification which in my opinion is more then suboptimal...