### PR TITLE
fix waterfall start indices

### DIFF
--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -325,9 +325,9 @@ def process_offset_for_list(
     fvals_all = []
     for result in results:
         fvals = np.array(result.optimize_result.fval)
-        # todo: order of results plays a role
-        start_indices = process_start_indices(result, start_indices)
-        fvals = fvals[start_indices]
+
+        result_start_indices = process_start_indices(result, start_indices)
+        fvals = fvals[result_start_indices]
         # if none of the fvals are finite, set default value to zero as
         # np.nanmin will error for an empty array
         if np.isfinite(fvals).any():


### PR DESCRIPTION
Otherwise, when there is more than one optimization result, one might get different `start_indices` depending on result order. E.g., if  a result with fewer multistarts precedes one with more multistarts, the resulting start indices will be limited to the indices of the first  result. If the order of the results is opposite, the result with fewer multistarts won't limit the number of starts that will be plotted for the other result.