### PR TITLE
ESSOptimizer: allow passing an optimizer factory

### DIFF
--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -525,11 +525,16 @@ def test_ess_multiprocess(problem, request):
         # Not pickleable - incompatible with CESS
         pytest.skip()
 
+    from fides.constants import Options as FidesOptions
+
     from pypesto.optimize.ess import ESSOptimizer, FunctionEvaluatorMP, RefSet
 
     ess = ESSOptimizer(
         max_iter=20,
-        local_optimizer=optimize.FidesOptimizer(),
+        # also test passing a callable as local_optimizer
+        local_optimizer=lambda max_walltime_s, **kwargs: optimize.FidesOptimizer(
+            options={FidesOptions.MAXTIME: max_walltime_s}
+        ),
     )
     refset = RefSet(
         dim=10,


### PR DESCRIPTION
Allow passing a optimizer factory to ESSOptimizer so that overall ESS walltime and function evaluation limits can be respected by the local optimizer.