### PR TITLE
AmiciObjective: check that sensitivities wrt all relevant parameters …

### DIFF
--- a/doc/example/petab_import.ipynb
+++ b/doc/example/petab_import.ipynb
@@ -178,7 +178,7 @@
     "converter_config = libsbml.SBMLLocalParameterConverter().getDefaultProperties()\n",
     "petab_problem.sbml_document.convert(converter_config)\n",
     "\n",
-    "obj = importer.create_objective()\n",
+    "obj = problem.objective\n",
     "\n",
     "# for some models, hyperparameters need to be adjusted\n",
     "# obj.amici_solver.setMaxSteps(10000)\n",

--- a/doc/example/petab_import.ipynb
+++ b/doc/example/petab_import.ipynb
@@ -383,7 +383,7 @@
    "outputs": [],
    "source": [
     "ref = visualize.create_references(\n",
-    "    x=petab_problem.x_nominal_scaled, fval=obj(petab_problem.x_nominal_scaled)\n",
+    "    x=petab_problem.x_nominal_scaled, fval=obj(petab_problem.x_nominal_free_scaled)\n",
     ")\n",
     "\n",
     "visualize.waterfall(result, reference=ref, scale_y=\"lin\")\n",

--- a/doc/example/petab_import.ipynb
+++ b/doc/example/petab_import.ipynb
@@ -200,7 +200,7 @@
    "outputs": [],
    "source": [
     "ret = obj(\n",
-    "    petab_problem.x_nominal_scaled,\n",
+    "    petab_problem.x_nominal_free_scaled,\n",
     "    mode=\"mode_fun\",\n",
     "    sensi_orders=(0, 1),\n",
     "    return_dict=True,\n",

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -488,7 +488,8 @@ class AmiciObjective(ObjectiveBase):
         #  based on the supplied model. If not, raise an error.
         #  This has to be done on every call, since the preprocessor may
         #  change the parameters w.r.t. which sensitivities are required.
-        if max(0, *sensi_orders) > 0 and (
+        # max(0, 0) to work with empty sensi_orders
+        if max(0, 0, *sensi_orders) > 0 and (
             missing_sensitivities := self._get_missing_sensitivities()
         ):
             raise ValueError(

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -488,7 +488,7 @@ class AmiciObjective(ObjectiveBase):
         #  based on the supplied model. If not, raise an error.
         #  This has to be done on every call, since the preprocessor may
         #  change the parameters w.r.t. which sensitivities are required.
-        if max(sensi_orders) > 0 and (
+        if max(0, *sensi_orders) > 0 and (
             missing_sensitivities := self._get_missing_sensitivities()
         ):
             raise ValueError(

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -92,7 +92,7 @@ class AmiciCalculator:
         # set order in solver
         sensi_order = 0
         if sensi_orders:
-            sensi_order = max(sensi_orders)
+            sensi_order = max(0, *sensi_orders)
 
         if sensi_order == 2 and fim_for_hess:
             # we use the FIM

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -92,7 +92,7 @@ class AmiciCalculator:
         # set order in solver
         sensi_order = 0
         if sensi_orders:
-            sensi_order = max(0, *sensi_orders)
+            sensi_order = max(sensi_orders)
 
         if sensi_order == 2 and fim_for_hess:
             # we use the FIM

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -447,6 +447,9 @@ class PetabImporter(AmiciObjectBuilder):
         Returns
         -------
         A :class:`pypesto.objective.AmiciObjective` for the model and the data.
+        This object is expected to be passed to
+        :class:`PetabImporter.create_problem` to correctly handle fixed
+        parameters.
         """
         # get simulation conditions
         simulation_conditions = petab.get_simulation_conditions(


### PR DESCRIPTION
…can be computed

Adds a check whether the amici model in an `AmiciObjective` is able to compute sensitivities w.r.t. to the objective parameters.

Closes #1414

This raised the question of whether an objective can have implicitly fixed parameters. I.e. whether it should be considered a use case, that some objective parameters that may change the objective value, have zero entries in the gradient. This is what's happening if one uses `PetabImporter.create_objective()` without passing it through `PetabImporter.create_problem()`. So far, pypesto is rather unclear on that. Whether this affects optimization will depend on into which `Problem` this objective will be put.

My assumption here is that this is undesirable and that changes in the objective value should be reflected in the gradient.