### PR TITLE
Fix SacessOptimizer sometimes not logging the best result

### DIFF
--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -186,15 +186,17 @@ class SacessOptimizer:
             for p in worker_processes:
                 p.join()
 
-            logging_thread.stop()
+        logging_thread.stop()
 
-            walltime = time.time() - start_time
-            logger.info(
-                f"sacess stopping after {walltime:3g}s with global best "
-                f"{sacess_manager.get_best_solution()[1]}."
-            )
+        result = self._create_result(problem)
 
-        return self._create_result(problem)
+        walltime = time.time() - start_time
+        logger.info(
+            f"{self.__class__.__name__} stopped after {walltime:3g}s with global best "
+            f"{result.optimize_result[0].fval}."
+        )
+
+        return result
 
     def _create_result(self, problem: Problem) -> pypesto.Result:
         """Create result object.


### PR DESCRIPTION
In some cases, SacessOptimizer logged a sub-optimal final fval. The returned result was corrected, though.

Now the correct value is logged.