### PR TITLE
Adding Thermodynamic Integration

### DIFF
--- a/pypesto/C.py
+++ b/pypesto/C.py
@@ -256,6 +256,13 @@ LOG_UNIFORM = "logUniform"
 LOG_NORMAL = "logNormal"
 LOG_LAPLACE = "logLaplace"
 
+###############################################################################
+# SAMPLING
+
+EXPONENTIAL_DECAY = (
+    "exponential_decay"  # temperature schedule for parallel tempering
+)
+BETA_DECAY = "beta_decay"  # temperature schedule for parallel tempering
 
 ###############################################################################
 # PREDICT

--- a/pypesto/sample/adaptive_parallel_tempering.py
+++ b/pypesto/sample/adaptive_parallel_tempering.py
@@ -4,6 +4,7 @@ from typing import Dict, Sequence
 
 import numpy as np
 
+from ..C import EXPONENTIAL_DECAY
 from .parallel_tempering import ParallelTemperingSampler
 
 
@@ -36,6 +37,8 @@ class AdaptiveParallelTemperingSampler(ParallelTemperingSampler):
         # controls the adaptation degeneration velocity of the temperature
         # adaption.
         options["nu"] = 1e3
+        # initial temperature schedule as in Vousden et. al. 2016.
+        options["beta_init"] = EXPONENTIAL_DECAY
 
         return options
 

--- a/pypesto/sample/adaptive_parallel_tempering.py
+++ b/pypesto/sample/adaptive_parallel_tempering.py
@@ -5,6 +5,7 @@ from typing import Dict, Sequence
 import numpy as np
 
 from ..C import EXPONENTIAL_DECAY
+from ..result import Result
 from .parallel_tempering import ParallelTemperingSampler
 
 
@@ -64,3 +65,20 @@ class AdaptiveParallelTemperingSampler(ParallelTemperingSampler):
 
         # fill in
         self.betas = betas
+
+    def compute_log_evidence(
+        self, result: Result, method: str = "trapezoid"
+    ) -> float:
+        """Perform thermodynamic integration to estimate the log evidence.
+
+        Parameters
+        ----------
+        result:
+            Result object containing the samples.
+        method:
+            Integration method, either 'trapezoid' or 'simpson' (uses scipy for integration).
+        """
+        raise NotImplementedError(
+            "Thermodynamic integration is not implemented for adaptive parallel tempering, "
+            "since the temperature schedule is adapted during the sampling process."
+        )

--- a/pypesto/sample/parallel_tempering.py
+++ b/pypesto/sample/parallel_tempering.py
@@ -173,10 +173,10 @@ class ParallelTemperingSampler(Sampler):
     def adjust_betas(self, i_sample: int, swapped: Sequence[bool]):
         """Adjust temperature values. Default: Do nothing."""
 
-    def thermodynamic_integration(
+    def compute_log_evidence(
         self, result: Result, method: str = "trapezoid"
     ) -> float:
-        """Perform thermodynamic integration to estimate the evidence.
+        """Perform thermodynamic integration to estimate the log evidence.
 
         Parameters
         ----------

--- a/pypesto/sample/parallel_tempering.py
+++ b/pypesto/sample/parallel_tempering.py
@@ -54,7 +54,7 @@ class ParallelTemperingSampler(Sampler):
                 max_temp=self.options["max_temp"],
             )
         elif betas is None and self.options["beta_init"] == BETA_DECAY:
-            betas = beta_decay_for_beta(
+            betas = beta_decay_betas(
                 n_chains=n_chains, alpha=self.options["alpha"]
             )
         if betas[0] != 1.0:
@@ -216,7 +216,7 @@ class ParallelTemperingSampler(Sampler):
         return log_evidence
 
 
-def beta_decay_for_beta(n_chains: int, alpha: float) -> np.ndarray:
+def beta_decay_betas(n_chains: int, alpha: float) -> np.ndarray:
     """Initialize betas to the (j-1)th quantile of a Beta(alpha, 1) distribution.
 
     Proposed by Xie et al. (2011) to be used for thermodynamic integration.

--- a/pypesto/sample/parallel_tempering.py
+++ b/pypesto/sample/parallel_tempering.py
@@ -48,12 +48,14 @@ class ParallelTemperingSampler(Sampler):
         if (betas is None) == (n_chains is None):
             raise ValueError("Set either betas or n_chains.")
         if betas is None and self.options["beta_init"] == EXPONENTIAL_DECAY:
+            logger.info('Initializing betas with "near-exponential decay".')
             betas = near_exponential_decay_betas(
                 n_chains=n_chains,
                 exponent=self.options["exponent"],
                 max_temp=self.options["max_temp"],
             )
         elif betas is None and self.options["beta_init"] == BETA_DECAY:
+            logger.info('Initializing betas with "beta decay".')
             betas = beta_decay_betas(
                 n_chains=n_chains, alpha=self.options["alpha"]
             )

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -750,6 +750,7 @@ def test_thermodynamic_integration():
     # test thermodynamic integration
     problem = gaussian_problem()
 
+    # approximation should be better for more chains
     for n_chains, tol in zip([10, 20], [1, 1e-1]):
         sampler = sample.ParallelTemperingSampler(
             internal_sampler=sample.AdaptiveMetropolisSampler(),

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -770,10 +770,8 @@ def test_thermodynamic_integration():
         )
 
         # compute the log evidence using trapezoid and simpson rule
-        log_evidence = sampler.thermodynamic_integration(
-            result, method="trapezoid"
-        )
-        log_evidence_simps = sampler.thermodynamic_integration(
+        log_evidence = sampler.compute_log_evidence(result, method="trapezoid")
+        log_evidence_simps = sampler.compute_log_evidence(
             result, method="simpson"
         )
 

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -6,6 +6,7 @@ import numpy as np
 import petab
 import pytest
 import scipy.optimize as so
+from scipy.integrate import quad
 from scipy.stats import ks_2samp, kstest, multivariate_normal, norm, uniform
 
 import pypesto
@@ -743,3 +744,46 @@ def test_dynesty_mcmc_samples():
     assert (np.diff(original_sample_result.trace_neglogpost) <= 0).all()
     # MCMC samples are not
     assert not (np.diff(mcmc_sample_result.trace_neglogpost) <= 0).all()
+
+
+def test_thermodynamic_integration():
+    # test thermodynamic integration
+    problem = gaussian_problem()
+
+    for n_chains, tol in zip([10, 20], [1, 1e-1]):
+        sampler = sample.ParallelTemperingSampler(
+            internal_sampler=sample.AdaptiveMetropolisSampler(),
+            options={"show_progress": False, "beta_init": "beta_decay"},
+            n_chains=n_chains,
+        )
+
+        result = optimize.minimize(
+            problem,
+            progress_bar=False,
+        )
+
+        result = sample.sample(
+            problem,
+            n_samples=5000,
+            result=result,
+            sampler=sampler,
+        )
+
+        # compute the log evidence using trapezoid and simpson rule
+        log_evidence = sampler.thermodynamic_integration(
+            result, method="trapezoid"
+        )
+        log_evidence_simps = sampler.thermodynamic_integration(
+            result, method="simpson"
+        )
+
+        # compute evidence
+        evidence = quad(
+            lambda x: 1 / (problem.ub - problem.lb) * np.exp(gaussian_llh(x)),
+            a=problem.lb,
+            b=problem.ub,
+        )
+
+        # compare to known value
+        assert np.isclose(log_evidence, np.log(evidence[0]), atol=tol)
+        assert np.isclose(log_evidence_simps, np.log(evidence[0]), atol=tol)


### PR DESCRIPTION
I added a small function `compute_log_evidence` to the `ParallelTemperingSampler` which allows one to compute the log-evidence of a model after sampling. This is based on thermodynamic integration, which computes the integral over the mean log likelihood, where the mean is taken over the samples from the tempered posteriors. Usually a different temperature schedule is used with thermodynamic integration, which can be added as an option during sampling by
```
sampler = sample.ParallelTemperingSampler(
            internal_sampler=sample.AdaptiveMetropolisSampler(),
            options={"beta_init": "beta_decay"},
            n_chains=n_chains,
)
```

The evidence can be calculated by
```
 log_evidence = compute_log_evidence(result)
```