### PR TITLE
Handle message and exitflag in histories

### DIFF
--- a/pypesto/history/base.py
+++ b/pypesto/history/base.py
@@ -118,6 +118,16 @@ class HistoryBase(ABC):
     def start_time(self) -> float:
         """Return start time."""
 
+    @property
+    @abstractmethod
+    def message(self) -> str:
+        """Return message."""
+
+    @property
+    @abstractmethod
+    def exitflag(self) -> str:
+        """Return exitflag."""
+
     @abstractmethod
     def get_x_trace(
         self,
@@ -304,6 +314,14 @@ class NoHistory(HistoryBase):
     def start_time(self) -> float:  # noqa: D102
         raise NotImplementedError()
 
+    @property
+    def message(self) -> float:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def exitflag(self) -> float:  # noqa: D102
+        raise NotImplementedError()
+
     def get_x_trace(  # noqa: D102
         self, ix: Union[int, Sequence[int], None] = None, trim: bool = False
     ) -> Union[Sequence[np.ndarray], np.ndarray]:
@@ -354,6 +372,8 @@ class CountHistoryBase(HistoryBase):
         self._n_res: int = 0
         self._n_sres: int = 0
         self._start_time: float = time.time()
+        self._exitflag = ""
+        self._message = ""
 
     def update(  # noqa: D102
         self,
@@ -406,6 +426,22 @@ class CountHistoryBase(HistoryBase):
     @property
     def start_time(self) -> float:  # noqa: D102
         return self._start_time
+
+    @property
+    def message(self) -> str:  # noqa: D102
+        return self._message
+
+    @property
+    def exitflag(self) -> str:  # noqa: D102
+        return self._exitflag
+
+    def finalize(  # noqa: D102
+        self,
+        message: str = None,
+        exitflag: str = None,
+    ) -> None:  # noqa: D102
+        self._message = message
+        self._exitflag = exitflag
 
 
 class CountHistory(CountHistoryBase):

--- a/pypesto/history/csv.py
+++ b/pypesto/history/csv.py
@@ -97,7 +97,7 @@ class CsvHistory(CountHistoryBase):
 
     def finalize(self, message: str = None, exitflag: str = None):
         """See `HistoryBase` docstring."""
-        super().finalize()
+        super().finalize(message=message, exitflag=exitflag)
         self._save_trace(finalize=True)
 
     def _update_trace(

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -528,7 +528,7 @@ def history(request) -> pypesto.HistoryBase:
     for _ in range(10):
         result = {FVAL: np.random.randn(), GRAD: np.random.randn(7)}
         history.update(np.random.randn(7), (0, 1), 'mode_fun', result)
-    history.finalize()
+    history.finalize(message="some message", exitflag="some flag")
 
     return history
 
@@ -539,6 +539,8 @@ def test_history_properties(history: pypesto.HistoryBase):
     assert history.n_hess == 0
     assert history.n_res == 0
     assert history.n_sres == 0
+    assert history.exitflag == "some flag"
+    assert history.message == "some message"
 
     if not history.implements_trace():
         with pytest.raises(NotImplementedError):

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -200,6 +200,11 @@ class HistoryTest(unittest.TestCase):
                 'x_names',
                 'editable',
             ]
+            # exitflag and message are not stored in CsvHistory
+            and (
+                not isinstance(start.history, CsvHistory)
+                or a not in ["_exitflag", "_message", "exitflag", "message"]
+            )
         ]
         for attr in history_attributes:
             assert getattr(start.history, attr) == getattr(


### PR DESCRIPTION
* Add properties `message` and `exitflag` to `HistoryBase`
* Implement them in derived classes where missing
* Store them in `CountHistoryBase`

Resolves #1191