### PR TITLE
Make test/base/ less verbose

### DIFF
--- a/pypesto/ensemble/task.py
+++ b/pypesto/ensemble/task.py
@@ -34,7 +34,7 @@ class EnsembleTask(Task):
 
     def execute(self) -> List[Any]:
         """Execute the task."""
-        logger.info(f"Executing task {self.id}.")
+        logger.debug(f"Executing task {self.id}.")
         results = []
         for index in range(self.vectors.shape[1]):
             results.append(self.method(self.vectors[:, index]))

--- a/pypesto/objective/finite_difference.py
+++ b/pypesto/objective/finite_difference.py
@@ -212,7 +212,7 @@ class FDDelta:
         self.delta = delta_opt
 
         # log
-        logger.info(f"Optimal FD delta: {self.delta}")
+        logger.debug(f"Optimal FD delta: {self.delta}")
         self.updates += 1
 
     def get(self) -> np.ndarray:

--- a/pypesto/predict/task.py
+++ b/pypesto/predict/task.py
@@ -43,6 +43,6 @@ class PredictorTask(Task):
 
     def execute(self) -> 'pypesto.predict.PredictionResult':  # noqa: F821
         """Execute and return the prediction."""
-        logger.info(f"Executing task {self.id}.")
+        logger.debug(f"Executing task {self.id}.")
         prediction = self.predictor(self.x, self.sensi_orders, self.mode)
         return prediction

--- a/test/base/test_logging.py
+++ b/test/base/test_logging.py
@@ -9,7 +9,6 @@ import pypesto.optimize
 
 def test_optimize():
     # logging
-    pypesto.logging.log_to_console(logging.WARN)
     filename = ".test_logging.tmp"
     pypesto.logging.log_to_file(logging.DEBUG, filename)
     logger = logging.getLogger('pypesto')
@@ -17,27 +16,33 @@ def test_optimize():
         os.remove(filename)
     fh = logging.FileHandler(filename)
     fh.setLevel(logging.DEBUG)
-    logger.addHandler(fh)
-    logger.info("start test")
 
-    # problem definition
-    def fun(_):
-        raise Exception("This function cannot be called.")
+    old_handlers = logger.handlers
+    logger.handlers = []
+    try:
+        logger.addHandler(fh)
+        logger.info("start test")
 
-    objective = pypesto.Objective(fun=fun)
-    problem = pypesto.Problem(objective, -1, 1)
+        # problem definition
+        def fun(_):
+            raise Exception("This function cannot be called.")
 
-    optimizer = pypesto.optimize.ScipyOptimizer()
-    options = {'allow_failed_starts': True}
+        objective = pypesto.Objective(fun=fun)
+        problem = pypesto.Problem(objective, -1, 1)
 
-    # optimization
-    pypesto.optimize.minimize(
-        problem=problem,
-        optimizer=optimizer,
-        n_starts=5,
-        options=options,
-        progress_bar=False,
-    )
+        optimizer = pypesto.optimize.ScipyOptimizer()
+        options = {'allow_failed_starts': True}
+
+        # optimization
+        pypesto.optimize.minimize(
+            problem=problem,
+            optimizer=optimizer,
+            n_starts=5,
+            options=options,
+            progress_bar=False,
+        )
+    finally:
+        logger.handlers = old_handlers
 
     # assert logging worked
     assert os.path.exists(filename)

--- a/test/base/test_objective.py
+++ b/test/base/test_objective.py
@@ -3,16 +3,11 @@
 import copy
 import numbers
 
-import aesara.tensor as aet
-import jax
-import jax.numpy as jnp
 import numpy as np
 import pytest
 import sympy as sp
 
 import pypesto
-from pypesto.objective.aesara import AesaraObjective
-from pypesto.objective.jax import JaxObjective
 
 from ..util import CRProblem, poly_for_sensi, rosen_for_sensi
 
@@ -162,7 +157,9 @@ def test_finite_difference_checks():
 
     # Test the single step size `check_grad` method.
     eps = 1e-5
-    result_single_eps = objective.check_grad(np.array([theta]), eps=eps)
+    result_single_eps = objective.check_grad(
+        np.array([theta]), eps=eps, verbosity=False
+    )
     np.testing.assert_almost_equal(
         result_single_eps['rel_err'].squeeze(),
         rel_err(eps),
@@ -171,7 +168,7 @@ def test_finite_difference_checks():
     # Test the multiple step size `check_grad_multi_eps` method.
     multi_eps = {1e-1, 1e-3, 1e-5, 1e-7, 1e-9}
     result_multi_eps = objective.check_grad_multi_eps(
-        [theta], multi_eps=multi_eps
+        [theta], multi_eps=multi_eps, verbosity=False
     )
 
     np.testing.assert_almost_equal(
@@ -182,6 +179,10 @@ def test_finite_difference_checks():
 
 def test_aesara(max_sensi_order, integrated):
     """Test function composition and gradient computation via aesara"""
+    import aesara.tensor as aet
+
+    from pypesto.objective.aesara import AesaraObjective
+
     prob = rosen_for_sensi(max_sensi_order, integrated, [0, 1])
 
     # create aesara specific symbolic tensor variables
@@ -215,6 +216,11 @@ def test_aesara(max_sensi_order, integrated):
 
 def test_jax(max_sensi_order, integrated):
     """Test function composition and gradient computation via jax"""
+    import jax
+    import jax.numpy as jnp
+
+    from pypesto.objective.jax import JaxObjective
+
     prob = rosen_for_sensi(max_sensi_order, integrated, [0, 1])
 
     # apply inverse transform such that we evaluate at prob['x']


### PR DESCRIPTION
Removes quite some not so interesting test output.

Also moved some imports, so at least a subset of tests can be run if jax and aesara aren't installed.