### PR TITLE
Include pymc in the documentation.

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -24,6 +24,7 @@ API reference
    pypesto.profile.profile_next_guess
    pypesto.result
    pypesto.sample
+   pypesto.sample.pymc
    pypesto.select
    pypesto.select.postprocessors
    pypesto.startpoint

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,6 +150,7 @@ doc =
     %(petab)s
     %(aesara)s
     %(jax)s
+    %(pymc)s
 example =
     %(julia)s
     %(pymc)s


### PR DESCRIPTION
Pymc was not listed in the documentation.