### PR TITLE
Semiquant: Fix spline inner parameter initial values

### DIFF
--- a/pypesto/hierarchical/semiquantitative/solver.py
+++ b/pypesto/hierarchical/semiquantitative/solver.py
@@ -1086,11 +1086,8 @@ def save_inner_parameters_to_inner_problem(
         group
     )
 
-    lower_trian = np.tril(np.ones((len(s), len(s))))
-    xi = np.dot(lower_trian, s)
-
     for idx in range(len(inner_spline_parameters)):
-        inner_spline_parameters[idx].value = xi[idx]
+        inner_spline_parameters[idx].value = s[idx]
 
     sigma = group_dict[INNER_NOISE_PARS]
 


### PR DESCRIPTION
Initial values of spline inner parameters of each optimization are set to end values of the previous inner optimization, if possible. However, the saving of previous inner parameters was saving the spline knot values, instead of the spline knot differences, which are the inner parameters.

This wasn't a big issue, as the initial values of the inner optimization are not that important (the problem is convex). But in some cases, they were so different that the inner solver stopped early.

Updated the visualization to work with the change.