### PR TITLE
Require scipy<1.13.0 for pypesto[pymc]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,7 @@ mpi =
     mpi4py >= 3.0.3
 pymc =
     arviz >= 0.12.1
+    scipy < 1.13.0 # https://github.com/ICB-DCM/pyPESTO/issues/1354
     aesara >= 2.8.6
     pymc >= 4.2.1
 aesara =


### PR DESCRIPTION
See #1354.