### PR TITLE
Doc: fix formatting

### DIFF
--- a/doc/example/model_evidence_and_bayes_factors.ipynb
+++ b/doc/example/model_evidence_and_bayes_factors.ipynb
@@ -44,6 +44,7 @@
     "A $\\operatorname{BF}_{12} > 1$ indicates that the data favors model $\\mathcal{M}_1$ over model $\\mathcal{M}_2$, while $\\operatorname{BF}_{12} < 1$ indicates the opposite.\n",
     "\n",
     "Jeffreys (1961) suggested interpreting Bayes factors in half-units on the log10 scale (this was further simplified in Kass and Raftery (1995)):\n",
+    "\n",
     "- Not worth more than a bare mention: $0 < \\log_{10} \\operatorname{BF}_{12} \\leq 0.5$\n",
     "- Substantial: $0.5 < \\log_{10}\\operatorname{BF}_{12} \\leq 1$\n",
     "- Strong: $1 < \\log_{10}\\operatorname{BF}_{12} \\leq 2$\n",
@@ -57,7 +58,7 @@
    "source": [
     "## Example\n",
     "\n",
-    "To illustrate different methods to compute marginal likelihoods we introduce two toy models, for which we can compute the marginal likelihoods analytically:\n",
+    "To illustrate different methods to compute marginal likelihoods, we introduce two toy models, for which we can compute the marginal likelihoods analytically:\n",
     "\n",
     "1. **Mixture of Two Gaussians (True Data Generator)**: Composed of two Gaussian distributions, $\\mathcal{N}(\\mu_1, \\sigma_1^2)$ and $\\mathcal{N}(\\mu_2, \\sigma_2^2)$, with mixing coefficient $\\pi=0.7$.\n",
     "\n",
@@ -560,11 +561,11 @@
     "\n",
     "The harmonic mean estimator approximates the evidence from above since it tends to ignore low likelihood regions, such as those comprising the prior, leading to overestimates of the marginal likelihoods, even when asymptotically unbiased.\n",
     "Moreover, the estimator can have a high variance due to evaluating the likelihood at low probability regions and inverting it.\n",
-    "Hence, it can be very unstable and even fail catastrophically. A more stable version, the stabilized harmonic mean, also uses samples from the prior (see [Newton and Raftery (1994)](https://doi.org/10.1111/j.2517-6161.1994.tb01956.x)). However, there more efficient methods available.\n",
+    "Hence, it can be very unstable and even fail catastrophically. A more stable version, the stabilized harmonic mean, also uses samples from the prior (see [Newton and Raftery (1994)](https://doi.org/10.1111/j.2517-6161.1994.tb01956.x)). However, there are more efficient methods available.\n",
     "\n",
     "A reliable sampling method is bridge sampling (see [\"A Tutorial on Bridge Sampling\" by Gronau et al. (2017)](https://api.semanticscholar.org/CorpusID:5447695) for a nice introduction). It uses samples from a proposal and the posterior to estimate the marginal likelihood. The proposal distribution should be chosen to have a high overlap with the posterior (we construct it from half of the posterior samples by fitting a Gaussian distribution with the same mean and covariance). This method is more stable than the harmonic mean estimator. However, its accuracy may depend on the choice of the proposal distribution.\n",
     "\n",
-    "A different approach, the learnt harmonic mean estimator, was proposed by [McEwen et al. (2021)](https://api.semanticscholar.org/CorpusID:244709474). The estimator solves the large variance problem by interpreting the harmonic mean estimator as importance sampling and introducing a new target distribution, which is learned from the posterior samples. The method can be applied just using samples from the posterior and is implemented in software package accompanying the paper.\n"
+    "A different approach, the learnt harmonic mean estimator, was proposed by [McEwen et al. (2021)](https://api.semanticscholar.org/CorpusID:244709474). The estimator solves the large variance problem by interpreting the harmonic mean estimator as importance sampling and introducing a new target distribution, which is learned from the posterior samples. The method can be applied just using samples from the posterior and is implemented in the software package accompanying the paper.\n"
    ],
    "metadata": {
     "collapsed": false
@@ -912,7 +913,7 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "We recommend to use either bridge sampling, nested sampling or one of the methods using power posteriors depending on the computational resources available. \n",
+    "We recommend using either bridge sampling, nested sampling or one of the methods using power posteriors depending on the computational resources available. \n",
     "\n",
     "Bayes factors and marginal likelihoods are powerful tools for Bayesian model comparison. While there are various methods to compute marginal likelihoods, each has its strengths and weaknesses. Choosing the appropriate method depends on the specific context, the complexity of the models, and the computational resources available."
    ],

--- a/setup.cfg
+++ b/setup.cfg
@@ -160,6 +160,7 @@ example =
     %(nlopt)s
     %(pyswarm)s
     notebook >= 6.1.4
+    ipywidgets >= 8.1.5
     benchmark_models_petab @ git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python
 select =
     # Remove when vis is moved to PEtab Select version


### PR DESCRIPTION
Fix list formatting in doc/example/model_evidence_and_bayes_factors.ipynb, get rid of ipywidgets warning, and fix typo.

https://pypesto.readthedocs.io/en/develop/example/model_evidence_and_bayes_factors.html

![image](https://github.com/user-attachments/assets/e0b490a3-e9b2-46d0-b3af-f63214583377)

```
/home/docs/checkouts/readthedocs.org/user_builds/pypesto/envs/develop/lib/python3.11/site-packages/rich/live.py:231
: UserWarning: install "ipywidgets" for Jupyter support
  warnings.warn('install "ipywidgets" for Jupyter support')
```


:eyes: https://pypesto--1456.org.readthedocs.build/en/1456/example/model_evidence_and_bayes_factors.html#Bayes-Factor