### PR TITLE
GHA: Don't run quality checks twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,10 +314,6 @@ jobs:
     - name: Check repository size
       run: tox -e size
 
-    - name: Run quality checks
-      timeout-minutes: 5
-      run: tox -e project,flake8
-
     - name: Run pre-commit hooks
       run: pre-commit run --all-files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,9 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-ci-quality
 
     - name: Install dependencies
-      run: pip install tox pre-commit
+      run: |
+        pip install -U wheel setuptools
+        pip install tox pre-commit
 
     - name: Check repository size
       run: tox -e size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,9 +311,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-ci-quality
 
     - name: Install dependencies
-      run: |
-        pip install -U wheel setuptools
-        pip install tox pre-commit
+      run: pip install tox pre-commit
 
     - name: Check repository size
       run: tox -e size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,9 @@ jobs:
     - name: Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: |
+          ~/.cache
+          .tox/
         key: ${{ runner.os }}-${{ matrix.python-version }}-ci-quality
 
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,5 +60,5 @@ repos:
     name: Check style
     description: Check style
     entry: tox -e project,flake8 --
-    language: python
+    language: system
     types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
   - id: style
     name: Check style
     description: Check style
-    require_serial: true
-    entry: tox -e project,flake8 --
+    pass_filenames: false
+    entry: tox -e project,flake8
     language: system
     types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
   - id: style
     name: Check style
     description: Check style
+    require_serial: true
     entry: tox -e project,flake8 --
     language: system
     types: [python]


### PR DESCRIPTION
* GHA: Don't run quality checks twice 
  Already run here:
  https://github.com/ICB-DCM/pyPESTO/blob/develop/.pre-commit-config.yaml#L62
  Via:
  https://github.com/ICB-DCM/pyPESTO/blob/develop/.github/workflows/ci.yml#L322C6-L322C6

* Also cache `.tox/`.
* Don't run tox repeatedly and in parallel (Fixes #1186)
* 1 min faster