### PR TITLE
Retry test_autocorrelation_mixture

### DIFF
--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -545,6 +545,7 @@ def test_autocorrelation_short_chain():
     assert ess is None
 
 
+@pytest.mark.flaky(reruns=3)
 def test_autocorrelation_mixture():
     """Check that the autocorrelation is the same for the same chain
     with different scalings."""


### PR DESCRIPTION
Occassionally fails due to strict tolerances. Retry.

last failure: https://github.com/ICB-DCM/pyPESTO/actions/runs/6903920970/job/18783573410?pr=1184