### PR TITLE
 test/hierarchical/test_{ordinal,spline}.py::test_optimization: Set seed for reproducibility

### DIFF
--- a/test/hierarchical/test_ordinal.py
+++ b/test/hierarchical/test_ordinal.py
@@ -82,7 +82,8 @@ def test_evaluate_objective(inner_options: List[Dict]):
 def test_optimization(inner_options: List[Dict]):
     """Check that optimizations finishes without error."""
     petab_problem = petab.Problem.from_yaml(example_ordinal_yaml)
-
+    # Set seed for reproducibility.
+    np.random.seed(0)
     optimizer = pypesto.optimize.ScipyOptimizer(
         method='L-BFGS-B', options={'maxiter': 10}
     )

--- a/test/hierarchical/test_spline.py
+++ b/test/hierarchical/test_spline.py
@@ -53,7 +53,8 @@ def inner_options(request):
 def test_optimization(inner_options: Dict):
     """Check that optimizations finishes without error."""
     petab_problem = petab.Problem.from_yaml(example_nonlinear_monotone_yaml)
-
+    # Set seed for reproducibility.
+    np.random.seed(0)
     optimizer = pypesto.optimize.ScipyOptimizer(
         method="L-BFGS-B",
         options={"disp": None, "ftol": 2.220446049250313e-09, "gtol": 1e-5},


### PR DESCRIPTION
The tests were sometimes failing if the start point chosen was such that it was already in the optimum (or close). Then the end objective function was the same as it was at the start point. Setting a seed so it does not happen again.
Solution to this issue: https://github.com/ICB-DCM/pyPESTO/issues/1179