### PR TITLE
Fix missing fixed parameters in scatter search results

### DIFF
--- a/pypesto/optimize/ess/cess.py
+++ b/pypesto/optimize/ess/cess.py
@@ -225,6 +225,7 @@ class CESSOptimizer:
             message="Global best",
             **common_result_fields,
         )
+        optimizer_result.update_to_full(problem)
         # TODO DW: Create a single History with the global best?
         result.optimize_result.append(optimizer_result)
 
@@ -241,6 +242,7 @@ class CESSOptimizer:
                         **common_result_fields,
                     )
                 )
+                result.optimize_result[-1].update_to_full(result.problem)
 
         # TODO DW: also save local solutions?
         #  (need to track fvals or re-evaluate)

--- a/pypesto/optimize/ess/ess.py
+++ b/pypesto/optimize/ess/ess.py
@@ -312,6 +312,7 @@ class ESSOptimizer:
             message="Global best",
             **common_result_fields,
         )
+        optimizer_result.update_to_full(result.problem)
         # TODO DW: Create a single History with the global best?
         result.optimize_result.append(optimizer_result)
 
@@ -327,6 +328,7 @@ class ESSOptimizer:
                     **common_result_fields,
                 )
             )
+            result.optimize_result[-1].update_to_full(result.problem)
 
         # TODO DW: also save local solutions?
         #  (need to track fvals or re-evaluate)


### PR DESCRIPTION
So far, the OptimizerResults from Ess/Cess/SacessOptimizer (incorrectly) contained only the estimated parameter values. Now, fixed parameters are included as well, as done for the other Optimizers.