### PR TITLE
GHA: use clang for amici-heavy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
     # run Monday and Thursday at 03:42 UTC
     - cron: '42 3 * * MON,THU'
 
+env:
+  # use all available cores for compiling amici models
+  AMICI_PARALLEL_COMPILE: ""
+
 # jobs
 jobs:
   base:
@@ -40,6 +44,9 @@ jobs:
     - name: Run tests
       timeout-minutes: 25
       run: tox -e base
+      env:
+        CC: clang
+        CXX: clang++
 
     - name: Coverage
       uses: codecov/codecov-action@v3
@@ -133,6 +140,9 @@ jobs:
     - name: Run tests
       timeout-minutes: 35
       run: tox -e petab
+      env:
+        CC: clang
+        CXX: clang++
 
     - name: Coverage
       uses: codecov/codecov-action@v3

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -32,7 +32,7 @@ for par in "$@"; do
         brew install swig hdf5 libomp
       else
         sudo apt-get install \
-          swig libatlas-base-dev libhdf5-serial-dev
+          swig libatlas-base-dev libhdf5-serial-dev clang
       fi
     ;;
 

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -32,7 +32,7 @@ for par in "$@"; do
         brew install swig hdf5 libomp
       else
         sudo apt-get install \
-          swig libatlas-base-dev libhdf5-serial-dev clang
+          clang libatlas-base-dev libhdf5-serial-dev libomp-dev swig
       fi
     ;;
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ envlist =
 # Base-environment
 
 [testenv]
-passenv = AMICI_PARALLEL_COMPILE
+passenv = AMICI_PARALLEL_COMPILE,CC,CXX
 
 # Sub-environments
 #  inherit settings defined in the base


### PR DESCRIPTION
Should be faster. Also use all cores for building amici models.

Saves 2-3 minutes for the petab test suite.