### PR TITLE
Variational inference with PyMC

### DIFF
--- a/pypesto/sample/__init__.py
+++ b/pypesto/sample/__init__.py
@@ -16,3 +16,7 @@ from .parallel_tempering import ParallelTemperingSampler
 from .sample import sample
 from .sampler import InternalSampler, Sampler
 from .util import calculate_ci_mcmc_sample, calculate_ci_mcmc_sample_prediction
+from .variational_inference import (
+    eval_variational_log_density,
+    variational_fit,
+)

--- a/pypesto/sample/pymc.py
+++ b/pypesto/sample/pymc.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Union
+from typing import Optional, Union
 
 import arviz as az
 import numpy as np
@@ -220,10 +220,11 @@ class PymcSampler(Sampler):
         self,
         n_iterations: int,
         method: str = 'advi',
-        random_seed: int = None,
-        start_sigma=None,
-        inf_kwargs=None,
+        random_seed: Optional[int] = None,
+        start_sigma: Optional = None,
+        inf_kwargs: Optional = None,
         beta: float = 1.0,
+        **kwargs,
     ):
         """
         Sample the problem.
@@ -233,7 +234,7 @@ class PymcSampler(Sampler):
         n_iterations:
             Number of iterations.
         method: str or :class:`Inference`
-            string name is case insensitive in:
+            string name is case-insensitive in:
             -   'advi'  for ADVI
             -   'fullrank_advi'  for FullRankADVI
             -   'svgd'  for Stein Variational Gradient Descent
@@ -293,6 +294,7 @@ class PymcSampler(Sampler):
                 start=x0,
                 start_sigma=start_sigma,
                 inf_kwargs=inf_kwargs,
+                **kwargs,
             )
 
         self.data = data

--- a/pypesto/sample/pymc.py
+++ b/pypesto/sample/pymc.py
@@ -222,6 +222,7 @@ class PymcSampler(Sampler):
         method: str = 'advi',
         random_seed: int = None,
         start_sigma=None,
+        inf_kwargs=None,
         beta: float = 1.0,
     ):
         """
@@ -241,6 +242,10 @@ class PymcSampler(Sampler):
             random seed for reproducibility
         start_sigma: `dict[str, np.ndarray]`
             starting standard deviation for inference, only available for method 'advi'
+        inf_kwargs: dict
+            additional kwargs passed to pymc.Inference
+        beta:
+            Inverse temperature (e.g. in parallel tempering).
         """
         try:
             import pymc
@@ -282,11 +287,12 @@ class PymcSampler(Sampler):
 
             # perform the actual sampling
             data = pymc.fit(
-                draws=int(n_iterations),
+                n=int(n_iterations),
                 method=method,
-                start=x0,
                 random_seed=random_seed,
+                start=x0,
                 start_sigma=start_sigma,
+                inf_kwargs=inf_kwargs,
             )
 
         self.data = data

--- a/pypesto/sample/variational_inference.py
+++ b/pypesto/sample/variational_inference.py
@@ -129,7 +129,9 @@ def variational_fit(
     # return result
 
 
-def eval_log_density(x_points: np.ndarray, vi_approx) -> np.ndarray:
+def eval_variational_log_density(
+    x_points: np.ndarray, vi_approx
+) -> np.ndarray:
     """
     Evaluate the log density of the variational approximation at x_points.
 

--- a/pypesto/sample/variational_inference.py
+++ b/pypesto/sample/variational_inference.py
@@ -26,6 +26,7 @@ def variational_fit(
     result: Result = None,
     # filename: Union[str, Callable, None] = None,
     # overwrite: bool = False,
+    **kwargs,
 ) -> Result:
     """
     Call to do parameter sampling.
@@ -38,7 +39,7 @@ def variational_fit(
     n_iterations:
         Number of iterations for the optimization.
     method: str or :class:`Inference`
-        string name is case insensitive in:
+        string name is case-insensitive in:
             -   'advi'  for ADVI
             -   'fullrank_advi'  for FullRankADVI
             -   'svgd'  for Stein Variational Gradient Descent
@@ -50,10 +51,8 @@ def variational_fit(
     start_sigma: `dict[str, np.ndarray]`
         starting standard deviation for inference, only available for method 'advi'
     x0:
-        Initial parameter for the Markov chain. If None, the best parameter
-        found in optimization is used. Note that some samplers require an
-        initial parameter, some may ignore it. x0 can also be a list,
-        to have separate starting points for parallel tempering chains.
+        Initial parameter for the variational optimization. If None, the best parameter
+        found in optimization is used.
     result:
         A result to write to. If None provided, one is created from the
         problem.
@@ -102,6 +101,7 @@ def variational_fit(
         method=method,
         random_seed=random_seed,
         start_sigma=start_sigma,
+        **kwargs,
     )
     t_elapsed = process_time() - t_start
     logger.info("Elapsed time: " + str(t_elapsed))
@@ -144,10 +144,10 @@ def eval_variational_log_density(
     """
     if x_points.ndim == 1:
         x_points = x_points.reshape(1, -1)
-    density_at_points = np.zeros_like(x_points)
+    log_density_at_points = np.zeros_like(x_points)
     for i, point in enumerate(x_points):
-        density_at_points[i] = stats.multivariate_normal.pdf(
+        log_density_at_points[i] = stats.multivariate_normal.logpdf(
             point, mean=vi_approx.mean.eval(), cov=vi_approx.cov.eval()
         )
-    vi_log_density = np.sum(np.log(density_at_points), axis=-1)
+    vi_log_density = np.sum(log_density_at_points, axis=-1)
     return vi_log_density

--- a/pypesto/sample/variational_inference.py
+++ b/pypesto/sample/variational_inference.py
@@ -1,0 +1,151 @@
+import logging
+from time import process_time
+from typing import List, Optional, Union
+
+import numpy as np
+from scipy import stats
+
+from ..problem import Problem
+from ..result import Result
+
+# from ..store import autosave
+from .pymc import PymcSampler
+from .util import bound_n_samples_from_env
+
+logger = logging.getLogger(__name__)
+
+
+def variational_fit(
+    problem: Problem,
+    n_iterations: int,
+    method: str = 'advi',
+    # n_samples: Optional[int] = None,
+    random_seed: Optional[int] = None,
+    start_sigma: Optional[dict[str, np.ndarray]] = None,
+    x0: Union[np.ndarray, List[np.ndarray]] = None,
+    result: Result = None,
+    # filename: Union[str, Callable, None] = None,
+    # overwrite: bool = False,
+) -> Result:
+    """
+    Call to do parameter sampling.
+
+    Parameters
+    ----------
+    problem:
+        The problem to be solved. If None is provided, a
+        :class:`pypesto.AdaptiveMetropolisSampler` is used.
+    n_iterations:
+        Number of iterations for the optimization.
+    method: str or :class:`Inference`
+        string name is case insensitive in:
+            -   'advi'  for ADVI
+            -   'fullrank_advi'  for FullRankADVI
+            -   'svgd'  for Stein Variational Gradient Descent
+            -   'asvgd'  for Amortized Stein Variational Gradient Descent
+    n_samples:
+        Number of samples to generate after optimization.
+    random_seed: int
+        random seed for reproducibility
+    start_sigma: `dict[str, np.ndarray]`
+        starting standard deviation for inference, only available for method 'advi'
+    x0:
+        Initial parameter for the Markov chain. If None, the best parameter
+        found in optimization is used. Note that some samplers require an
+        initial parameter, some may ignore it. x0 can also be a list,
+        to have separate starting points for parallel tempering chains.
+    result:
+        A result to write to. If None provided, one is created from the
+        problem.
+    filename:
+        Name of the hdf5 file, where the result will be saved. Default is
+        None, which deactivates automatic saving. If set to
+        "Auto" it will automatically generate a file named
+        `year_month_day_profiling_result.hdf5`.
+        Optionally a method, see docs for `pypesto.store.auto.autosave`.
+    overwrite:
+        Whether to overwrite `result/sampling` in the autosave file
+        if it already exists.
+
+    Returns
+    -------
+    result:
+        A result with filled in sample_options part.
+    """
+    # prepare result object
+    if result is None:
+        result = Result(problem)
+
+    # number of samples
+    if n_iterations is not None:
+        n_iterations = bound_n_samples_from_env(n_iterations)
+
+    # try to find initial parameters
+    if x0 is None:
+        result.optimize_result.sort()
+        if len(result.optimize_result.list) > 0:
+            x0 = problem.get_reduced_vector(
+                result.optimize_result.list[0]['x']
+            )
+        # TODO multiple x0 for PT, #269
+
+    # set variational inference
+    variational_approx = PymcSampler()
+
+    # initialize sampler to problem
+    variational_approx.initialize(problem=problem, x0=x0)
+
+    # perform the sampling and track time
+    t_start = process_time()
+    variational_approx.fit(
+        n_iterations=n_iterations,
+        method=method,
+        random_seed=random_seed,
+        start_sigma=start_sigma,
+    )
+    t_elapsed = process_time() - t_start
+    logger.info("Elapsed time: " + str(t_elapsed))
+
+    # extract results
+    # todo: build variational result object
+    return variational_approx.data
+
+    # if n_samples is not None:
+    #     vi_result.samples = variational_approx.data.sample(n_samples)
+    #
+    # # record time
+    # vi_result.time = t_elapsed
+    #
+    # # record results
+    # result.vi_result = vi_result
+    #
+    # autosave(
+    #     filename=filename,
+    #     result=result,
+    #     store_type="variational",
+    #     overwrite=overwrite,
+    # )
+    #
+    # return result
+
+
+def eval_log_density(x_points: np.ndarray, vi_approx) -> np.ndarray:
+    """
+    Evaluate the log density of the variational approximation at x_points.
+
+    Parameters
+    ----------
+    x_points:
+        The points at which to evaluate the log density.
+    vi_approx:
+        The variational approximation object from PyMC.
+    """
+    if x_points.ndim == 1:
+        x_points = x_points.reshape(1, -1)
+    density_at_points = np.zeros_like(x_points)
+    for i, point in enumerate(x_points):
+        density_at_points[i] = stats.multivariate_normal.pdf(
+            point, mean=vi_approx.mean.eval(), cov=vi_approx.cov.eval()
+        )
+    vi_log_density = np.sum(np.log(density_at_points), axis=-1)
+    return vi_log_density


### PR DESCRIPTION
I added a wrapper for variational inference with `PyMC`. The wrapper uses the `PymcSampler` as basis and directly supports all functions and methods from `PyMC` [see here for details on VI](https://www.pymc.io/projects/examples/en/latest/variational_inference/variational_api_quickstart.html).

To include this properly in `pyPESTO` one would need to add proper testing and write a `Result Object` to save the estimated parameters of the variational distribution.