### PR TITLE
Relative: Fix return of inner parameters on objective call

### DIFF
--- a/pypesto/hierarchical/inner_calculator_collector.py
+++ b/pypesto/hierarchical/inner_calculator_collector.py
@@ -112,7 +112,6 @@ class InnerCalculatorCollector(AmiciCalculator):
 
     def initialize(self):
         """Initialize."""
-        self.best_fval = np.inf
         for calculator in self.inner_calculators:
             calculator.initialize()
 
@@ -125,7 +124,6 @@ class InnerCalculatorCollector(AmiciCalculator):
     ):
         """Construct inner calculators for each data type."""
         self.necessary_par_dummy_values = {}
-        self.best_fval = np.inf
 
         if RELATIVE in self.data_types:
             relative_inner_problem = RelativeInnerProblem.from_petab_amici(
@@ -382,9 +380,6 @@ class InnerCalculatorCollector(AmiciCalculator):
                 parameter_mapping=parameter_mapping,
                 fim_for_hess=fim_for_hess,
             )
-            # only return inner parameters if the objective value improved
-            if ret[FVAL] > self.best_fval:
-                ret[INNER_PARAMETERS] = None
             return filter_return_dict(ret)
 
         # get dimension of outer problem
@@ -517,16 +512,12 @@ class InnerCalculatorCollector(AmiciCalculator):
             RDATAS: rdatas,
         }
 
-        # Add inner parameters to return dict
-        # only if the objective value improved.
-        if ret[FVAL] < self.best_fval:
-            ret[SPLINE_KNOTS] = spline_knots
-            ret[INNER_PARAMETERS] = (
-                interpretable_inner_pars
-                if len(interpretable_inner_pars) > 0
-                else None
-            )
-            self.best_fval = ret[FVAL]
+        ret[INNER_PARAMETERS] = (
+            interpretable_inner_pars
+            if len(interpretable_inner_pars) > 0
+            else None
+        )
+        ret[SPLINE_KNOTS] = spline_knots
 
         return filter_return_dict(ret)
 

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -10,11 +10,9 @@ import numpy as np
 
 from ...C import (
     FVAL,
-    INNER_PARAMETERS,
     MODE_FUN,
     MODE_RES,
     RDATAS,
-    SPLINE_KNOTS,
     SUFFIXES_CSV,
     SUFFIXES_HDF5,
     ModeType,
@@ -232,10 +230,6 @@ class AmiciObjective(ObjectiveBase):
         # Custom (condition-specific) timepoints. See the
         # `set_custom_timepoints` method for more information.
         self.custom_timepoints = None
-
-        # Initialize the list for saving of inner parameter values.
-        self.inner_parameters: list[float] = None
-        self.spline_knots: list[list[list[float]]] = None
 
     def get_config(self) -> dict:
         """Return basic information of the objective configuration."""
@@ -503,11 +497,6 @@ class AmiciObjective(ObjectiveBase):
 
         nllh = ret[FVAL]
         rdatas = ret[RDATAS]
-        if ret.get(INNER_PARAMETERS, None) is not None:
-            self.inner_parameters = ret[INNER_PARAMETERS]
-
-        if ret.get(SPLINE_KNOTS, None) is not None:
-            self.spline_knots = ret[SPLINE_KNOTS]
 
         # check whether we should update data for preequilibration guesses
         if (

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -14,7 +14,7 @@ import scipy.optimize
 from ..C import FVAL, GRAD, INNER_PARAMETERS, MODE_FUN, MODE_RES, SPLINE_KNOTS
 from ..history import HistoryOptions, NoHistory, OptimizerHistory
 from ..objective import Objective
-from ..problem import Problem
+from ..problem import HierarchicalProblem, Problem
 from ..result import OptimizerResult
 from .load import fill_result_from_history
 from .options import OptimizeOptions
@@ -61,18 +61,17 @@ def hierarchical_decorator(minimize):
             optimize_options=optimize_options,
         )
 
-        # add inner parameters
-        if (
-            hasattr(problem.objective, INNER_PARAMETERS)
-            and problem.objective.inner_parameters is not None
-        ):
-            result[INNER_PARAMETERS] = problem.objective.inner_parameters
-
-        if (
-            hasattr(problem.objective, SPLINE_KNOTS)
-            and problem.objective.spline_knots is not None
-        ):
-            result[SPLINE_KNOTS] = problem.objective.spline_knots
+        if isinstance(problem, HierarchicalProblem):
+            # Call the objective to obtain inner parameters of
+            # the optimal outer optimization parameters
+            return_dict = problem.objective(
+                result.x,
+                return_dict=True,
+            )
+            if INNER_PARAMETERS in return_dict:
+                result[INNER_PARAMETERS] = return_dict[INNER_PARAMETERS]
+            if SPLINE_KNOTS in return_dict:
+                result[SPLINE_KNOTS] = return_dict[SPLINE_KNOTS]
 
         return result
 

--- a/pypesto/visualize/model_fit.py
+++ b/pypesto/visualize/model_fit.py
@@ -17,9 +17,8 @@ from amici.petab_objective import rdatas_to_simulation_df
 from petab.visualize import plot_problem
 
 from ..C import CENSORED, ORDINAL, RDATAS, SEMIQUANTITATIVE
-from ..hierarchical.relative.calculator import RelativeAmiciCalculator
 from ..petab.importer import get_petab_non_quantitative_data_types
-from ..problem import Problem
+from ..problem import HierarchicalProblem, Problem
 from ..result import Result
 from .ordinal_categories import plot_categories_from_pypesto_result
 from .spline_approximation import _add_spline_mapped_simulations_to_model_fit
@@ -241,7 +240,7 @@ def _get_simulation_rdatas(
     parameters = problem.get_reduced_vector(parameters)
 
     # simulate with custom timepoints for hierarchical model
-    if isinstance(problem.objective.calculator, RelativeAmiciCalculator):
+    if isinstance(problem, HierarchicalProblem):
         # get parameter dictionary
         x_dct = dict(
             zip(problem.x_names, result.optimize_result.list[start_index].x)
@@ -253,8 +252,10 @@ def _get_simulation_rdatas(
         )
 
         # update parameter dictionary with inner parameters
-        inner_parameters = ret["inner_parameters"]
-        x_dct.update(inner_parameters)
+        inner_parameter_dict = dict(
+            zip(problem.inner_x_names, ret["inner_parameters"])
+        )
+        x_dct.update(inner_parameter_dict)
 
         parameter_mapping = problem.objective.parameter_mapping
         edatas = copy.deepcopy(problem.objective.edatas)


### PR DESCRIPTION
There was as bad implementation of inner parameter returning on call of objective.
Previously, the `InnerCalculatorCollector` would take note of `self.best_fval` such that it returns `inner_parameters` only in cases a better objective function value was found. This was ok during optimization, but then if one wanted to get inner parameters for some other outer parameter vector for which the objective function would not be better, the inner parameters would not be returned. 

This is bad practice: to save current states in the calculator and objective objects. So now, after an optimization start is finished, the `hierarchical_decorator` instead calls the objective once more with the best outer parameters found to obtain the inner parameters for that outer vector.

There some small update in the visualize of `model_fit.time_trajectory_model`. Was not working with the current implementation due to recent hierarchical structure changes.