### PR TITLE
Require and test python>=3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # ipopt does not work on 3.9 (https://github.com/mechmotum/cyipopt/issues/225)
         python-version: ['3.12']
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.11']
 
     # needed to allow julia-actions/cache to delete old caches that it has created
     permissions:
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository
@@ -399,7 +399,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository
@@ -429,7 +429,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - name: Check out repository
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - name: Check out repository
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10', '3.11']
 
     # needed to allow julia-actions/cache to delete old caches that it has created
     permissions:
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - name: Check out repository
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - name: Check out repository
@@ -399,7 +399,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10']
 
     steps:
     - name: Check out repository
@@ -429,7 +429,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.12']
 
     steps:
     - name: Check out repository
@@ -63,7 +63,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository
@@ -99,7 +99,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.12']
 
     steps:
     - name: Check out repository
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.12']
 
     # needed to allow julia-actions/cache to delete old caches that it has created
     permissions:
@@ -226,7 +226,7 @@ jobs:
     strategy:
       matrix:
         # ipopt does not work on 3.9 (https://github.com/mechmotum/cyipopt/issues/225)
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.12']
 
     steps:
     - name: Check out repository
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.12']
 
     steps:
     - name: Check out repository
@@ -334,7 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.10
 keywords =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.9
 keywords =
     parameter inference
     optimization
@@ -58,7 +57,7 @@ install_requires =
     tqdm >= 4.46.0
     tabulate >= 0.8.10
 
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = True
 
 # Where is my code

--- a/test/base/test_objective.py
+++ b/test/base/test_objective.py
@@ -2,6 +2,7 @@
 
 import copy
 import numbers
+import sys
 from functools import partial
 
 import numpy as np
@@ -11,6 +12,11 @@ import sympy as sp
 import pypesto
 
 from ..util import CRProblem, poly_for_sensi, rosen_for_sensi
+
+pytest_skip_aesara = pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Skipped Aesara tests on Python 3.12  or higher",
+)
 
 
 @pytest.fixture(params=[True, False])
@@ -178,6 +184,7 @@ def test_finite_difference_checks():
     )
 
 
+@pytest_skip_aesara
 def test_aesara(max_sensi_order, integrated):
     """Test function composition and gradient computation via aesara"""
     import aesara.tensor as aet

--- a/test/base/test_objective.py
+++ b/test/base/test_objective.py
@@ -15,7 +15,7 @@ from ..util import CRProblem, poly_for_sensi, rosen_for_sensi
 
 pytest_skip_aesara = pytest.mark.skipif(
     sys.version_info >= (3, 12),
-    reason="Skipped Aesara tests on Python 3.12  or higher",
+    reason="Skipped Aesara tests on Python 3.12 or higher",
 )
 
 


### PR DESCRIPTION
As seen in #1378 petab tests are failing due to use of syntax in AMICI that is not supported in python version <=3.9.

I guess, we should think about dropping the python support for python <=3.9. 
Other packages as numpy already dropped support for 3.9 as well.
https://numpy.org/neps/nep-0029-deprecation_policy.html

