### PR TITLE
More detailed defaults for `problem.get_full_vector`

### DIFF
--- a/pypesto/problem/base.py
+++ b/pypesto/problem/base.py
@@ -345,11 +345,9 @@ class Problem:
         x: array_like, shape=(dim,)
             The vector in dimension dim.
         x_fixed_vals: array_like, ndim=1, optional
-            The values to be used for the fixed indices. If None, then nans are
-            inserted in case of grad and problem.x_fixed_vals is used in case
-            of x.
+            The values to be used for the fixed indices. If None and x_is_grad=False, problem.x_fixed_vals is used; for x_is_grad=True, nans are inserted.
         x_is_grad: bool
-            Whether the vector is a grad or x.
+            If true, x is treated as gradients.
         """
         if x is None:
             return None

--- a/pypesto/problem/base.py
+++ b/pypesto/problem/base.py
@@ -332,7 +332,10 @@ class Problem:
         self.normalize()
 
     def get_full_vector(
-        self, x: Union[np.ndarray, None], x_fixed_vals: Iterable[float] = None
+        self,
+        x: Union[np.ndarray, None],
+        x_fixed_vals: Iterable[float] = None,
+        x_is_grad: bool = False,
     ) -> Union[np.ndarray, None]:
         """
         Map vector from dim to dim_full. Usually used for x, grad.
@@ -343,8 +346,10 @@ class Problem:
             The vector in dimension dim.
         x_fixed_vals: array_like, ndim=1, optional
             The values to be used for the fixed indices. If None, then nans are
-            inserted. Usually, None will be used for grad and
-            problem.x_fixed_vals for x.
+            inserted in case of grad and problem.x_fixed_vals is used in case
+            of x.
+        x_is_grad: bool
+            Whether the vector is a grad or x.
         """
         if x is None:
             return None
@@ -362,6 +367,9 @@ class Problem:
         x_full[..., self.x_free_indices] = x
         if x_fixed_vals is not None:
             x_full[..., self.x_fixed_indices] = x_fixed_vals
+            return x_full
+        if not x_is_grad:
+            x_full[..., self.x_fixed_indices] = self.x_fixed_vals
         return x_full
 
     def get_full_matrix(

--- a/pypesto/result/optimize.py
+++ b/pypesto/result/optimize.py
@@ -191,10 +191,10 @@ class OptimizerResult(dict):
             problem which contains info about how to convert to full vectors
             or matrices
         """
-        self.x = problem.get_full_vector(self.x, problem.x_fixed_vals)
-        self.grad = problem.get_full_vector(self.grad)
+        self.x = problem.get_full_vector(self.x)
+        self.grad = problem.get_full_vector(self.grad, x_is_grad=True)
         self.hess = problem.get_full_matrix(self.hess)
-        self.x0 = problem.get_full_vector(self.x0, problem.x_fixed_vals)
+        self.x0 = problem.get_full_vector(self.x0)
         self.free_indices = np.array(problem.x_free_indices)
 
 

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -417,8 +417,8 @@ def handle_inputs(
         ub = result.problem.get_reduced_vector(ub, parameter_indices)
         x_labels = [x_labels[int(i)] for i in parameter_indices]
     else:
-        lb = result.problem.get_full_vector(lb)
-        ub = result.problem.get_full_vector(ub)
+        lb = result.problem.lb_full
+        ub = result.problem.ub_full
 
     if inner_xs is not None and plot_inner_parameters:
         lb = np.concatenate([lb, inner_lb])

--- a/test/base/test_history.py
+++ b/test/base/test_history.py
@@ -236,9 +236,7 @@ class HistoryTest(unittest.TestCase):
 
     def check_history_consistency(self, start: pypesto.OptimizerResult):
         def xfull(x_trace):
-            return self.problem.get_full_vector(
-                x_trace, self.problem.x_fixed_vals
-            )
+            return self.problem.get_full_vector(x_trace)
 
         if isinstance(start.history, (CsvHistory, Hdf5History)):
             # get index of optimal parameter

--- a/test/base/test_x_fixed.py
+++ b/test/base/test_x_fixed.py
@@ -41,8 +41,7 @@ def test_optimize():
     # fixed values written into parameter vector
     assert optimizer_result.x[1] == 1
 
-    lb_full = problem.get_full_vector(problem.lb)
-    assert len(lb_full) == 5
+    assert len(problem.lb_full) == 5
 
 
 def create_problem():


### PR DESCRIPTION
As the doctoring already explained before, we usually want `problem.x_fixed_vals` as defaults if we update a vector x. I think this should be a default and leaving the nans should be left for gradients (hence another parameter to distinguish the two.