### PR TITLE
Hierarchical: avoid recomputing inner parameters if simulation failed

### DIFF
--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -83,7 +83,9 @@ class AmiciObjective(ObjectiveBase):
         n_threads: Optional[int] = 1,
         fim_for_hess: Optional[bool] = True,
         amici_object_builder: Optional[AmiciObjectBuilder] = None,
-        calculator: Optional[AmiciCalculator] = None,
+        calculator: Optional[
+            Union[AmiciCalculator, "InnerCalculatorCollector"]  # noqa: F821
+        ] = None,
         amici_reporting: Optional["amici.RDataReporting"] = None,
     ):
         """

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -61,9 +61,7 @@ def hierarchical_decorator(minimize):
             optimize_options=optimize_options,
         )
 
-        failed_start = result.n_fval == 1
-
-        if isinstance(problem, HierarchicalProblem) and not failed_start:
+        if isinstance(problem, HierarchicalProblem) and result.x is not None:
             # Call the objective to obtain inner parameters of
             # the optimal outer optimization parameters
             return_dict = problem.objective(

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -61,7 +61,9 @@ def hierarchical_decorator(minimize):
             optimize_options=optimize_options,
         )
 
-        if isinstance(problem, HierarchicalProblem):
+        failed_start = result.n_fval == 1
+
+        if isinstance(problem, HierarchicalProblem) and not failed_start:
             # Call the objective to obtain inner parameters of
             # the optimal outer optimization parameters
             return_dict = problem.objective(


### PR DESCRIPTION
`result.x = None` if simulation fails at the startpoint. `result.x` is used to compute hierarchical inner parameters after optimization. When `result.x = None`, an AMICI simulation to compute inner parameters is still run, unexpectedly... I didn't look deeper there, but this PR stops the computation of inner parameters if simulation fails at the startpoint (defined by `result.x = None`).

This PR means users do not see `NaN in p` AMICI  simulation errors due to `result.x = None`. This can be confusing for users, who then try (and fail) to reproduce those errors with `objective(result.x0)`.