### PR TITLE
Removing Benchmark collection for deploy. Update action versions.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,15 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Remove direct dependencies from setup.cfg
+      # Remove any "git+https"-based dependencies that are not supported
+      #  by PyPI and are only required for testing.
+      run: sed -i '/git+https/d' python/sdist/setup.cfg
 
     - name: Prepare python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Deploy did not work due to the benchmark collection being a direct link