### PR TITLE
SacessOptimizer: avoid FileNotFoundError if run with ridiculously low…

### DIFF
--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -471,7 +471,8 @@ class SacessWorker:
         i_iter = 0
         ess_results = pypesto.Result(problem=problem)
 
-        while self._keep_going():
+        # run ESS until exit criteria are met, but start at least one iteration
+        while self._keep_going() or i_iter == 0:
             # run standard ESS
             ess, cur_ess_results = self._run_ess(
                 refset=refset,


### PR DESCRIPTION
… walltime limit

It was possible that SacessOptimizer would quit before even starting the first iteration if a tiny walltime limit is set. This led to a FileNotFoundError when trying to collect the temporary results. Fixed here by starting at least one iteration.

Closes #1172