### PR TITLE
Fix incorrect types in pypesto.result.profile.ProfilerResult

### DIFF
--- a/pypesto/profile/util.py
+++ b/pypesto/profile/util.py
@@ -183,11 +183,11 @@ def fill_profile_list(
 
     # create blank profile
     new_profile = ProfilerResult(
-        x_path=optimizer_result["x"],
+        x_path=optimizer_result["x"][..., np.newaxis],
         fval_path=np.array([optimizer_result["fval"]]),
         ratio_path=np.array([np.exp(global_opt - optimizer_result["fval"])]),
-        gradnorm_path=gradnorm,
-        exitflag_path=optimizer_result["exitflag"],
+        gradnorm_path=np.array([gradnorm]),
+        exitflag_path=np.array([optimizer_result["exitflag"]]),
         time_path=np.array([0.0]),
         time_total=0.0,
         n_fval=0,

--- a/pypesto/store/read_from_hdf5.py
+++ b/pypesto/store/read_from_hdf5.py
@@ -32,7 +32,7 @@ def read_hdf5_profile(
         specifies the profile index that is read
         from the HDF5 file
     """
-    result = ProfilerResult(np.array([]), np.array([]), np.array([]))
+    result = ProfilerResult(np.empty((0, 0)), np.array([]), np.array([]))
 
     for profile_key in result.keys():
         if profile_key in f[f'/profiling/{profile_id}/{parameter_id}']:

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -178,8 +178,8 @@ def create_profile_result():
     result = create_optimization_result()
 
     # write some dummy results for profiling
-    ratio_path_1 = [0.15, 0.25, 0.7, 1.0, 0.8, 0.35, 0.15]
-    ratio_path_2 = [0.1, 0.2, 0.7, 1.0, 0.8, 0.3, 0.1]
+    ratio_path_1 = np.array([0.15, 0.25, 0.7, 1.0, 0.8, 0.35, 0.15])
+    ratio_path_2 = np.array([0.1, 0.2, 0.7, 1.0, 0.8, 0.3, 0.1])
     x_path_1 = np.array(
         [
             [2.0, 2.1, 2.3, 2.5, 2.7, 2.9, 3.0],


### PR DESCRIPTION
* Make all `*_path` attributes numpy arrays as promised in the type hints

  This caused #1205, because some entries were just plain `nan`. Fixes #1205.

* Fixes a lurking issue of potentially mismatching path lengths

  If e.g. `x_path` with length >1 was passed, but any of the default arguments would be missing, the `*_paths` wouldn't be aligned properly. I don't think this problem occurred here yet.

* Remove some unnecessary complexity