### PR TITLE
Select: use petab_select method to set estimated parameters

### DIFF
--- a/pypesto/select/model_problem.py
+++ b/pypesto/select/model_problem.py
@@ -165,16 +165,22 @@ class ModelProblem:
         self.model.set_criterion(Criterion.NLLH, float(self.best_start.fval))
         self.model.compute_criterion(criterion=self.criterion)
 
-        self.model.estimated_parameters = {
+        estimated_parameters = {
             id: float(value)
             for index, (id, value) in enumerate(
-                zip(
-                    self.pypesto_problem.x_names,
-                    self.best_start.x,
-                )
+                dict(
+                    zip(
+                        self.pypesto_problem.x_names,
+                        self.best_start.x,
+                    )
+                ).items()
             )
             if index in self.pypesto_problem.x_free_indices
         }
+        self.model.set_estimated_parameters(
+            estimated_parameters=estimated_parameters,
+            scaled=True,
+        )
 
         if self.postprocessor is not None:
             self.postprocessor(self)


### PR DESCRIPTION
Possibly a breaking change, if users expect scaled values at `petab_select.Model.estimated_parameters`