### PR TITLE
GHA: Set mpl backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
 env:
   # use all available cores for compiling amici models
   AMICI_PARALLEL_COMPILE: ""
+  # non-interactive backend for matplotlib
+  MPLBACKEND: "agg"
 
 # jobs
 jobs:

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ envlist =
 # Base-environment
 
 [testenv]
-passenv = AMICI_PARALLEL_COMPILE,CC,CXX
+passenv = AMICI_PARALLEL_COMPILE,CC,CXX,MPLBACKEND
 
 # Sub-environments
 #  inherit settings defined in the base


### PR DESCRIPTION
Avoid such issues:
```
    fig = plt.figure()
.tox\windows\Lib\site-packages\matplotlib\pyplot.py:934: in figure
    manager = new_figure_manager(
.tox\windows\Lib\site-packages\matplotlib\pyplot.py:465: in new_figure_manager
    return _get_backend_mod().new_figure_manager(*args, **kwargs)
.tox\windows\Lib\site-packages\matplotlib\backend_bases.py:3402: in new_figure_manager
    return cls.new_figure_manager_given_figure(num, fig)
.tox\windows\Lib\site-packages\matplotlib\backend_bases.py:3407: in new_figure_manager_given_figure
    return cls.FigureCanvas.new_manager(figure, num)
.tox\windows\Lib\site-packages\matplotlib\backend_bases.py:1785: in new_manager
    return cls.manager_class.create_with_canvas(cls, figure, num)
.tox\windows\Lib\site-packages\matplotlib\backends\_backend_tk.py:486: in create_with_canvas
    window = tk.Tk(className="matplotlib")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tkinter.Tk object .>, screenName = None, baseName = 'pytest.EXE'
className = 'matplotlib', useTk = True, sync = False, use = None

    def __init__(self, screenName=None, baseName=None, className='Tk',
                 useTk=True, sync=False, use=None):
        """Return a new top level widget on screen SCREENNAME. A new Tcl interpreter will
        be created. BASENAME will be used for the identification of the profile file (see
        readprofile).
        It is constructed from sys.argv[0] without extensions if None is given. CLASSNAME
        is the name of the widget class."""
        self.master = None
        self.children = {}
        self._tkloaded = False
        # to avoid recursions in the getattr code in case of failure, we
        # ensure that self.tk is always _something_.
        self.tk = None
        if baseName is None:
            import os
            baseName = os.path.basename(sys.argv[0])
            baseName, ext = os.path.splitext(baseName)
            if ext not in ('.py', '.pyc'):
                baseName = baseName + ext
        interactive = False
>       self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
E       _tkinter.TclError: Can't find a usable tk.tcl in the following directories: 
E           C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tcl8.6/tk8.6 C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6 C:/hostedtoolcache/windows/Python/3.11.7/lib/tk8.6 C:/hostedtoolcache/windows/Python/3.11.7/lib/tk8.6 C:/hostedtoolcache/windows/Python/lib/tk8.6 C:/hostedtoolcache/windows/Python/3.11.7/library
E       
E       C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6/tk.tcl: couldn't read file "C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6/ttk/scrollbar.tcl": no such file or directory
E       couldn't read file "C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6/ttk/scrollbar.tcl": no such file or directory
E           while executing
E       "source -encoding utf-8 [file join $::ttk::library scrollbar.tcl]"
E           (file "C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6/ttk/ttk.tcl" line 102)
E           invoked from within
E       "source -encoding utf-8 C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6/ttk/ttk.tcl"
E           ("uplevel" body line 1)
E           invoked from within
E       "uplevel \#0 [list source -encoding utf-8 $::ttk::library/ttk.tcl]"
E           (file "C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6/tk.tcl" line 706)
E           invoked from within
E       "source C:/hostedtoolcache/windows/Python/3.11.7/x64/tcl/tk8.6/tk.tcl"
E           ("uplevel" body line 1)
E           invoked from within
E       "uplevel #0 [list source $file]"
E       
E       
E       This probably means that tk wasn't installed properly.

C:\hostedtoolcache\windows\Python\3.11.7\x64\Lib\tkinter\__init__.py:2326: TclError
```
e.g. here https://github.com/ICB-DCM/pyPESTO/actions/runs/7261863194/job/19783894242?pr=1243