### PR TITLE
Fix check for allow_failed_starts

### DIFF
--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -93,7 +93,7 @@ def history_decorator(minimize):
                 message=result.message, exitflag=result.exitflag
             )
         except Exception as err:
-            if optimize_options.allow_failed_starts:
+            if optimize_options and optimize_options.allow_failed_starts:
                 import sys
                 import traceback
 


### PR DESCRIPTION
Previously it was incorrectly assumed that `optimize_options` is not None. Not it's checked before accessing it.