### PR TITLE
Vis: Sacess history plot

### DIFF
--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -922,7 +922,9 @@ def get_default_ess_options(
     # Set local optimizer
     for cur_settings in settings:
         if local_optimizer is True:
-            cur_settings['local_optimizer'] = SacessFidesFactory()
+            cur_settings['local_optimizer'] = SacessFidesFactory(
+                fides_kwargs={"verbose": logging.WARNING}
+            )
         elif local_optimizer is not False:
             cur_settings['local_optimizer'] = local_optimizer
 

--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -54,6 +54,8 @@ class SacessOptimizer:
     histories:
         List of the histories of the best values/parameters
         found by each worker. (Monotonously decreasing objective values.)
+        See :func:`pypesto.visualize.optimizer_history.sacess_history` for
+        visualization.
     """
 
     def __init__(

--- a/pypesto/visualize/optimizer_history.py
+++ b/pypesto/visualize/optimizer_history.py
@@ -481,7 +481,6 @@ def handle_options(
 def sacess_history(
     histories: list[HistoryBase],
     ax: Optional[plt.Axes] = None,
-    legend_kwargs: dict = None,
 ) -> plt.Axes:
     """Plot `SacessOptimizer` history.
 
@@ -496,8 +495,6 @@ def sacess_history(
         :attr:`pypesto.optimize.ess.sacess.SacessOptimizer.histories`.
     ax:
         Axes object to use.
-    legend_kwargs:
-        Keyword arguments passed to :meth:`matplotlib.axes.Axes.legend`.
 
     Returns
     -------
@@ -544,8 +541,8 @@ def sacess_history(
         # even if redundant, so we can just skip the marker for the last point.
         for line in lines:
             line.set_markevery([True] * (len(x) - 1) + [False])
-    legend_kwargs = legend_kwargs or {}
-    ax.legend(**legend_kwargs)
+
+    ax.legend()
     ax.set_xlabel("time (s)")
     ax.set_ylabel("fval")
     ax.set_title("SacessOptimizer convergence")

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import os
 from functools import wraps
 from typing import Sequence
@@ -1167,3 +1168,17 @@ def test_time_trajectory_model():
 
     # test call of time_trajectory_model
     time_trajectory_model(result=result)
+
+
+@close_fig
+def test_sacess_history():
+    """Test pypesto.visualize.optimizer_history.sacess_history"""
+    from pypesto.optimize.ess.sacess import SacessOptimizer
+    from pypesto.visualize.optimizer_history import sacess_history
+
+    problem = create_problem()
+    sacess = SacessOptimizer(
+        max_walltime_s=1, num_workers=2, sacess_loglevel=logging.WARNING
+    )
+    sacess.minimize(problem)
+    sacess_history(sacess.histories)

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ description =
 # Unit tests
 
 [testenv:base]
-extras = test,test_petab,amici,petab,emcee,dynesty,mltools,aesara,pymc,jax
+extras = test,test_petab,amici,petab,emcee,dynesty,mltools,aesara,pymc,jax,fides
 deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
 commands =


### PR DESCRIPTION
Added `pypesto.visualize.optimizer_history.sacess_history` to visualize SacessOptimizer histories. In principle, they could be plotted the same as any other history, but here a step plot is usually preferable, and we show the global best in addition to all workers.