### PR TITLE
Hierarchical log space startpoint sampling

### DIFF
--- a/pypesto/hierarchical/solver.py
+++ b/pypesto/hierarchical/solver.py
@@ -303,10 +303,12 @@ class NumericalInnerSolver(InnerSolver):
         """Sample startpoints for the numerical optimization.
 
         Samples the startpoints for the numerical optimization from a
-        log-uniform distribution.
+        log-uniform distribution using the symmetric logarithmic scale.
 
         Parameters
         ----------
+        problem:
+            The inner problem to solve.
         pars:
             The inner parameters to sample startpoints for.
         Returns
@@ -332,19 +334,19 @@ class NumericalInnerSolver(InnerSolver):
             [x.ub if x.ub != np.inf else self.dummy_ub for x in pars]
         )
 
-        def log_transformation_function(x):
+        def symlog(x):
             return np.sign(x) * np.log10(np.abs(x) + 1)
 
-        def inverse_log_transformation_function(x):
-            return np.sign(x) * (10 ** np.abs(x) - 1)
+        def inverse_symlog(x):
+            return np.sign(x) * (np.power(10, np.abs(x)) - 1)
 
         # Sample startpoints from a log-uniform distribution
         startpoints = np.random.uniform(
-            low=log_transformation_function(lb),
-            high=log_transformation_function(ub),
+            low=symlog(lb),
+            high=symlog(ub),
             size=(n_samples, len(pars)),
         )
-        startpoints = inverse_log_transformation_function(startpoints)
+        startpoints = inverse_symlog(startpoints)
 
         # Stack the sampled startpoints with the cached startpoints
         if self.x_guesses is not None:

--- a/pypesto/hierarchical/solver.py
+++ b/pypesto/hierarchical/solver.py
@@ -311,6 +311,7 @@ class NumericalInnerSolver(InnerSolver):
             The inner problem to solve.
         pars:
             The inner parameters to sample startpoints for.
+
         Returns
         -------
         The sampled startpoints appended to the cached startpoints.

--- a/pypesto/hierarchical/solver.py
+++ b/pypesto/hierarchical/solver.py
@@ -335,19 +335,19 @@ class NumericalInnerSolver(InnerSolver):
             [x.ub if x.ub != np.inf else self.dummy_ub for x in pars]
         )
 
-        def symlog(x):
+        def symlog10(x):
             return np.sign(x) * np.log10(np.abs(x) + 1)
 
-        def inverse_symlog(x):
+        def inverse_symlog10(x):
             return np.sign(x) * (np.power(10, np.abs(x)) - 1)
 
         # Sample startpoints from a log-uniform distribution
         startpoints = np.random.uniform(
-            low=symlog(lb),
-            high=symlog(ub),
+            low=symlog10(lb),
+            high=symlog10(ub),
             size=(n_samples, len(pars)),
         )
-        startpoints = inverse_symlog(startpoints)
+        startpoints = inverse_symlog10(startpoints)
 
         # Stack the sampled startpoints with the cached startpoints
         if self.x_guesses is not None:

--- a/pypesto/hierarchical/solver.py
+++ b/pypesto/hierarchical/solver.py
@@ -299,7 +299,7 @@ class NumericalInnerSolver(InnerSolver):
 
     def sample_startpoints(
         self, problem: InnerProblem, pars: List[InnerParameter]
-    ):
+    )  -> np.array:
         """Sample startpoints for the numerical optimization.
 
         Samples the startpoints for the numerical optimization from a

--- a/pypesto/hierarchical/solver.py
+++ b/pypesto/hierarchical/solver.py
@@ -328,12 +328,8 @@ class NumericalInnerSolver(InnerSolver):
         if n_samples <= 0:
             return self.x_guesses
 
-        lb = np.array(
-            [x.lb if x.lb != -np.inf else self.dummy_lb for x in pars]
-        )
-        ub = np.array(
-            [x.ub if x.ub != np.inf else self.dummy_ub for x in pars]
-        )
+        lb = np.nan_to_num([x.lb for x in pars], neginf=self.dummy_lb)
+        ub = np.nan_to_num([x.ub for x in pars], posinf=self.dummy_ub)
 
         def symlog10(x):
             return np.sign(x) * np.log10(np.abs(x) + 1)

--- a/pypesto/hierarchical/solver.py
+++ b/pypesto/hierarchical/solver.py
@@ -299,7 +299,7 @@ class NumericalInnerSolver(InnerSolver):
 
     def sample_startpoints(
         self, problem: InnerProblem, pars: List[InnerParameter]
-    )  -> np.array:
+    ) -> np.ndarray:
         """Sample startpoints for the numerical optimization.
 
         Samples the startpoints for the numerical optimization from a


### PR DESCRIPTION
The numerical inner solver of the scaling+offset parameters has a multi-start option. However, the multi-start sampling was done in linear space. In this version, bounds of scaling and offset are not possible. Because of that [-1e20, 1e20] dummy bounds were introduced. But that resulted in the linear sampling having huge values, mostly in the order of 10^19. These startpoints would never converge, rendering the multi-start approach practically useless.

I've implemented sampling in log space for the numerical solver. The values can be negative, so I couldn't directly use pypesto's log sampling. So I used a symmetric logarithm function `np.sign(x) * np.log10(np.abs(x) + 1)` transformation which supports negative values, sampled in that space, and transformed the values back with its inverse `np.sign(x) * (10 ** np.abs(x) - 1)`.