### PR TITLE
Fix `pypesto.sample.geweke_test.spectrum` for nfft<=3

### DIFF
--- a/pypesto/sample/geweke_test.py
+++ b/pypesto/sample/geweke_test.py
@@ -46,7 +46,11 @@ def spectrum(x: np.ndarray, nfft: int = None, nw: int = None) -> np.ndarray:
         n = nw
 
     # Number of windows
-    k = np.floor((n - n_overlap) / (nw - n_overlap)).astype(int)
+    k = (
+        np.floor((n - n_overlap) / (nw - n_overlap)).astype(int)
+        if nw != n_overlap
+        else 0
+    )
     index = np.arange(nw)
     # Normalizing scale factor
     kmu = k * np.linalg.norm(w) ** 2


### PR DESCRIPTION
For `nfft<=3`, this function computed `k` by converting infinity to int64.

For the last [4 years](https://github.com/ICB-DCM/pyPESTO/commit/fdbacb49df944051cfccf5116a1de30da9365747), this seemed to not cause any trouble, because `np.float64("inf").astype(int)` yielded -9223372036854775808 and the loop did not run. However, with the current `macos-14` GitHub runner, this yields 9223372036854775807, and accordingly, rather long computation times (this is what caused #1383).

I am not really sure what caused this change. macos-12 vs macos-14, arm64 vs x86, ...? all should be IEEE 754-compliant. Maybe some different integer type? :man_shrugging:

With this change `macos-14` runners yield the same results as the other runners. However, I am not familiar with computing power spectral density and I don't know if this is indeed what should happen. It would be great if somebody more familiar with that topic could double-check. (Also, can't we use [scipy.signal.welch](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.welch.html#scipy.signal.welch) here?)