### PR TITLE
Fix unwanted amici model recompilation

### DIFF
--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -353,7 +353,11 @@ class PetabImporter(AmiciObjectBuilder):
         # try to import (in particular checks version)
         try:
             # importing will already raise an exception if version wrong
-            importlib.import_module(self.model_name)
+            # importlib.import_module(self.model_name)
+            spec = importlib.machinery.PathFinder().find_spec(
+                self.model_name, [str(self.output_folder)]
+            )
+            importlib.util.module_from_spec(spec)
         except ModuleNotFoundError:
             return True
         except amici.AmiciVersionError as e:

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import logging
 import os
 import shutil
@@ -353,10 +352,7 @@ class PetabImporter(AmiciObjectBuilder):
         # try to import (in particular checks version)
         try:
             # importing will already raise an exception if version wrong
-            spec = importlib.machinery.PathFinder().find_spec(
-                self.model_name, [str(self.output_folder)]
-            )
-            importlib.util.module_from_spec(spec)
+            amici.import_model_module(self.model_name, self.output_folder)
         except ModuleNotFoundError:
             return True
         except amici.AmiciVersionError as e:

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -353,7 +353,6 @@ class PetabImporter(AmiciObjectBuilder):
         # try to import (in particular checks version)
         try:
             # importing will already raise an exception if version wrong
-            # importlib.import_module(self.model_name)
             spec = importlib.machinery.PathFinder().find_spec(
                 self.model_name, [str(self.output_folder)]
             )


### PR DESCRIPTION
changes:
- `PetabImporter` checks for existing amici model in the location specified by `output_folder` before re-compiling.
- closes #1318 