### PR TITLE
GHA: Test macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici
@@ -60,7 +60,7 @@ jobs:
         file: ./coverage.xml
 
   mac:
-    runs-on: macos-12
+    runs-on: macos-latest
     strategy:
       matrix:
         python-version: ['3.12']
@@ -80,7 +80,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici
@@ -116,7 +116,7 @@ jobs:
         path: |
           ~\AppData\Local\pip\Cache
           .tox
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: |
@@ -149,7 +149,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici pysb
@@ -193,7 +193,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install julia
       uses: julia-actions/setup-julia@v1
@@ -242,7 +242,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh ipopt
@@ -278,7 +278,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici
@@ -314,7 +314,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici
@@ -350,7 +350,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: pip install tox pre-commit
@@ -382,7 +382,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh doc amici
@@ -415,7 +415,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici ipopt
@@ -445,7 +445,7 @@ jobs:
         path: |
           ~/.cache/pip
           .tox/
-        key: ${{ runner.os }}-${{ matrix.python-version }}-ci-${{ github.job }}
+        key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
       run: .github/workflows/install_deps.sh amici

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
     - name: Run tests
       timeout-minutes: 30
-      run: tox -e base
+      run: ulimit -n 65536 65536 && tox -e base
 
     - name: Coverage
       uses: codecov/codecov-action@v3

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -3,7 +3,6 @@
 import os
 
 import numpy as np
-import petab
 import pytest
 import scipy.optimize as so
 from scipy.integrate import quad
@@ -11,10 +10,8 @@ from scipy.stats import ks_2samp, kstest, multivariate_normal, norm, uniform
 
 import pypesto
 import pypesto.optimize as optimize
-import pypesto.petab
 import pypesto.sample as sample
 from pypesto.C import OBJECTIVE_NEGLOGLIKE, OBJECTIVE_NEGLOGPOST
-from pypesto.sample.pymc import PymcSampler
 
 
 def gaussian_llh(x):
@@ -96,6 +93,10 @@ def rosenbrock_problem():
 
 
 def create_petab_problem():
+    import petab
+
+    import pypesto.petab
+
     current_path = os.path.dirname(os.path.realpath(__file__))
     dir_path = os.path.abspath(
         os.path.join(current_path, "..", "..", "doc", "example")
@@ -187,6 +188,8 @@ def sampler(request):
             n_chains=5,
         )
     elif request.param == "Pymc":
+        from pypesto.sample.pymc import PymcSampler
+
         return PymcSampler(tune=5, progressbar=False)
     elif request.param == "Emcee":
         return sample.EmceeSampler(nwalkers=10)


### PR DESCRIPTION
* switch to `macos-14`
  previous issues with macos-14 were a mix of #1388 and caching with seemingly random switching between macos-12 and macos-14 runners when using macos-latest
* include arch in cache keys; use uniform cache keys
* change some imports in `test/sample/test_sample.py` to be able to run subsets of tests despite missing optional dependencies
* adjust resource limits to avoid [random](https://github.com/ICB-DCM/pyPESTO/actions/runs/8945258779/job/24573887731) [failures](https://github.com/ICB-DCM/pyPESTO/actions/runs/8945870387/job/24575587898?pr=1387) such as:
```
/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/_pytest/main.py:339: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
Plugin: _cov, Hook: pytest_runtestloop
DataError: Couldn't use data file '/Users/runner/work/pyPESTO/pyPESTO/.coverage.Mac-1714771409828.local.9672.XvRVVmRx': unable to open database file
For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
  config.hook.pytest_runtestloop(session=session)
..FFFF                                                                   [100%]
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqlitedb.py", line 52, in _connect
INTERNALERROR> sqlite3.OperationalError: unable to open database file
INTERNALERROR> 
INTERNALERROR> The above exception was the direct cause of the following exception:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/_pytest/main.py", line 285, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/_pytest/main.py", line 339, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/pluggy/_callers.py", line 156, in _multicall
INTERNALERROR>     teardown[0].send(outcome)
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/pytest_cov/plugin.py", line 339, in pytest_runtestloop
INTERNALERROR>     self.cov_controller.finish()
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/pytest_cov/engine.py", line 46, in ensure_topdir_wrapper
INTERNALERROR>     return meth(self, *args, **kwargs)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/pytest_cov/engine.py", line 256, in finish
INTERNALERROR>     self.cov.save()
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/control.py", line 785, in save
INTERNALERROR>     data = self.get_data()
INTERNALERROR>            ^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/control.py", line 865, in get_data
INTERNALERROR>     if self._collector.flush_data():
INTERNALERROR>        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/collector.py", line 535, in flush_data
INTERNALERROR>     self.covdata.add_lines(self.mapped_file_dict(line_data))
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqldata.py", line 124, in _wrapped
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqldata.py", line 495, in add_lines
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqldata.py", line 564, in _choose_lines_or_arcs
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqldata.py", line 344, in _connect
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqldata.py", line 287, in _open_db
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqldata.py", line 291, in _read_db
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqlitedb.py", line 88, in __enter__
INTERNALERROR>   File "/Users/runner/work/pyPESTO/pyPESTO/.tox/base/lib/python3.12/site-packages/coverage/sqlitedb.py", line 54, in _connect
INTERNALERROR> coverage.exceptions.DataError: Couldn't use data file '/Users/runner/work/pyPESTO/pyPESTO/.coverage.Mac-1714771409828.local.9672.XvRVVmRx': unable to open database file
```