### PR TITLE
Fix numpy DeprecationWarning in `burn_in_by_sequential_geweke`

### DIFF
--- a/pypesto/sample/geweke_test.py
+++ b/pypesto/sample/geweke_test.py
@@ -199,9 +199,7 @@ def burn_in_by_sequential_geweke(
     alpha2 = zscore * np.ones((len(idxs)))
 
     for i in range(len(max_z)):
-        alpha2[idxs[i]] = alpha2[idxs[i]] / (
-            len(fragments) - np.where(idxs == i)[0] + 1
-        )
+        alpha2[idxs[i]] /= len(fragments) - np.argwhere(idxs == i).item(0) + 1
 
     if np.any(alpha2 > max_z):
         burn_in = (np.where(alpha2 > max_z)[0][0]) * step


### PR DESCRIPTION
Fixes
```
test/sample/test_sample.py: 542 warnings
  pyPESTO/pypesto/sample/geweke_test.py:202: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    alpha2[idxs[i]] = alpha2[idxs[i]] / (
```

Fixes #1207