### PR TITLE
SacessOptimizer: Fix acceptance threshold for objective improvement

### DIFF
--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -363,8 +363,11 @@ class SacessManager:
         self._best_known_fx = shmem_manager.Value("d", np.inf)
         self._best_known_x = shmem_manager.Array("d", [np.nan] * dim)
         self._rejections = shmem_manager.Value("i", 0)
-        # initial value from [PenasGon2017]_ p.9
-        self._rejection_threshold = shmem_manager.Value("d", 0.1)
+        # The initial value for the acceptance/rejection threshold in
+        # [PenasGon2017]_ p.9 is 0.1.
+        # However, their implementation uses 0.1 *percent*. I assume this is a
+        # mistake in the paper.
+        self._rejection_threshold = shmem_manager.Value("d", 0.001)
         # scores of the workers, ordered by worker-index
         # initial score is the worker index
         self._worker_scores = shmem_manager.Array(


### PR DESCRIPTION
There seems to be a difference in the acceptance threshold for objective improvement that is reported in the sacess paper and the value that is used in the implementation. Changing to the value used in the original implementation.

For the manager:
[Paper](https://doi.org/10.1186/s12859-016-1452-4): 10%
Implementation accompanying the paper: [0.5%](https://bitbucket.org/DavidPenas/sacess-library/src/18b2027af5b97158e5d5303487455e5e529bcf5a/src/method_module_fortran/eSS/parallelscattersearchfunctions.f90#lines-388) 
More [recent](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1011151) implementation: [0.01%](https://bitbucket.org/DavidPenas/sacess-library/src/508e7ac15579104731cf1f8c3969960c6e72b872/src/method_module_fortran/eSS/parallelscattersearchfunctions.f90#lines-396)
Also added a check for the minimum acceptance threshold as in the original implementation. 

For the workers: 
should be 0.01% instead 0.01.