### PR TITLE
Visualize: visualization of estimated observable mapping

### DIFF
--- a/doc/example/relative_data.ipynb
+++ b/doc/example/relative_data.ipynb
@@ -259,6 +259,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can visualize the estimated linear observable mapping of both the analytical and numerical approach using the `pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping` routine. The routine plots all estimated linear or spline observable mappings of relative or semiquantitative obserables, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping(\n",
+    "    pypesto_result=result_num,\n",
+    "    pypesto_problem=problem,\n",
+    "    figsize=(7, 7),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping(\n",
+    "    pypesto_result=result_ana,\n",
+    "    pypesto_problem=problem,\n",
+    "    figsize=(7, 7),\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -434,7 +467,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.2"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/example/relative_data.ipynb
+++ b/doc/example/relative_data.ipynb
@@ -262,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can visualize the estimated linear observable mapping of both the analytical and numerical approach using the `pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping` routine. The routine plots all estimated linear or spline observable mappings of relative or semiquantitative obserables, respectively."
+    "We can visualize the estimated linear observable mapping of both the analytical and numerical approach using the `pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping` routine. The routine plots all estimated linear or spline observable mappings of relative or semiquantitative observables, respectively."
    ]
   },
   {

--- a/doc/example/semiquantitative_data.ipynb
+++ b/doc/example/semiquantitative_data.ipynb
@@ -314,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can visualize the estimated spline observable mapping using the `pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping` routine. The routine plots all estimated linear or spline observable mappings of relative or semiquantitative obserables, respectively."
+    "We can visualize the estimated spline observable mapping using the `pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping` routine. The routine plots all estimated linear or spline observable mappings of relative or semiquantitative observables, respectively."
    ]
   },
   {

--- a/doc/example/semiquantitative_data.ipynb
+++ b/doc/example/semiquantitative_data.ipynb
@@ -67,7 +67,7 @@
     ")\n",
     "from pypesto.visualize import (\n",
     "    plot_splines_from_inner_result,\n",
-    "    plot_splines_from_pypesto_result,\n",
+    "    visualize_estimated_observable_mapping,\n",
     ")\n",
     "from pypesto.visualize.model_fit import visualize_optimized_model_fit"
    ]
@@ -314,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can plot the optimized spline of the best start using the `plot_from_pypesto_result` visualization:"
+    "We can visualize the estimated spline observable mapping using the `pypesto.visualize.observable_mapping.visualize_estimated_observable_mapping` routine. The routine plots all estimated linear or spline observable mappings of relative or semiquantitative obserables, respectively."
    ]
   },
   {
@@ -323,7 +323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_splines_from_pypesto_result(result, figsize=(10, 8))\n",
+    "visualize_estimated_observable_mapping(result, problem, figsize=(10, 8))\n",
     "plt.show()"
    ]
   },
@@ -470,7 +470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.2"
   },
   "vscode": {
    "interpreter": {

--- a/pypesto/hierarchical/base_problem.py
+++ b/pypesto/hierarchical/base_problem.py
@@ -193,6 +193,11 @@ class AmiciInnerProblem(InnerProblem):
             amici.numpy.ExpDataView(edata)["observedData"] for edata in edatas
         ]
 
+        # Mask the data using the inner problem mask. This is necessary
+        # because the inner problem is aware of only the data it uses.
+        for i in range(len(data)):
+            data[i][~self.data_mask[i]] = np.nan
+
         if len(self.data) != len(data):
             return False
 

--- a/pypesto/hierarchical/inner_calculator_collector.py
+++ b/pypesto/hierarchical/inner_calculator_collector.py
@@ -35,7 +35,6 @@ from ..C import (
     SPLINE_KNOTS,
     SPLINE_RATIO,
     SRES,
-    InnerParameterType,
     ModeType,
 )
 from ..objective.amici.amici_calculator import AmiciCalculator
@@ -102,6 +101,10 @@ class InnerCalculatorCollector(AmiciCalculator):
         self.inner_calculators: list[
             AmiciCalculator
         ] = []  # TODO make into a dictionary (future PR, together with .hierarchical of Problem)
+
+        self.semiquant_observable_ids = None
+        self.relative_observable_ids = None
+
         self.construct_inner_calculators(
             petab_problem, model, edatas, inner_options
         )
@@ -109,7 +112,6 @@ class InnerCalculatorCollector(AmiciCalculator):
         self.quantitative_data_mask = self._get_quantitative_data_mask(edatas)
 
         self._known_least_squares_safe = False
-        self.semiquant_observable_ids = None
 
     def initialize(self):
         """Initialize."""
@@ -137,6 +139,9 @@ class InnerCalculatorCollector(AmiciCalculator):
                 inner_problem=relative_inner_problem
             )
             self.inner_calculators.append(relative_inner_solver)
+            self.relative_observable_ids = (
+                relative_inner_problem.get_relative_observable_ids()
+            )
 
         if ORDINAL in self.data_types or CENSORED in self.data_types:
             optimal_scaling_inner_options = {
@@ -178,12 +183,9 @@ class InnerCalculatorCollector(AmiciCalculator):
                 semiquant_problem.get_noise_dummy_values(scaled=True)
             )
             self.inner_calculators.append(semiquant_calculator)
-            self.semiquant_observable_ids = [
-                model.getObservableIds()[group - 1]
-                for group in semiquant_problem.get_groups_for_xs(
-                    InnerParameterType.SPLINE
-                )
-            ]
+            self.semiquant_observable_ids = (
+                semiquant_problem.get_semiquant_observable_ids()
+            )
 
         if self.data_types - {
             RELATIVE,

--- a/pypesto/hierarchical/relative/parameter.py
+++ b/pypesto/hierarchical/relative/parameter.py
@@ -1,0 +1,44 @@
+import logging
+
+from ...C import InnerParameterType
+from ..base_parameter import InnerParameter
+
+logger = logging.getLogger(__name__)
+
+
+class RelativeInnerParameter(InnerParameter):
+    """A relative (inner) parameter of the relative hierarchical optimization problem.
+
+    Attributes
+    ----------
+    observable_id:
+        The id of the observable the relative inner parameter is connected to.
+    group:
+        Group index. Corresponds to `amici_model.index(observable_id)` + 1.
+    """
+
+    def __init__(
+        self,
+        *args,
+        observable_id: str = None,
+        group: int = None,
+        **kwargs,
+    ):
+        """Construct.
+
+        Parameters
+        ----------
+        See class attributes.
+        """
+        super().__init__(*args, **kwargs)
+        if self.inner_parameter_type not in [
+            InnerParameterType.SCALING,
+            InnerParameterType.OFFSET,
+            InnerParameterType.SIGMA,
+        ]:
+            raise ValueError(
+                "For the RelativeParameter class, the parameter type has to be scaling, offset or sigma."
+            )
+
+        self.observable_id = observable_id
+        self.group = group

--- a/pypesto/hierarchical/relative/parameter.py
+++ b/pypesto/hierarchical/relative/parameter.py
@@ -11,17 +11,18 @@ class RelativeInnerParameter(InnerParameter):
 
     Attributes
     ----------
-    observable_id:
-        The id of the observable the relative inner parameter is connected to.
-    group:
-        Group index. Corresponds to `amici_model.index(observable_id)` + 1.
+    observable_ids:
+        A list of IDs of the observables that the relative inner parameter is connected to.
+        Can be a single or multiple observables.
+    observable_indices:
+        A list of indices of the observables that the relative inner parameter is connected to.
     """
 
     def __init__(
         self,
         *args,
-        observable_id: str = None,
-        group: int = None,
+        observable_ids: list[str] = None,
+        observable_indices: list[int] = None,
         **kwargs,
     ):
         """Construct.
@@ -40,5 +41,5 @@ class RelativeInnerParameter(InnerParameter):
                 "For the RelativeParameter class, the parameter type has to be scaling, offset or sigma."
             )
 
-        self.observable_id = observable_id
-        self.group = group
+        self.observable_ids = observable_ids
+        self.observable_indices = observable_indices

--- a/pypesto/hierarchical/relative/problem.py
+++ b/pypesto/hierarchical/relative/problem.py
@@ -94,7 +94,7 @@ class RelativeInnerProblem(AmiciInnerProblem):
         )
 
     def get_xs_for_obs_idx(self, obs_idx: int) -> list[RelativeInnerParameter]:
-        """Get ``RelativeParameter``s that belong to the observable with index `obs_idx`."""
+        r"""Get ``RelativeParameter``\s that belong to the observable with index `obs_idx`."""
         return [x for x in self.xs.values() if obs_idx in x.observable_indices]
 
 

--- a/pypesto/hierarchical/semiquantitative/problem.py
+++ b/pypesto/hierarchical/semiquantitative/problem.py
@@ -147,6 +147,16 @@ class SemiquantProblem(AmiciInnerProblem):
             if x.inner_parameter_type == InnerParameterType.SIGMA
         ]
 
+    def get_semiquant_observable_ids(self) -> list[str]:
+        """Get the ids of semiquantitative observables."""
+        return list(
+            {
+                x.observable_id
+                for x in self.xs.values()
+                if x.inner_parameter_type == InnerParameterType.SPLINE
+            }
+        )
+
     def get_groups_for_xs(self, inner_parameter_type: str) -> list[int]:
         """Get unique list of ``SplineParameter.group`` values."""
         groups = [x.group for x in self.get_xs_for_type(inner_parameter_type)]

--- a/pypesto/hierarchical/semiquantitative/problem.py
+++ b/pypesto/hierarchical/semiquantitative/problem.py
@@ -148,7 +148,7 @@ class SemiquantProblem(AmiciInnerProblem):
         ]
 
     def get_semiquant_observable_ids(self) -> list[str]:
-        """Get the ids of semiquantitative observables."""
+        """Get the IDs of semiquantitative observables."""
         return list(
             {
                 x.observable_id

--- a/pypesto/problem/hierarchical.py
+++ b/pypesto/problem/hierarchical.py
@@ -80,3 +80,6 @@ class HierarchicalProblem(Problem):
         self.semiquant_observable_ids = (
             self.objective.calculator.semiquant_observable_ids
         )
+        self.relative_observable_ids = (
+            self.objective.calculator.relative_observable_ids
+        )

--- a/pypesto/visualize/__init__.py
+++ b/pypesto/visualize/__init__.py
@@ -21,6 +21,7 @@ from .ensemble import ensemble_identifiability
 from .misc import process_offset_y, process_result_list, process_y_limits
 from .observable_mapping import (
     _add_spline_mapped_simulations_to_model_fit,
+    plot_linear_observable_mappings_from_pypesto_result,
     plot_splines_from_inner_result,
     plot_splines_from_pypesto_result,
     visualize_estimated_observable_mapping,

--- a/pypesto/visualize/__init__.py
+++ b/pypesto/visualize/__init__.py
@@ -20,7 +20,6 @@ from .dimension_reduction import (
 from .ensemble import ensemble_identifiability
 from .misc import process_offset_y, process_result_list, process_y_limits
 from .observable_mapping import (
-    _add_spline_mapped_simulations_to_model_fit,
     plot_linear_observable_mappings_from_pypesto_result,
     plot_splines_from_inner_result,
     plot_splines_from_pypesto_result,

--- a/pypesto/visualize/__init__.py
+++ b/pypesto/visualize/__init__.py
@@ -19,6 +19,12 @@ from .dimension_reduction import (
 )
 from .ensemble import ensemble_identifiability
 from .misc import process_offset_y, process_result_list, process_y_limits
+from .observable_mapping import (
+    _add_spline_mapped_simulations_to_model_fit,
+    plot_splines_from_inner_result,
+    plot_splines_from_pypesto_result,
+    visualize_estimated_observable_mapping,
+)
 from .optimization_stats import (
     optimization_run_properties_one_plot,
     optimization_run_properties_per_multistart,
@@ -47,10 +53,5 @@ from .sampling import (
     sampling_parameter_traces,
     sampling_prediction_trajectories,
     sampling_scatter,
-)
-from .spline_approximation import (
-    _add_spline_mapped_simulations_to_model_fit,
-    plot_splines_from_inner_result,
-    plot_splines_from_pypesto_result,
 )
 from .waterfall import waterfall, waterfall_lowlevel

--- a/pypesto/visualize/model_fit.py
+++ b/pypesto/visualize/model_fit.py
@@ -22,8 +22,8 @@ from ..C import CENSORED, ORDINAL, RDATAS, SEMIQUANTITATIVE
 from ..petab.importer import get_petab_non_quantitative_data_types
 from ..problem import HierarchicalProblem, Problem
 from ..result import Result
+from .observable_mapping import _add_spline_mapped_simulations_to_model_fit
 from .ordinal_categories import plot_categories_from_pypesto_result
-from .spline_approximation import _add_spline_mapped_simulations_to_model_fit
 
 AmiciModel = Union["amici.Model", "amici.ModelPtr"]
 

--- a/pypesto/visualize/observable_mapping.py
+++ b/pypesto/visualize/observable_mapping.py
@@ -58,7 +58,7 @@ def visualize_estimated_observable_mapping(
     pypesto_result:
         The pyPESTO result object from optimization.
     pypesto_problem:
-        The pyPESTO problem.
+        The pyPESTO problem. It should contain the objective object that was used for estimation.
     start_index:
         The observable mapping from this start's optimized vector will be plotted.
     axes:
@@ -77,6 +77,20 @@ def visualize_estimated_observable_mapping(
     if not isinstance(pypesto_problem, HierarchicalProblem):
         raise ValueError(
             "Only hierarchical problems contain estimated observable mappings. Please provide a hierarchical problem."
+        )
+
+    # Check if the pyPESTO problem contains an objective.
+    if pypesto_problem.objective is None:
+        raise ValueError(
+            "The problem must contain the corresponding objective that was used for estimation."
+        )
+
+    # Check the calculator is the InnerCalculatorCollector.
+    if not isinstance(
+        pypesto_problem.objective.calculator, InnerCalculatorCollector
+    ):
+        raise ValueError(
+            "The calculator must be an instance of the InnerCalculatorCollector."
         )
 
     amici_model = pypesto_problem.objective.amici_model
@@ -161,7 +175,7 @@ def plot_linear_observable_mappings_from_pypesto_result(
     pypesto_result:
         The pyPESTO result object from optimization.
     pypesto_problem:
-        The pyPESTO problem.
+        The pyPESTO problem. It should contain the objective object that was used for estimation.
     start_index:
         The observable mapping from this start's optimized vector will be plotted.
     axes:


### PR DESCRIPTION
I implemented a visualization routine to visualize all estimated observable mappings: linear scaling+offset for relative data and splines for semiquantitative data. The visualization of estimated splines already existed, so I made the linear one and combined them into a single routine. However, I made it so that each can also be called separately.

To make the implementation easier, I had to expand some classes connected to the relative data: inner problem, inner parameter.

During the implementation, a few bugs popped up. I fixed those here as well. I'll comment on the PR so it's easier to distinguish.

The notebooks have also been updated accordingly.