### PR TITLE
NegLogParameterPriors does not evaluate prior density at fixed params

### DIFF
--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from collections.abc import Sequence
-from typing import Callable, Optional, Union
+from typing import Callable, Union
 
 import numpy as np
 
@@ -51,7 +51,7 @@ class NegLogParameterPriors(ObjectiveBase):
     def __init__(
         self,
         prior_list: list[dict],
-        x_names: Optional[Sequence[str]] = None,
+        x_names: Sequence[str] = None,
     ):
         """
         Initialize.

--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -160,23 +160,12 @@ class NegLogParameterPriors(ObjectiveBase):
                 f"{C.MODE_RES}, received {mode} instead."
             )
 
-    def _create_fixed_mask(self, x_fixed_indices: Sequence[int]):
-        """Create a mask for fixed parameters."""
-        self.fixed_mask = np.zeros(len(self._prior_list), dtype=bool)
-        for prior in self._prior_list:
-            if prior["index"] in x_fixed_indices:
-                self.fixed_mask[prior["index"]] = False
-            else:
-                self.fixed_mask[prior["index"]] = True
-        return
-
-    @property
-    def prior_list(self) -> list[dict]:
-        """Return the list of priors for fixed parameters."""
-        return [
-            self._prior_list[i]
-            for i in range(len(self._prior_list))
-            if self.fixed_mask[i]
+    def _reset_priors(self, excluded_indices: Sequence[int] | None = None):
+        """Reset the list of priors."""
+        self.prior_list = [
+            prior
+            for prior_index, prior in enumerate(self._prior_list_full)
+            if prior_index not in (excluded_indices or [])
         ]
 
     def update_from_problem(

--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -68,11 +68,8 @@ class NegLogParameterPriors(ObjectiveBase):
         x_names:
             Sequence of parameter names (optional).
         """
-        self._prior_list = prior_list
-        x_fixed_indices = (
-            x_fixed_indices if x_fixed_indices is not None else []
-        )
-        self._create_fixed_mask(x_fixed_indices)
+        self._prior_list_full = prior_list
+        self._reset_priors(excluded_indices=x_fixed_indices)
         super().__init__(x_names)
 
     def call_unprocessed(

--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -210,7 +210,7 @@ class NegLogParameterPriors(ObjectiveBase):
             x_fixed_indices=x_fixed_indices,
             x_fixed_vals=x_fixed_vals,
         )
-        self._create_fixed_mask(x_fixed_indices)
+        self._reset_priors(excluded_indices=x_fixed_indices)
 
     def neg_log_density(self, x):
         """Evaluate the negative log-density at x."""

--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -164,8 +164,8 @@ class NegLogParameterPriors(ObjectiveBase):
         """Reset the list of priors."""
         self.prior_list = [
             prior
-            for prior in self._prior_list_full
-            if prior["index"] not in (excluded_indices or [])
+            for prior_index, prior in enumerate(self._prior_list_full)
+            if prior_index not in (excluded_indices or [])
         ]
 
     def update_from_problem(

--- a/pypesto/objective/priors.py
+++ b/pypesto/objective/priors.py
@@ -164,8 +164,8 @@ class NegLogParameterPriors(ObjectiveBase):
         """Reset the list of priors."""
         self.prior_list = [
             prior
-            for prior_index, prior in enumerate(self._prior_list_full)
-            if prior_index not in (excluded_indices or [])
+            for prior in self._prior_list_full
+            if prior["index"] not in (excluded_indices or [])
         ]
 
     def update_from_problem(

--- a/pypesto/objective/roadrunner/petab_importer_roadrunner.py
+++ b/pypesto/objective/roadrunner/petab_importer_roadrunner.py
@@ -295,7 +295,9 @@ class PetabImporterRR:
                         i, prior_type_entry, prior_params, scale
                     )
                 )
-        return NegLogParameterPriors(prior_list)
+        return NegLogParameterPriors(
+            prior_list, x_fixed_indices=self.petab_problem.x_fixed_indices
+        )
 
     def create_startpoint_method(self, **kwargs) -> StartpointMethod:
         """Create a startpoint method.

--- a/pypesto/objective/roadrunner/petab_importer_roadrunner.py
+++ b/pypesto/objective/roadrunner/petab_importer_roadrunner.py
@@ -295,9 +295,7 @@ class PetabImporterRR:
                         i, prior_type_entry, prior_params, scale
                     )
                 )
-        return NegLogParameterPriors(
-            prior_list, x_fixed_indices=self.petab_problem.x_fixed_indices
-        )
+        return NegLogParameterPriors(prior_list)
 
     def create_startpoint_method(self, **kwargs) -> StartpointMethod:
         """Create a startpoint method.

--- a/pypesto/objective/roadrunner/petab_importer_roadrunner.py
+++ b/pypesto/objective/roadrunner/petab_importer_roadrunner.py
@@ -6,6 +6,7 @@ depends on the noise model specified in the provided PEtab problem.
 """
 from __future__ import annotations
 
+import logging
 import numbers
 import re
 from collections.abc import Iterable
@@ -31,6 +32,8 @@ from ..priors import NegLogParameterPriors, get_parameter_prior_dict
 from .road_runner import RoadRunnerObjective
 from .roadrunner_calculator import RoadRunnerCalculator
 from .utils import ExpData
+
+logger = logging.getLogger(__name__)
 
 
 class PetabImporterRR:
@@ -279,6 +282,13 @@ class PetabImporterRR:
                 isinstance(prior_type_entry, str)
                 and prior_type_entry != petab.PARAMETER_SCALE_UNIFORM
             ):
+                # check if parameter for which prior is defined is a fixed parameter
+                if x_id in self.petab_problem.x_fixed_ids:
+                    logger.warning(
+                        f"Parameter {x_id} is marked as fixed but has a "
+                        f"prior defined. This might be unintended."
+                    )
+
                 prior_params = [
                     float(param)
                     for param in self.petab_problem.parameter_df.loc[

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -685,7 +685,9 @@ class PetabImporter(AmiciObjectBuilder):
                     )
 
         if len(prior_list):
-            return NegLogParameterPriors(prior_list)
+            return NegLogParameterPriors(
+                prior_list, x_fixed_indices=self.petab_problem.x_fixed_indices
+            )
         else:
             return None
 

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -667,6 +667,13 @@ class PetabImporter(AmiciObjectBuilder):
                     isinstance(prior_type_entry, str)
                     and prior_type_entry != petab.PARAMETER_SCALE_UNIFORM
                 ):
+                    # check if parameter for which prior is defined is a fixed parameter
+                    if x_id in self.petab_problem.x_fixed_ids:
+                        logger.warning(
+                            f"Parameter {x_id} is marked as fixed but has a "
+                            f"prior defined. This might be unintended."
+                        )
+
                     prior_params = [
                         float(param)
                         for param in self.petab_problem.parameter_df.loc[

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -685,9 +685,7 @@ class PetabImporter(AmiciObjectBuilder):
                     )
 
         if len(prior_list):
-            return NegLogParameterPriors(
-                prior_list, x_fixed_indices=self.petab_problem.x_fixed_indices
-            )
+            return NegLogParameterPriors(prior_list)
         else:
             return None
 


### PR DESCRIPTION
Based on #1412 

Making the `NegLogParameterPriors` aware of fixed parameters. The density is not evaluted for those. Moreover, the petab importet is updated to indicate the fixed parameters while creating the prior. 

Question: should this argument stay optional? If priors are not given for fixed parameters, no problem would occure. The problem only occurs when priors are given and parameters fixed.