### PR TITLE
Fix Chain Burn-in Calculation in Thermodynamic Integration

### DIFF
--- a/pypesto/sample/diagnostics.py
+++ b/pypesto/sample/diagnostics.py
@@ -11,7 +11,9 @@ from .geweke_test import burn_in_by_sequential_geweke
 logger = logging.getLogger(__name__)
 
 
-def geweke_test(result: Result, zscore: float = 2.0) -> int:
+def geweke_test(
+    result: Result, zscore: float = 2.0, chain_number: int = 0
+) -> int:
     """
     Calculate the burn-in of MCMC chains.
 
@@ -21,6 +23,9 @@ def geweke_test(result: Result, zscore: float = 2.0) -> int:
         The pyPESTO result object with filled sample result.
     zscore:
         The Geweke test threshold.
+    chain_number:
+        The chain number to be used for the Geweke test (in a parallel tempering setting).
+        Usually we are only interested in the first chain.
 
     Returns
     -------
@@ -29,16 +34,17 @@ def geweke_test(result: Result, zscore: float = 2.0) -> int:
         do not differ significantly regarding Geweke test -> Burn-In
     """
     # Get parameter samples as numpy arrays
-    chain = np.asarray(result.sample_result.trace_x[0])
+    chain = np.asarray(result.sample_result.trace_x[chain_number])
 
     # Calculate burn in index
     burn_in = burn_in_by_sequential_geweke(chain=chain, zscore=zscore)
 
-    # Log
-    logger.info(f"Geweke burn-in index: {burn_in}")
+    if chain_number == 0:
+        # Log
+        logger.info(f"Geweke burn-in index: {burn_in}")
 
-    # Fill in burn-in value into result
-    result.sample_result.burn_in = burn_in
+        # Fill in burn-in value into result
+        result.sample_result.burn_in = burn_in
 
     return burn_in
 

--- a/pypesto/sample/parallel_tempering.py
+++ b/pypesto/sample/parallel_tempering.py
@@ -206,7 +206,7 @@ class ParallelTemperingSampler(Sampler):
 
             if (
                 burn_in_i < result.sample_result.trace_x.shape[1]
-                or i_chain == len(self.betas) - 1
+                or self.betas[i_chain] == 0
             ):
                 # save temperature-chain as it is converged
                 # last chain converges always, only samples from prior

--- a/pypesto/sample/parallel_tempering.py
+++ b/pypesto/sample/parallel_tempering.py
@@ -179,8 +179,11 @@ class ParallelTemperingSampler(Sampler):
         """Adjust temperature values. Default: Do nothing."""
 
     def compute_log_evidence(
-        self, result: Result, method: str = "trapezoid"
-    ) -> float:
+        self,
+        result: Result,
+        method: str = "trapezoid",
+        use_all_chains: bool = True,
+    ) -> Union[float, None]:
         """Perform thermodynamic integration to estimate the log evidence.
 
         Parameters
@@ -189,6 +192,10 @@ class ParallelTemperingSampler(Sampler):
             Result object containing the samples.
         method:
             Integration method, either 'trapezoid' or 'simpson' (uses scipy for integration).
+        use_all_chains:
+            If True, calculate burn-in for each chain and use the maximal burn-in for all chains for the integration.
+            This will fail if not all chains have converged yet.
+            Otherwise, use only the converged chains for the integration (might increase the integration error).
         """
         from scipy.integrate import simpson, trapezoid
 
@@ -198,34 +205,62 @@ class ParallelTemperingSampler(Sampler):
                 f"Carefully check the results. Consider using beta_init='{BETA_DECAY}' for better results."
             )
 
-        # compute burn in for all chains and then estimate mean of log likelihood for each beta
-        mean_loglike_per_beta = []
-        temps = []
-        for i_chain in reversed(range(len(self.betas))):
-            burn_in_i = geweke_test(result, chain_number=i_chain)
+        # compute burn in for all chains but the last one (prior only)
+        burn_ins = np.zeros(len(self.betas), dtype=int)
+        for i_chain in range(len(self.betas)):
+            burn_ins[i_chain] = geweke_test(result, chain_number=i_chain)
+        max_burn_in = int(np.max(burn_ins))
 
-            if (
-                burn_in_i < result.sample_result.trace_x.shape[1]
-                or self.betas[i_chain] == 0
-            ):
-                # save temperature-chain as it is converged
-                # last chain converges always, only samples from prior
-                temps.append(i_chain)
-                trace_loglike_i = (
-                    result.sample_result.trace_neglogprior[i_chain, burn_in_i:]
-                    - result.sample_result.trace_neglogpost[
-                        i_chain, burn_in_i:
-                    ]
+        if max_burn_in >= result.sample_result.trace_x.shape[1]:
+            logger.warning(
+                f"At least {np.sum(burn_ins >= result.sample_result.trace_x.shape[1])} chains seem to not have "
+                f"converged yet. You may want to use a larger number of samples."
+            )
+            if use_all_chains:
+                raise ValueError(
+                    "Not all chains have converged yet. You may want to use a larger number of samples, "
+                    "or try ´use_all_chains=False´, which might increase the integration error."
                 )
-                mean_loglike_per_beta.append(np.mean(trace_loglike_i))
+
+        if use_all_chains:
+            # estimate mean of log likelihood for each beta
+            trace_loglike = (
+                result.sample_result.trace_neglogprior[::-1, max_burn_in:]
+                - result.sample_result.trace_neglogpost[::-1, max_burn_in:]
+            )
+            mean_loglike_per_beta = np.mean(trace_loglike, axis=1)
+            temps = self.betas[::-1]
+        else:
+            # estimate mean of log likelihood for each beta if chain has converged
+            mean_loglike_per_beta = []
+            temps = []
+            for i_chain in reversed(range(len(self.betas))):
+                if burn_ins[i_chain] < result.sample_result.trace_x.shape[1]:
+                    # save temperature-chain as it is converged
+                    temps.append(self.betas[i_chain])
+                    # calculate mean log likelihood for each beta
+                    trace_loglike_i = (
+                        result.sample_result.trace_neglogprior[
+                            i_chain, burn_ins[i_chain] :
+                        ]
+                        - result.sample_result.trace_neglogpost[
+                            i_chain, burn_ins[i_chain] :
+                        ]
+                    )
+                    mean_loglike_per_beta.append(np.mean(trace_loglike_i))
 
         if method == "trapezoid":
             log_evidence = trapezoid(
-                y=mean_loglike_per_beta, x=self.betas[::-1]
+                # integrate from low to high temperature
+                y=mean_loglike_per_beta,
+                x=temps,
             )
         elif method == "simpson":
             log_evidence = simpson(
-                y=mean_loglike_per_beta, x=self.betas[::-1], even="last"
+                # integrate from low to high temperature
+                y=mean_loglike_per_beta,
+                x=temps,
+                even="last",
             )
         else:
             raise ValueError(

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -787,6 +787,7 @@ def test_dynesty_posterior():
     assert not (np.diff(mcmc_sample_result.trace_neglogpost) <= 0).all()
 
 
+@pytest.mark.flaky(reruns=2)  # sometimes not all chains converge
 def test_thermodynamic_integration():
     # test thermodynamic integration
     problem = gaussian_problem()
@@ -806,13 +807,16 @@ def test_thermodynamic_integration():
 
         result = sample.sample(
             problem,
-            n_samples=5000,
+            n_samples=10000,
             result=result,
             sampler=sampler,
         )
 
         # compute the log evidence using trapezoid and simpson rule
         log_evidence = sampler.compute_log_evidence(result, method="trapezoid")
+        log_evidence_not_all = sampler.compute_log_evidence(
+            result, method="trapezoid", use_all_chains=False
+        )
         log_evidence_simps = sampler.compute_log_evidence(
             result, method="simpson"
         )
@@ -826,4 +830,5 @@ def test_thermodynamic_integration():
 
         # compare to known value
         assert np.isclose(log_evidence, np.log(evidence[0]), atol=tol)
+        assert np.isclose(log_evidence_not_all, np.log(evidence[0]), atol=tol)
         assert np.isclose(log_evidence_simps, np.log(evidence[0]), atol=tol)


### PR DESCRIPTION
Several weeks ago, I introduced a function to calculate the log evidence from a parallel tempering run using thermodynamic integration. Initially, only the first chain was assessed for convergence and the burn-in was determined. Now, I've enhanced the process by computing the burn-in individually for each chain, enhancing the validity and accuracy of the approximation.