### PR TITLE
Fix tempfile warning

### DIFF
--- a/test/run_notebook.sh
+++ b/test/run_notebook.sh
@@ -52,7 +52,7 @@ fi
 
 run_notebook () {
   # Run a notebook
-  tempfile=$(tempfile)
+  tempfile=$(mktemp)
   jupyter nbconvert \
     --ExecutePreprocessor.timeout=-1 --debug --stdout --execute \
     --to markdown $@ &> $tempfile


### PR DESCRIPTION
Fixes a number of `WARNING: tempfile is deprecated; consider using mktemp instead.`

e.g. https://github.com/ICB-DCM/pyPESTO/actions/runs/6903646092/job/18782766099