### PR TITLE
Fix test/optimize/test_optimize.py: OptimizeWarning: Unknown solver o…

### DIFF
--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -471,10 +471,13 @@ class ScipyOptimizer(Optimizer):
 
     def get_default_options(self):
         """Create default options specific for the optimizer."""
+        options = {'disp': False}
         if self.is_least_squares():
-            options = {'max_nfev': 1000, 'disp': False}
-        else:
-            options = {'maxfun': 1000, 'disp': False}
+            options['max_nfev'] = 1000
+        elif self.method.lower() in ('l-bfgs-b', 'tnc'):
+            options['maxfun'] = 1000
+        elif self.method.lower() in ('nelder-mead', 'powell'):
+            options['maxfev'] = 1000
         return options
 
 

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -142,7 +142,10 @@ optimizers = [
 
 @pytest.fixture(
     params=optimizers,
-    ids=[f"{i}-{o[0]}" for i, o in enumerate(optimizers)],
+    ids=[
+        f"{i}-{o[0]}{'-' + str(o[1]) if isinstance(o[1], str) and o[1] else ''}"
+        for i, o in enumerate(optimizers)
+    ],
 )
 def optimizer(request):
     return request.param
@@ -249,7 +252,8 @@ def get_optimizer(library, solver):
     options = {'maxiter': 100}
 
     if library == 'scipy':
-        options['maxfun'] = options.pop('maxiter')
+        if solver == "TNC":
+            options['maxfun'] = options.pop('maxiter')
         optimizer = optimize.ScipyOptimizer(method=solver, options=options)
     elif library == 'ipopt':
         optimizer = optimize.IpoptOptimizer()

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -252,7 +252,7 @@ def get_optimizer(library, solver):
     options = {'maxiter': 100}
 
     if library == 'scipy':
-        if solver == "TNC":
+        if solver == "TNC" or solver.startswith("ls_"):
             options['maxfun'] = options.pop('maxiter')
         optimizer = optimize.ScipyOptimizer(method=solver, options=options)
     elif library == 'ipopt':

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -54,11 +54,13 @@ optimizers = [
             'Powell',
             'CG',
             'BFGS',
+            'dogleg',
             'Newton-CG',
             'L-BFGS-B',
             'TNC',
             'COBYLA',
             'SLSQP',
+            'trust-constr',
             'trust-ncg',
             'trust-exact',
             'trust-krylov',
@@ -66,7 +68,7 @@ optimizers = [
             'ls_dogbox',
         ]
     ],
-    # disabled: ,'trust-constr', 'ls_lm', 'dogleg'
+    # disabled: 'ls_lm' (ValueError when passing bounds)
     ('ipopt', ''),
     ('dlib', ''),
     ('pyswarm', ''),


### PR DESCRIPTION
…ptions: maxfun

* Use the correct option for setting the maximum number of function evaluations for each scipy optimizer.

  Closes #970

  Note that this changes the default settings for some optimizers for which `maxfun` has so far been ignored.

* Reenable tests for scipy `trust-constr` and `dogleg` optimizers, closes https://github.com/ICB-DCM/pyPESTO/issues/613