### PR TITLE
Semiquantitative: fix inner opt tolerance 

### DIFF
--- a/pypesto/hierarchical/inner_calculator_collector.py
+++ b/pypesto/hierarchical/inner_calculator_collector.py
@@ -240,6 +240,10 @@ class InnerCalculatorCollector(AmiciCalculator):
                 ):
                     condition_mask[inner_par.ixs[cond_idx]] = False
 
+        # Put to False all entries that have a nan value in the edata
+        for condition_mask, edata in zip(quantitative_data_mask, edatas):
+            condition_mask[np.isnan(edata)] = False
+
         # If there is no quantitative data, return None
         if not all(mask.any() for mask in quantitative_data_mask):
             return None

--- a/pypesto/hierarchical/semiquantitative/solver.py
+++ b/pypesto/hierarchical/semiquantitative/solver.py
@@ -580,7 +580,7 @@ class SemiquantInnerSolver(InnerSolver):
         inner_options = {
             "x0": x0,
             "method": "L-BFGS-B",
-            "options": {"ftol": 1e-16, "disp": None},
+            "options": {"disp": None},
             "bounds": Bounds(lb=constraint_min_diff),
         }
 


### PR DESCRIPTION
The default tolerance for the inner optimization of semiquantitative observables was set too low. Setting it to the default L-BFGS-B tolerances.

Additionally, there was a small bug in the inner calculator collector: the `quantitative_data_mask` of the edatas was not taking into account that some entries of edatas can be nan. This led to some failures and nan values in the calculation of the quantitative result.