### PR TITLE
Relative: fix log of zero for default 0 sigma values

### DIFF
--- a/pypesto/hierarchical/relative/solver.py
+++ b/pypesto/hierarchical/relative/solver.py
@@ -502,7 +502,7 @@ class NumericalInnerSolver(RelativeInnerSolver):
                         f"`{par.inner_parameter_type}`."
                     )
 
-            return compute_nllh(_data, _sim, _sigma)
+            return compute_nllh(_data, _sim, _sigma, problem.data_mask)
 
         # TODO gradient
         objective = Objective(fun)

--- a/pypesto/hierarchical/relative/solver.py
+++ b/pypesto/hierarchical/relative/solver.py
@@ -82,7 +82,7 @@ class RelativeInnerSolver(InnerSolver):
                 mask=x.ixs,
             )
 
-        return compute_nllh(relevant_data, sim, sigma)
+        return compute_nllh(relevant_data, sim, sigma, problem.data_mask)
 
     def calculate_gradients(
         self,

--- a/pypesto/hierarchical/relative/util.py
+++ b/pypesto/hierarchical/relative/util.py
@@ -362,6 +362,11 @@ def compute_bounded_optimal_scaling_offset_coupled(
         relevant_data[i][~s.ixs[i]] = np.nan
         relevant_sim[i][~s.ixs[i]] = np.nan
 
+    # Get relevant data mask
+    relevant_data_mask = []
+    for i in range(len(data)):
+        relevant_data_mask.append(~np.isnan(relevant_data[i]))
+
     # Get bounds
     s_bounds = s.get_bounds()
     b_bounds = b.get_bounds()
@@ -407,6 +412,7 @@ def compute_bounded_optimal_scaling_offset_coupled(
                     for sim_i in relevant_sim
                 ],
                 sigma=sigma,
+                data_mask=relevant_data_mask,
             )
             for candidate_point in candidate_points
         ]

--- a/pypesto/hierarchical/relative/util.py
+++ b/pypesto/hierarchical/relative/util.py
@@ -447,18 +447,31 @@ def compute_bounded_optimal_scaling_offset_coupled(
 
 
 def compute_nllh(
-    data: list[np.ndarray], sim: list[np.ndarray], sigma: list[np.ndarray]
+    data: list[np.ndarray],
+    sim: list[np.ndarray],
+    sigma: list[np.ndarray],
+    data_mask: list[np.ndarray],
 ) -> float:
     """Compute negative log-likelihood.
 
     Compute negative log-likelihood of the data, given the model outputs and
     sigmas.
     """
-    return sum(
-        0.5 * np.nansum(np.log(2 * np.pi * sigma_i**2))
-        + 0.5 * np.nansum((data_i - sim_i) ** 2 / sigma_i**2)
-        for data_i, sim_i, sigma_i in zip(data, sim, sigma)
-    )
+    nllh = 0.0
+    for data_i, sim_i, sigma_i, data_mask_i in zip(
+        data, sim, sigma, data_mask
+    ):
+        # Mask the data, sim and sigma
+        data_i = data_i[data_mask_i]
+        sim_i = sim_i[data_mask_i]
+        sigma_i = sigma_i[data_mask_i]
+
+        # Compute the negative log-likelihood
+        nllh += 0.5 * np.nansum(
+            np.log(2 * np.pi * sigma_i**2)
+        ) + 0.5 * np.nansum((data_i - sim_i) ** 2 / sigma_i**2)
+
+    return nllh
 
 
 def compute_nllh_gradient_for_condition(


### PR DESCRIPTION
If an observable has hierarchical noise, but has no measurement at some simulation timepoint for which the model is simulated, then the `edata.getObservedData` will be `nan` but the `rdata.sigmay` for that condition, observable and timepoint will be 0.

This was causing an issue in the direct calculation of the NLLH as we were taking the `log(2 * np.pi * sigma_i**2)` where `sigma_i` was `rdata.sigmay`. This gave `RuntimeWarning: divide by zero encountered in log` errors. 

The fix is simple: mask the `sigma_i` array with the mask for which the data is not `nan`. Already available in `problem.data_mask`.

Was raised in issue #1375 