### PR TITLE
Quiet tests.

### DIFF
--- a/test/base/test_prior.py
+++ b/test/base/test_prior.py
@@ -125,7 +125,7 @@ def test_mode(scale, prior_type_list):
 
             # flat functions don't have local minima, so dont check this
             # for uniform priors
-            print("XXXXX", result.optimize_result.list[0].fval)
+
             num_optim = result.optimize_result.list[0]['x'][~np.isnan(topt)]
             assert np.isclose(
                 num_optim, topt[~np.isnan(topt)], atol=1e-03

--- a/test/base/test_prior.py
+++ b/test/base/test_prior.py
@@ -125,7 +125,7 @@ def test_mode(scale, prior_type_list):
 
             # flat functions don't have local minima, so dont check this
             # for uniform priors
-
+            print("XXXXX", result.optimize_result.list[0].fval)
             num_optim = result.optimize_result.list[0]['x'][~np.isnan(topt)]
             assert np.isclose(
                 num_optim, topt[~np.isnan(topt)], atol=1e-03

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
         test/base --durations=0 \
         test/profile --durations=0 \
         test/sample --durations=0 \
-        test/visualize --durations=0 \
+        test/visualize --durations=0
 description =
     Test basic functionality
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,6 @@ commands =
         test/profile --durations=0 \
         test/sample --durations=0 \
         test/visualize --durations=0 \
-        -s
 description =
     Test basic functionality
 
@@ -82,7 +81,7 @@ deps =
 
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/petab -s
+        test/petab
 description =
     Test PEtab functionality
 
@@ -91,7 +90,7 @@ extras = test,julia
 commands =
     python -c "import julia; julia.install()"
     python-jl -m pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/julia -s
+        test/julia
 description =
     Test Julia interface
 
@@ -99,7 +98,7 @@ description =
 extras = test,dlib,ipopt,pyswarm,cmaes,nlopt,fides,mpi,pyswarms,petab
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/optimize -s
+        test/optimize
 description =
     Test optimization module
 
@@ -110,7 +109,7 @@ deps =
 commands =
     # workaround as ipopt has incomplete build
     pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/hierarchical -s
+        test/hierarchical
 description =
     Test hierarchical optimization module
 
@@ -118,7 +117,7 @@ description =
 extras = test,amici,petab,select
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
-        test/select -s
+        test/select
 description =
     Test model selection functionality
 


### PR DESCRIPTION
Don't print all the test output by default, only on failures.