### PR TITLE
SacessOptimizer: Fix passing parameters

### DIFF
--- a/pypesto/optimize/ess/ess.py
+++ b/pypesto/optimize/ess/ess.py
@@ -528,10 +528,15 @@ class ESSOptimizer:
                 f"{optimizer_result.exitflag}: {optimizer_result.message}"
             )
             if np.isfinite(optimizer_result.fval):
-                self.local_solutions.append(optimizer_result.x)
+                local_solution_x = optimizer_result.x[
+                    optimizer_result.free_indices
+                ]
+                local_solution_fx = optimizer_result.fval
+
+                self.local_solutions.append(local_solution_x)
 
                 self._maybe_update_global_best(
-                    optimizer_result.x, optimizer_result.fval
+                    local_solution_x, local_solution_fx
                 )
                 break
 

--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -358,9 +358,14 @@ class SacessManager:
                     f"Accepted solution from worker {sender_idx}: {fx}."
                 )
                 # accept
-                self._best_known_fx.value = fx
+                if len(x) != len(self._best_known_x):
+                    raise AssertionError(
+                        f"Received solution with {len(x)} parameters, "
+                        f"but expected {len(self._best_known_x)}."
+                    )
                 for i, xi in enumerate(x):
                     self._best_known_x[i] = xi
+                self._best_known_fx.value = fx
                 self._worker_comms[sender_idx] += 1
                 self._worker_scores[sender_idx] = (
                     self._worker_comms[sender_idx] * elapsed_time_s


### PR DESCRIPTION
* Fixes a bug during the cooperation step where best parameters wouldn't be shared correctly due to incorrect assignment to `SyncManager.Array`.
* Fixes a bug where free_indices are ignored, and thus, a wrong parameter vector is stored in local solutions and sent to the manager.
