### PR TITLE
Add support for complex noise formulae in roadrunner

### DIFF
--- a/pypesto/objective/roadrunner/petab_importer_roadrunner.py
+++ b/pypesto/objective/roadrunner/petab_importer_roadrunner.py
@@ -103,12 +103,6 @@ class PetabImporterRR:
                 pattern = r"noiseParameter1_(.*?)($|\s)"
                 observable_name = re.search(pattern, noise_formula).group(1)
                 to_change.append((i_edata, j_formula, observable_name))
-
-                # raise NotImplementedError(
-                #     "Noise formulae must be either constants or single "
-                #     "parameters. For more complex noise models, please "
-                #     "use amici for now."
-                # )
         # change formulae
         formulae_changed = []
         for i_edata, j_formula, obs_name in to_change:

--- a/pypesto/objective/roadrunner/petab_importer_roadrunner.py
+++ b/pypesto/objective/roadrunner/petab_importer_roadrunner.py
@@ -112,7 +112,7 @@ class PetabImporterRR:
                 j_formula
             ] = f"noiseFormula_{obs_name}"
             # different conditions will have the same noise formula
-            try:
+            if (obs_name, original_formula) not in formulae_changed:
                 self.rr.addParameter(f"noiseFormula_{obs_name}", 0.0, False)
                 self.rr.addAssignmentRule(
                     f"noiseFormula_{obs_name}",
@@ -121,9 +121,6 @@ class PetabImporterRR:
                 )
                 self.rr.regenerateModel()
                 formulae_changed.append((obs_name, original_formula))
-            except RuntimeError as e:
-                if (obs_name, original_formula) not in formulae_changed:
-                    raise e
 
     def _write_observables_to_model(self):
         """Write observables of petab problem to the model."""

--- a/pypesto/objective/roadrunner/roadrunner_calculator.py
+++ b/pypesto/objective/roadrunner/roadrunner_calculator.py
@@ -230,7 +230,7 @@ class RoadRunnerCalculator:
             times=timepoints, selections=[TIME] + observables_ids
         )
 
-        llhs = calculate_llh(sim_res, edata, par_map)
+        llhs = calculate_llh(sim_res, edata, par_map, roadrunner_instance)
 
         # reset the model
         roadrunner_instance.reset()
@@ -349,6 +349,7 @@ def calculate_llh(
     simulations: np.ndarray,
     edata: ExpData,
     parameter_mapping: dict,
+    roadrunner_instance: roadrunner.RoadRunner,
 ) -> float:
     """Calculate the negative log-likelihood for a single condition.
 
@@ -360,6 +361,8 @@ def calculate_llh(
         ExpData of a single condition.
     parameter_mapping:
         Parameter mapping for the condition.
+    roadrunner_instance:
+        RoadRunner instance. Needed to retrieve complex formulae.
 
     Returns
     -------
@@ -390,6 +393,9 @@ def calculate_llh(
         # if it is not a number, it is assumed to be a string
         if noise_formula in parameter_mapping.keys():
             return parameter_mapping[noise_formula]
+        # if the string starts with "noiseFormula_" it is saved in the model
+        if noise_formula.startswith("noiseFormula_"):
+            return roadrunner_instance.getValue(noise_formula)
 
     # replace noise formula with actual value from mapping
     noise_formulae = np.array(


### PR DESCRIPTION
This currently assumes two things:
* The noise formula for one observable is always the same
* There is no time dependent changes in the parameters of the formula

I think both assumptions are things we make implicitly in PEtab/pyPESTO?