### PR TITLE
GHA: Skip brew update

### DIFF
--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -12,7 +12,7 @@ pip install tox
 # Update package lists
 if [ "$(uname)" == "Darwin" ]; then
   # MacOS
-  brew update
+  :
 else
   # Linux
   sudo apt-get update


### PR DESCRIPTION
We don't need to upgrade all installed packages.