### PR TITLE
GHA: trigger CI workflow on merge_group event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     - develop
   pull_request:
   workflow_dispatch:
+  merge_group:
   schedule:
     # run Monday and Thursday at 03:42 UTC
     - cron: '42 3 * * MON,THU'


### PR DESCRIPTION
Trigger CI workflow on `merge_group` event.

Required for #1478. 

Closes #1478.