### PR TITLE
Dynesty warnings added

### DIFF
--- a/doc/example/sampler_study.ipynb
+++ b/doc/example/sampler_study.ipynb
@@ -590,7 +590,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampler = sample.DynestySampler()\n",
+    "sampler = sample.DynestySampler(objective_type=\"negloglike\")\n",
     "result = sample.sample(\n",
     "    problem=problem,\n",
     "    n_samples=None,\n",

--- a/pypesto/C.py
+++ b/pypesto/C.py
@@ -70,6 +70,8 @@ HESSP = "hessp"  # Hessian vector product
 RES = "res"  # residual
 SRES = "sres"  # residual sensitivities
 RDATAS = "rdatas"  # returned simulated data sets
+OBJECTIVE_NEGLOGPOST = "neglogpost"  # objective is negative log-posterior
+OBJECTIVE_NEGLOGLIKE = "negloglike"  # objective is negative log-likelihood
 
 TIME = "time"  # time
 N_FVAL = "n_fval"  # number of function evaluations

--- a/pypesto/sample/dynesty.py
+++ b/pypesto/sample/dynesty.py
@@ -176,13 +176,13 @@ class DynestySampler(Sampler):
         else:
             # if objective is the negative log likelihood, we will ignore x_priors even if they are defined
             if self.problem.x_priors is not None:
-                logger.info(
-                    f"Warning: Assuming '{OBJECTIVE_NEGLOGLIKE}' as objective. "
+                logger.warning(
+                    f"Assuming '{OBJECTIVE_NEGLOGLIKE}' as objective. "
                     f"'x_priors' defined in the problem will be ignored."
                 )
 
         # if priors are uniform, we can use the default prior transform (assuming that bounds are set correctly)
-        logger.info(
+        logger.warning(
             "Assuming 'prior_transform' is correctly specified. If 'x_priors' is not uniform, 'prior_transform'"
             " has to be adjusted accordingly."
         )

--- a/pypesto/sample/dynesty.py
+++ b/pypesto/sample/dynesty.py
@@ -62,7 +62,7 @@ class DynestySampler(Sampler):
         sampler_args: dict = None,
         run_args: dict = None,
         dynamic: bool = True,
-        objective: str = "neglogpost",
+        objective_type: str = "neglogpost",
     ):
         """
         Initialize sampler.
@@ -77,7 +77,7 @@ class DynestySampler(Sampler):
             method of the dynesty sampler.
         dynamic:
             Whether to use dynamic or static nested sampling.
-        objective:
+        objective_type:
             The objective to optimize (as defined in  pypesto.problem). Either "neglogpost" or "negloglike".
             If neglogpost, x_priors have to be defined in the problem.
         """
@@ -98,11 +98,11 @@ class DynestySampler(Sampler):
             run_args = {}
         self.run_args: dict = run_args
 
-        if objective not in ["neglogpost", "negloglike"]:
+        if objective_type not in ["neglogpost", "negloglike"]:
             raise ValueError(
                 "Objective has to be either 'neglogpost' or 'negloglike' as defined in pypesto.problem."
             )
-        self.objective = objective
+        self.objective_type = objective_type
 
         # set in initialize
         self.problem: Union[Problem, None] = None
@@ -164,7 +164,7 @@ class DynestySampler(Sampler):
             sampler_class = dynesty.DynamicNestedSampler
 
         # check if objective fits to the pyPESTO problem
-        if self.objective == "neglogpost":
+        if self.objective_type == "neglogpost":
             if self.problem.x_priors is None:
                 # objective is the negative log-posterior, but no priors are defined
                 # sampler need the likelihood

--- a/pypesto/sample/dynesty.py
+++ b/pypesto/sample/dynesty.py
@@ -167,7 +167,7 @@ class DynestySampler(Sampler):
         if self.objective_type == "neglogpost":
             if self.problem.x_priors is None:
                 # objective is the negative log-posterior, but no priors are defined
-                # sampler need the likelihood
+                # sampler needs the likelihood
                 raise ValueError(
                     "x_priors have to be defined in the problem if objective is 'neglogpost'."
                 )

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -727,7 +727,7 @@ def test_samples_cis():
 
 def test_dynesty_mcmc_samples():
     problem = gaussian_problem()
-    sampler = sample.DynestySampler(objective="negloglike")
+    sampler = sample.DynestySampler(objective_type="negloglike")
 
     result = sample.sample(
         problem=problem,
@@ -765,7 +765,7 @@ def test_dynesty_posterior():
     )
 
     # define sampler
-    sampler = sample.DynestySampler(objective="neglogpost")  # default
+    sampler = sample.DynestySampler(objective_type="neglogpost")  # default
 
     result = sample.sample(
         problem=test_problem,

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -12,6 +12,7 @@ import pypesto
 import pypesto.optimize as optimize
 import pypesto.petab
 import pypesto.sample as sample
+from pypesto.C import OBJECTIVE_NEGLOGLIKE, OBJECTIVE_NEGLOGPOST
 from pypesto.sample.pymc import PymcSampler
 
 
@@ -721,13 +722,13 @@ def test_samples_cis():
         assert (diff == 0).all()
         # check if lower bound is smaller than upper bound
         assert (lb < ub).all()
-        # check if dimmensions agree
+        # check if dimensions agree
         assert lb.shape == ub.shape
 
 
 def test_dynesty_mcmc_samples():
     problem = gaussian_problem()
-    sampler = sample.DynestySampler(objective_type="negloglike")
+    sampler = sample.DynestySampler(objective_type=OBJECTIVE_NEGLOGLIKE)
 
     result = sample.sample(
         problem=problem,
@@ -765,7 +766,9 @@ def test_dynesty_posterior():
     )
 
     # define sampler
-    sampler = sample.DynestySampler(objective_type="neglogpost")  # default
+    sampler = sample.DynestySampler(
+        objective_type=OBJECTIVE_NEGLOGPOST
+    )  # default
 
     result = sample.sample(
         problem=test_problem,

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -189,7 +189,7 @@ def sampler(request):
     elif request.param == "Emcee":
         return sample.EmceeSampler(nwalkers=10)
     elif request.param == "Dynesty":
-        return sample.DynestySampler()
+        return sample.DynestySampler(objective_type="negloglike")
 
 
 @pytest.fixture(params=["gaussian", "gaussian_mixture", "rosenbrock"])


### PR DESCRIPTION
The wrapper for the dynesty sampler differs significantly to the other samplers in pyPESTO. Usually the samplers expect the objective to be the posterior and `x_priors` to be defined, from which they compute the likelihood if needed. I added the argument `objective_type` to the sampler to switch between posterior and likelihood with default set to posterior. I also added checks in the `initialize` function to very if `x_priors` is defined in the problem or not.

Furthermore, I added a warning that by default, a uniform prior with bounds specified in the problem is assumed. This warning was missing, but already mentioned in the `prior_transform` function.