### PR TITLE
GHA: Enable dependabot for action upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+    target-branch: "develop"


### PR DESCRIPTION
Automated pull requests if a new major version of any used action is available.

(Will only happen once this makes it into `main`)