### PR TITLE
Fix flake8 warning

### DIFF
--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -621,5 +621,5 @@ class AmiciObjective(ObjectiveBase):
             x = self.amici_object_builder.petab_problem.x_nominal_scaled
             x_free = self.amici_object_builder.petab_problem.x_free_indices
         return super().check_gradients_match_finite_differences(
-            x=x, x_free=x_free, *args, **kwargs
+            *args, x=x, x_free=x_free, **kwargs
         )


### PR DESCRIPTION
The recent flake8 fails with `pypesto/objective/amici/amici.py:624:33: B026 Star-arg unpacking after a keyword argument is strongly discouraged, because it only works when the keyword parameter is declared after all parameters supplied by the unpacked sequence, and this change of ordering can surprise and mislead readers.`

Fixed here.