### PR TITLE
Require scipy<1.13.0 for pypesto[pymc] only for python3.9 (#1360)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,6 @@ mpi =
     mpi4py >= 3.0.3
 pymc =
     arviz >= 0.12.1
-    scipy < 1.13.0 # https://github.com/ICB-DCM/pyPESTO/issues/1354
     aesara >= 2.8.6
     pymc >= 4.2.1
 aesara =

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ mpi =
     mpi4py >= 3.0.3
 pymc =
     arviz >= 0.12.1
-    scipy < 1.13.0 # https://github.com/ICB-DCM/pyPESTO/issues/1354
+    scipy < 1.13.0; python_version=='3.9' # https://github.com/ICB-DCM/pyPESTO/issues/1354
     aesara >= 2.8.6
     pymc >= 4.2.1
 aesara =

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,7 @@ mpi =
     mpi4py >= 3.0.3
 pymc =
     arviz >= 0.12.1
+    scipy < 1.13.0 # https://github.com/ICB-DCM/pyPESTO/issues/1354
     aesara >= 2.8.6
     pymc >= 4.2.1
 aesara =


### PR DESCRIPTION
The most recent arviz should now work with the most recent scipy (but requires python>=3.10): https://github.com/arviz-devs/arviz/blob/main/CHANGELOG.md#maintenance-and-fixes-1


Closes #1354