### PR TITLE
Fix incorrect indexing in `pypesto.profile.profile_next_guess.get_reg…

### DIFF
--- a/pypesto/profile/profile_next_guess.py
+++ b/pypesto/profile/profile_next_guess.py
@@ -355,8 +355,8 @@ def get_reg_polynomial(
             # Do polynomial interpolation of profile path
             # Determine rank of polynomial interpolation
             regression_tmp = np.polyfit(
-                current_profile.x_path[par_index, -1:-reg_points:-1],
-                current_profile.x_path[i_par, -1:-reg_points:-1],
+                current_profile.x_path[par_index, -reg_points:],
+                current_profile.x_path[i_par, -reg_points:],
                 reg_order,
                 full=True,
             )
@@ -365,8 +365,8 @@ def get_reg_polynomial(
             if regression_tmp[2] < reg_order:
                 reg_order = regression_tmp[2]
                 regression_tmp = np.polyfit(
-                    current_profile.x_path[par_index, -reg_points:-1],
-                    current_profile.x_path[i_par, -reg_points:-1],
+                    current_profile.x_path[par_index, -reg_points:],
+                    current_profile.x_path[i_par, -reg_points:],
                     int(reg_order),
                     full=True,
                 )


### PR DESCRIPTION
…_polynomial`

There seems to be an indexing error in `pypesto.profile.profile_next_guess.get_reg_polynomial`, resulting in too few points being used for extrapolating parameter trajectories. In the second case, not only too few, but also not the most recent parameter values are used.

Closes #1224