### PR TITLE
Removing Aesara from readthedocs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -13,7 +13,6 @@ API reference
    pypesto.history
    pypesto.logging
    pypesto.objective
-   pypesto.objective.aesara
    pypesto.objective.jax
    pypesto.objective.julia
    pypesto.objective.roadrunner

--- a/tox.ini
+++ b/tox.ini
@@ -148,6 +148,8 @@ description =
 [testenv:doc]
 extras =
     doc,amici,petab,aesara,jax,select,roadrunner
+deps =
+    numpy < 2.0
 commands =
     sphinx-build -W -b html doc/ doc/_build/html
 description =


### PR DESCRIPTION
tried installing pypesto[aesara] in a complete new venv, which already threw errors. Removing it from the documentation for now (potentially completely from the package later depending on usage)