### PR TITLE
Doc: Show typehints in description

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,6 +56,8 @@ extensions = [
     'sphinxcontrib.bibtex',
     # ensure that jQuery is installed
     'sphinxcontrib.jquery',
+    # type hint formatting
+    'sphinx_autodoc_typehints',
 ]
 
 # default autodoc options
@@ -83,6 +85,10 @@ intersphinx_mapping = {
     'amici': ('https://amici.readthedocs.io/en/latest/', None),
     'fides': ('https://fides-optimizer.readthedocs.io/en/latest/', None),
 }
+
+
+typehints_document_rtype = True
+autodoc_typehints = "description"
 
 bibtex_bibfiles = ["using_pypesto.bib"]
 

--- a/pypesto/C.py
+++ b/pypesto/C.py
@@ -5,7 +5,7 @@ Package-wide consistent constant definitions.
 """
 
 from enum import Enum
-from typing import Callable, Literal, Tuple, Union
+from typing import Literal, Tuple, Union
 
 ###############################################################################
 # ENSEMBLE
@@ -274,13 +274,6 @@ CONDITION_IDS = 'condition_ids'
 
 CSV = 'csv'  # return file format
 H5 = 'h5'  # return file format
-
-
-###############################################################################
-# SELECT
-
-TYPE_POSTPROCESSOR = Callable[["ModelProblem"], None]  # noqa: F821
-
 
 ###############################################################################
 # VISUALIZE

--- a/pypesto/history/util.py
+++ b/pypesto/history/util.py
@@ -1,6 +1,7 @@
 """History utility functions."""
 
 import numbers
+from functools import wraps
 from typing import Dict, Sequence, Union
 
 import numpy as np
@@ -38,6 +39,7 @@ def trace_wrap(f):
     integer `ix` the output to a single value.
     """
 
+    @wraps(f)
     def wrapped_f(
         self, ix: Union[Sequence[int], int, None] = None, trim: bool = False
     ) -> Union[Sequence[Union[float, MaybeArray]], Union[float, MaybeArray]]:

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -5,6 +5,7 @@ import logging
 import re
 import time
 import warnings
+from functools import wraps
 from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
@@ -46,6 +47,7 @@ def history_decorator(minimize):
     Default decorator for the minimize() method.
     """
 
+    @wraps(minimize)
     def wrapped_minimize(
         self,
         problem: Problem,
@@ -129,6 +131,7 @@ def time_decorator(minimize):
     the wall-clock time.
     """
 
+    @wraps(minimize)
     def wrapped_minimize(
         self,
         problem: Problem,
@@ -160,6 +163,7 @@ def fix_decorator(minimize):
     derivatives).
     """
 
+    @wraps(minimize)
     def wrapped_minimize(
         self,
         problem: Problem,

--- a/pypesto/predict/task.py
+++ b/pypesto/predict/task.py
@@ -28,7 +28,7 @@ class PredictorTask(Task):
 
     def __init__(
         self,
-        predictor: 'pypesto.predict.Predictor',  # noqa: F821
+        predictor,  #: 'pypesto.predict.Predictor',  # noqa: F821
         x: Sequence[float],
         sensi_orders: Tuple[int, ...],
         mode: ModeType,
@@ -41,7 +41,7 @@ class PredictorTask(Task):
         self.mode = mode
         self.id = id
 
-    def execute(self) -> 'pypesto.predict.PredictionResult':  # noqa: F821
+    def execute(self):  # -> 'pypesto.predict.PredictionResult':  # noqa: F821
         """Execute and return the prediction."""
         logger.info(f"Executing task {self.id}.")
         prediction = self.predictor(self.x, self.sensi_orders, self.mode)

--- a/pypesto/select/method.py
+++ b/pypesto/select/method.py
@@ -14,9 +14,8 @@ from petab_select import (
     Model,
 )
 
-from ..C import TYPE_POSTPROCESSOR
 from ..problem import Problem
-from .model_problem import ModelProblem
+from .model_problem import TYPE_POSTPROCESSOR, ModelProblem
 
 
 class MethodSignalProceed(str, Enum):

--- a/pypesto/select/model_problem.py
+++ b/pypesto/select/model_problem.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, List, Optional
 
 from petab_select import Criterion, Model
 
-from ..C import TYPE_POSTPROCESSOR
 from ..objective import ObjectiveBase
 from ..optimize import minimize
 from ..problem import Problem
@@ -12,7 +11,7 @@ from ..result import OptimizerResult, Result
 from .misc import model_to_pypesto_problem
 
 OBJECTIVE_CUSTOMIZER_TYPE = Callable[[ObjectiveBase], None]
-POSTPROCESSOR_TYPE = Callable[["ModelProblem"], None]
+TYPE_POSTPROCESSOR = Callable[["ModelProblem"], None]  # noqa: F821
 
 
 class ModelProblem:
@@ -65,7 +64,7 @@ class ModelProblem:
         x_guess: List[float] = None,
         minimize_options: Dict = None,
         objective_customizer: Optional[OBJECTIVE_CUSTOMIZER_TYPE] = None,
-        postprocessor: Optional[TYPE_POSTPROCESSOR] = None,
+        postprocessor: Optional["TYPE_POSTPROCESSOR"] = None,
         model_to_pypesto_problem_method: Callable[[Any], Problem] = None,
     ):
         """Construct then calibrate a model problem.

--- a/pypesto/select/postprocessors.py
+++ b/pypesto/select/postprocessors.py
@@ -7,8 +7,7 @@ import numpy as np
 from petab_select.constants import ESTIMATE, TYPE_PATH, Criterion
 
 from .. import store, visualize
-from ..C import TYPE_POSTPROCESSOR
-from .model_problem import ModelProblem
+from .model_problem import TYPE_POSTPROCESSOR, ModelProblem
 
 __all__ = [
     'model_id_binary_postprocessor',

--- a/pypesto/select/problem.py
+++ b/pypesto/select/problem.py
@@ -7,8 +7,6 @@ from petab_select import Model
 from ..C import TYPE_POSTPROCESSOR
 from .method import MethodCaller
 
-__all__ = ["Problem"]
-
 
 class Problem:
     """Handles use of a model selection algorithm.

--- a/pypesto/select/problem.py
+++ b/pypesto/select/problem.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import petab_select
 from petab_select import Model
 
-from ..C import TYPE_POSTPROCESSOR
 from .method import MethodCaller
+from .model_problem import TYPE_POSTPROCESSOR, ModelProblem  # noqa: F401
 
 
 class Problem:

--- a/pypesto/select/problem.py
+++ b/pypesto/select/problem.py
@@ -7,6 +7,8 @@ from petab_select import Model
 from ..C import TYPE_POSTPROCESSOR
 from .method import MethodCaller
 
+__all__ = ["Problem"]
+
 
 class Problem:
     """Handles use of a model selection algorithm.

--- a/pypesto/visualize/ordinal_categories.py
+++ b/pypesto/visualize/ordinal_categories.py
@@ -1,5 +1,8 @@
 import warnings
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+if TYPE_CHECKING:
+    import pypesto
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -14,9 +17,7 @@ try:
     from ..hierarchical.optimal_scaling.parameter import (
         OptimalScalingParameter,
     )
-    from ..hierarchical.optimal_scaling.problem import OptimalScalingProblem
     from ..hierarchical.optimal_scaling.solver import (
-        OptimalScalingInnerSolver,
         compute_interval_constraints,
         get_bounds_for_category,
         undo_inner_parameter_reparameterization,
@@ -155,8 +156,8 @@ def plot_categories_from_pypesto_result(
 
 
 def plot_categories_from_inner_result(
-    inner_problem: 'OptimalScalingProblem',
-    inner_solver: 'OptimalScalingInnerSolver',
+    inner_problem: 'pypesto.hierarchical.optimal_scaling.problem.OptimalScalingProblem',
+    inner_solver: 'pypesto.hierarchical.optimal_scaling.solver.OptimalScalingInnerSolver',
     results: List[Dict],
     simulation: List[np.ndarray],
     timepoints: List[np.ndarray],

--- a/pypesto/visualize/spline_approximation.py
+++ b/pypesto/visualize/spline_approximation.py
@@ -5,6 +5,8 @@ import matplotlib.axes
 import matplotlib.pyplot as plt
 import numpy as np
 
+import pypesto
+
 from ..C import AMICI_SIGMAY, AMICI_Y, CURRENT_SIMULATION, DATAPOINTS, SCIPY_X
 from ..problem import Problem
 from ..result import Result
@@ -15,7 +17,6 @@ try:
     from ..hierarchical.spline_approximation.calculator import (
         SplineAmiciCalculator,
     )
-    from ..hierarchical.spline_approximation.problem import SplineInnerProblem
     from ..hierarchical.spline_approximation.solver import (
         SplineInnerSolver,
         get_spline_mapped_simulations,
@@ -114,7 +115,7 @@ def plot_splines_from_pypesto_result(
 
 
 def plot_splines_from_inner_result(
-    inner_problem: 'SplineInnerProblem',
+    inner_problem: 'pypesto.hierarchical.spline_approximation.problem.SplineInnerProblem',
     results: List[Dict],
     observable_ids=None,
     **kwargs,

--- a/tox.ini
+++ b/tox.ini
@@ -168,7 +168,7 @@ description =
 
 [testenv:doc]
 extras =
-    doc,amici,petab,aesara,jax
+    doc,amici,petab,aesara,jax,select
 commands =
     sphinx-build -W -b html doc/ doc/_build/html
 description =


### PR DESCRIPTION
Instead of in the signature. Much more readable.

E.g., before: https://pypesto.readthedocs.io/en/latest/api/pypesto.visualize.html#pypesto.visualize.waterfall
after: https://pypesto--1192.org.readthedocs.build/en/1192/api/pypesto.visualize.html#pypesto.visualize.waterfall

Also fixes some function documentation missing from sphinx docs due to lack of  `wraps`.

Also removes some circular dependencies.