### PR TITLE
Fix test.util.load_amici_objective / AmiciVersionError

### DIFF
--- a/test/util.py
+++ b/test/util.py
@@ -305,7 +305,7 @@ def load_amici_objective(example_name):
     try:
         model_module = importlib.import_module(model_name)
         model = model_module.getModel()
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, amici.AmiciVersionError):
         # import sbml model, compile and generate amici module
         sbml_importer = amici.SbmlImporter(sbml_file)
         sbml_importer.sbml2amici(model_name, model_output_dir, verbose=False)


### PR DESCRIPTION
So far, after updating amici, test.util.load_amici_objective would fail with AmiciVersionError. In that case, we just want to re-import the model. That's what's achieved here.