### PR TITLE
Renaming and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,13 @@
 # default owners
 * @ICB-DCM/pypesto-maintainers
 
+/doc/example/censored.ipynb @Doresic
 /doc/example/hdf5_storage.ipynb @PaulJonasJost
 /doc/example/hierarchical.ipynb @dilpath @dweindl
 /doc/example/julia.ipynb @PaulJonasJost
 /doc/example/model_selection.ipynb @dilpath
+/doc/example/nonlinear_monotone.ipynb @Doresic
+/doc/example/ordinal.ipynb @Doresic
 /doc/example/petab_import.ipynb @dweindl @FFroehlich
 /doc/example/sampler_study.ipynb @dilpath
 /doc/example/sampling_diagnostics.ipynb @dilpath
@@ -16,8 +19,9 @@
 /pypesto/engine/ @PaulJonasJost
 /pypesto/engine/mpi_pool.py @PaulJonasJost
 /pypesto/ensemble/ @dilpath @PaulJonasJost
-/pypesto/hierarchical/ @dweindl @doresic
-/pypesto/hierarchical/optimal_scaling_approach/ @doresic
+/pypesto/hierarchical/ @dweindl @Doresic
+/pypesto/hierarchical/optimal_scaling_approach/ @Doresic
+/pypesto/hierarchical/spline_approximation/ @Doresic
 /pypesto/history/ @PaulJonasJost
 /pypesto/objective/ @PaulJonasJost
 /pypesto/objective/amici/ @dweindl @FFroehlich

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ pyPESTO features include:
 * Parameter estimation with ordinal data as described in
   [Schmiester et al. (2020)](https://doi.org/10.1007/s00285-020-01522-w) and
   [Schmiester et al. (2021)](https://doi.org/10.1093/bioinformatics/btab512).
-  ([example](https://github.com/ICB-DCM/pyPESTO/blob/master/doc/example/example_ordinal.ipynb))
-* Parameter estimation with censored data. ([example](https://github.com/ICB-DCM/pyPESTO/blob/master/doc/example/example_censored.ipynb))
-* Parameter estimation with nonlinear-monotone data. ([example](https://github.com/ICB-DCM/pyPESTO/blob/master/doc/example/example_nonlinear_monotone.ipynb))
+  ([example](https://github.com/ICB-DCM/pyPESTO/blob/master/doc/example/ordinal.ipynb))
+* Parameter estimation with censored data. ([example](https://github.com/ICB-DCM/pyPESTO/blob/master/doc/example/censored.ipynb))
+* Parameter estimation with nonlinear-monotone data. ([example](https://github.com/ICB-DCM/pyPESTO/blob/master/doc/example/nonlinear_monotone.ipynb))
 
 ## Quick install
 

--- a/doc/example.rst
+++ b/doc/example.rst
@@ -52,9 +52,9 @@ Algorithms and features
    example/model_selection.ipynb
    example/julia.ipynb
    example/hierarchical.ipynb
-   example/example_ordinal.ipynb
-   example/example_censored.ipynb
-   example/example_nonlinear_monotone.ipynb
+   example/ordinal.ipynb
+   example/censored.ipynb
+   example/nonlinear_monotone.ipynb
 
 Application examples
 --------------------

--- a/doc/example/censored.ipynb
+++ b/doc/example/censored.ipynb
@@ -495,7 +495,7 @@
     "For censored measurements, the `measurement` column will be ignored. For the `Ybar` observable we didn't specify a measurement type, so those will be used as quantitative.\n",
     "\n",
     "#### Note on inclusion of additional data types:\n",
-    "It is possible to include observables with different types of data to the same `petab_problem`. Refer to the notebooks on using [nonlinear-monotone data](example_nonlinear_monotone.ipynb) and [ordinal data](example_ordinal.ipynb) for details on integration of other data types. Additionally, as shown in this example, if the `measurementType` column is left empty for all measurements of an observable, the observable will be treated as quantitative."
+    "It is possible to include observables with different types of data to the same `petab_problem`. Refer to the notebooks on using [nonlinear-monotone data](nonlinear_monotone.ipynb) and [ordinal data](ordinal.ipynb) for details on integration of other data types. Additionally, as shown in this example, if the `measurementType` column is left empty for all measurements of an observable, the observable will be treated as quantitative."
    ]
   },
   {

--- a/doc/example/nonlinear_monotone.ipynb
+++ b/doc/example/nonlinear_monotone.ipynb
@@ -606,7 +606,7 @@
    "metadata": {},
    "source": [
     "#### Note on inclusion of additional data types:\n",
-    "It is possible to include observables with different types of data to the same `petab_problem`. Refer to the notebooks on using [ordinal data](example_ordinal.ipynb) and [censored data](example_censored.ipynb) for details on integration of other data types. If the `measurementType` column is left empty for all measurements of an observable, the observable will be treated as quantitative."
+    "It is possible to include observables with different types of data to the same `petab_problem`. Refer to the notebooks on using [ordinal data](ordinal.ipynb) and [censored data](censored.ipynb) for details on integration of other data types. If the `measurementType` column is left empty for all measurements of an observable, the observable will be treated as quantitative."
    ]
   },
   {

--- a/doc/example/ordinal.ipynb
+++ b/doc/example/ordinal.ipynb
@@ -481,7 +481,7 @@
     "Measurements with a larger category number will be constrained to be higher in the ordering. Multiple measurements can be assigned to the same category. If this is done, these measurements will be treated as indistinguishable. \n",
     "\n",
     "#### Note on inclusion of additional data types:\n",
-    "It is possible to include observables with different types of data to the same `petab_problem`. Refer to the notebooks on using [nonlinear-monotone data](example_nonlinear_monotone.ipynb) and [censored data](example_censored.ipynb) for details on integration of other data types. If the `measurementType` column is left empty for all measurements of an observable, the observable will be treated as quantitative."
+    "It is possible to include observables with different types of data to the same `petab_problem`. Refer to the notebooks on using [nonlinear-monotone data](nonlinear_monotone.ipynb) and [censored data](censored.ipynb) for details on integration of other data types. If the `measurementType` column is left empty for all measurements of an observable, the observable will be treated as quantitative."
    ]
   },
   {

--- a/test/run_notebook.sh
+++ b/test/run_notebook.sh
@@ -25,8 +25,9 @@ nbs_1=(
   'store.ipynb'
   'synthetic_data.ipynb'
   'hierarchical.ipynb'
-  'example_ordinal.ipynb'
-  'example_nonlinear_monotone.ipynb'
+  'ordinal.ipynb'
+  'censored.ipynb'
+  'nonlinear_monotone.ipynb'
 )
 
 # Sampling notebooks


### PR DESCRIPTION
Updated CODEOWNERS with the nonlinear monotone stuff. Renamed the examples everywhere, removed the unnecessary `example_` part.