### PR TITLE
GHA: use macos-12 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         file: ./coverage.xml
 
   mac:
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       matrix:
         python-version: ['3.12']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
Prevents unclear timeouts that occur with `macos-14-arm64` (see #1383).