### PR TITLE
Clean up sampling tests

### DIFF
--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -85,7 +85,7 @@ def sampler(request):
     elif request.param == "Pymc":
         from pypesto.sample.pymc import PymcSampler
 
-        return PymcSampler(tune=5, progressbar=False)
+        return PymcSampler(tune=5, progressbar=False, chains=N_CHAINS)
     elif request.param == "Emcee":
         return sample.EmceeSampler(nwalkers=10)
     elif request.param == "Dynesty":

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -276,6 +276,7 @@ def test_ground_truth():
     assert statistic > 0.1
 
 
+@pytest.mark.flaky(reruns=3)
 def test_ground_truth_separated_modes():
     """Test whether we actually retrieve correct distributions."""
     # use best self-implemented sampler, which has a chance to correctly
@@ -294,7 +295,7 @@ def test_ground_truth_separated_modes():
 
     result = sample.sample(
         problem,
-        n_samples=1e4,
+        n_samples=2000,
         sampler=sampler,
         x0=np.array([0.0]),
     )
@@ -304,9 +305,9 @@ def test_ground_truth_separated_modes():
 
     # generate bimodal ground-truth samples
     # "first" mode centered at -1
-    rvs1 = norm.rvs(size=5000, loc=-1.0, scale=np.sqrt(0.7))
+    rvs1 = norm.rvs(size=1000, loc=-1.0, scale=np.sqrt(0.7))
     # "second" mode centered at 100
-    rvs2 = norm.rvs(size=5001, loc=100.0, scale=np.sqrt(0.8))
+    rvs2 = norm.rvs(size=1001, loc=100.0, scale=np.sqrt(0.8))
 
     # test for distribution similarity
     statistic, pval = ks_2samp(np.concatenate([rvs1, rvs2]), samples)
@@ -324,7 +325,7 @@ def test_ground_truth_separated_modes():
     )
     result = sample.sample(
         problem,
-        n_samples=1e4,
+        n_samples=2000,
         sampler=sampler,
         x0=np.array([-2.0]),
     )
@@ -354,7 +355,7 @@ def test_ground_truth_separated_modes():
     )
     result = sample.sample(
         problem,
-        n_samples=1e4,
+        n_samples=2000,
         sampler=sampler,
         x0=np.array([120.0]),
     )
@@ -412,19 +413,21 @@ def test_regularize_covariance():
 
 
 @pytest.mark.parametrize(
-    "warm_up_size, converged_size, expected_burn_in",
+    "non_converged_size, converged_size",
     [
-        (100, 901, 100),  # "Larger" sample numbers
-        (25, 75, 25),  # Small sample numbers
+        (100, 901),  # "Larger" sample numbers
+        (25, 75),  # Small sample numbers
     ],
 )
-def test_geweke_test_switch(warm_up_size, converged_size, expected_burn_in):
+def test_geweke_test_switch(
+    non_converged_size, converged_size, expected_burn_in
+):
     """Check geweke test returns expected burn in index for different chain sizes."""
-    warm_up = np.zeros((warm_up_size, 2))
+    warm_up = np.zeros((non_converged_size, 2))
     converged = np.ones((converged_size, 2))
     chain = np.concatenate((warm_up, converged), axis=0)
     burn_in = sample.diagnostics.burn_in_by_sequential_geweke(chain=chain)
-    assert burn_in == expected_burn_in
+    assert burn_in == non_converged_size
 
 
 def test_geweke_test_unconverged():

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -173,7 +173,7 @@ def test_ground_truth():
 
 def test_multiple_startpoints():
     problem = gaussian_problem()
-    x0s = [np.array([0]), np.array([1])]
+    x0s = [np.array([0]), np.array([1]), np.array([2])]
     sampler = sample.ParallelTemperingSampler(
         internal_sampler=sample.MetropolisSampler(),
         options={
@@ -188,10 +188,11 @@ def test_multiple_startpoints():
         sampler=sampler,
     )
 
-    assert result.sample_result.trace_neglogpost.shape[0] == 2
+    assert result.sample_result.trace_neglogpost.shape[0] == N_CHAINS
     assert [
         result.sample_result.trace_x[0][0],
         result.sample_result.trace_x[1][0],
+        result.sample_result.trace_x[2][0],
     ] == x0s
 
 

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -128,24 +128,6 @@ def create_petab_problem():
     return problem
 
 
-def sample_petab_problem():
-    # create problem
-    problem = create_petab_problem()
-
-    sampler = sample.AdaptiveMetropolisSampler(
-        options={
-            "show_progress": False,
-        },
-    )
-    result = sample.sample(
-        problem,
-        n_samples=1000,
-        sampler=sampler,
-        x0=np.array([3, -4]),
-    )
-    return result
-
-
 def prior(x):
     return multivariate_normal.pdf(x, mean=-1.0, cov=0.7)
 

--- a/test/sample/test_sample.py
+++ b/test/sample/test_sample.py
@@ -429,23 +429,20 @@ def test_regularize_covariance():
     assert np.all(np.linalg.eigvals(reg) >= 0)
 
 
-def test_geweke_test_switch():
-    """Check geweke test returns expected burn in index."""
-    warm_up = np.zeros((100, 2))
-    converged = np.ones((901, 2))
+@pytest.mark.parametrize(
+    "warm_up_size, converged_size, expected_burn_in",
+    [
+        (100, 901, 100),  # "Larger" sample numbers
+        (25, 75, 25),  # Small sample numbers
+    ],
+)
+def test_geweke_test_switch(warm_up_size, converged_size, expected_burn_in):
+    """Check geweke test returns expected burn in index for different chain sizes."""
+    warm_up = np.zeros((warm_up_size, 2))
+    converged = np.ones((converged_size, 2))
     chain = np.concatenate((warm_up, converged), axis=0)
     burn_in = sample.diagnostics.burn_in_by_sequential_geweke(chain=chain)
-    assert burn_in == 100
-
-
-def test_geweke_test_switch_short():
-    """Check geweke test returns expected burn in index
-    for small sample numbers."""
-    warm_up = np.zeros((25, 2))
-    converged = np.ones((75, 2))
-    chain = np.concatenate((warm_up, converged), axis=0)
-    burn_in = sample.diagnostics.burn_in_by_sequential_geweke(chain=chain)
-    assert burn_in == 25
+    assert burn_in == expected_burn_in
 
 
 def test_geweke_test_unconverged():

--- a/test/sample/util.py
+++ b/test/sample/util.py
@@ -2,10 +2,10 @@
 
 
 import numpy as np
+import scipy.optimize as so
 from scipy.stats import multivariate_normal, norm, uniform
 
 import pypesto
-import pypesto.optimize as optimize
 
 # Constants for Gaussian problems or Uniform with Gaussian prior
 MU = 0  # Gaussian mean
@@ -118,7 +118,7 @@ def gaussian_mixture_separated_modes_problem():
 
 def rosenbrock_problem():
     """Problem based on Rosenbrock objective."""
-    objective = pypesto.Objective(fun=optimize.rosen, grad=optimize.rosen_der)
+    objective = pypesto.Objective(fun=so.rosen, grad=so.rosen_der)
 
     dim_full = 2
     lb = -5 * np.ones((dim_full, 1))

--- a/test/sample/util.py
+++ b/test/sample/util.py
@@ -1,0 +1,177 @@
+"""Utility functions and constants for tests. Mainly problem definitions."""
+
+
+import numpy as np
+from scipy.stats import multivariate_normal, norm, uniform
+
+import pypesto
+import pypesto.optimize as optimize
+
+# Constants for Gaussian problems or Uniform with Gaussian prior
+MU = 0  # Gaussian mean
+SIGMA = 1  # Gaussian standard deviation
+LB_GAUSSIAN = [-10]  # Lower bound for Gaussian problem
+UB_GAUSSIAN = [10]  # Upper bound for Gaussian problem
+LB_GAUSSIAN_MODES = [-100]  # Lower bound for Gaussian modes problem
+UB_GAUSSIAN_MODES = [200]  # Upper bound for Gaussian modes problem
+X_NAMES = ["x"]  # Parameter names
+MIXTURE_WEIGHTS = [0.3, 0.7]  # Weights for Gaussian mixture model
+MIXTURE_MEANS = [-1.5, 2.5]  # Means for Gaussian mixture model
+MIXTURE_COVS = [0.1, 0.2]  # Covariances for Gaussian mixture model
+SEPARATED_MODES_MEANS = [-1.0, 100.0]  # Means for separated modes
+SEPARATED_MODES_COVS = [0.7, 0.8]  # Covariances for separated modes
+
+# Constants for general testing
+N_STARTS_FEW = 5  # Number of starts for tests that dont require convergence
+N_STARTS_SOME = 10  # Number of starts for tests that converge reliably
+N_SAMPLE_FEW = 100  # Number of samples for tests that dont require convergence
+N_SAMPLE_SOME = 1000  # Number of samples for tests that converge reliably
+N_SAMPLE_MANY = 5000  # Number of samples for tests that require convergence
+STATISTIC_TOL = 0.2  # Tolerance when comparing distributions
+N_CHAINS = 3  # Number of chains for ParallelTempering
+
+
+def gaussian_llh(x):
+    """Log-likelihood for Gaussian."""
+    return float(norm.logpdf(x, loc=MU, scale=SIGMA).item())
+
+
+def gaussian_nllh_grad(x):
+    """Negative log-likelihood gradient for Gaussian."""
+    return np.array([((x - MU) / (SIGMA**2))])
+
+
+def gaussian_nllh_hess(x):
+    """Negative log-likelihood Hessian for Gaussian."""
+    return np.array([(1 / (SIGMA**2))])
+
+
+def gaussian_problem():
+    """Defines a simple Gaussian problem."""
+
+    def nllh(x):
+        return -gaussian_llh(x)
+
+    objective = pypesto.Objective(fun=nllh)
+    problem = pypesto.Problem(
+        objective=objective, lb=LB_GAUSSIAN, ub=UB_GAUSSIAN
+    )
+    return problem
+
+
+def gaussian_mixture_llh(x):
+    """Log-likelihood for Gaussian mixture model."""
+    return np.log(
+        MIXTURE_WEIGHTS[0]
+        * multivariate_normal.pdf(
+            x, mean=MIXTURE_MEANS[0], cov=MIXTURE_COVS[0]
+        )
+        + MIXTURE_WEIGHTS[1]
+        * multivariate_normal.pdf(
+            x, mean=MIXTURE_MEANS[1], cov=MIXTURE_COVS[1]
+        )
+    )
+
+
+def gaussian_mixture_problem():
+    """Problem based on a mixture of Gaussians."""
+
+    def nllh(x):
+        return -gaussian_mixture_llh(x)
+
+    objective = pypesto.Objective(fun=nllh)
+    problem = pypesto.Problem(
+        objective=objective, lb=LB_GAUSSIAN, ub=UB_GAUSSIAN, x_names=X_NAMES
+    )
+    return problem
+
+
+def gaussian_mixture_separated_modes_llh(x):
+    """Log-likelihood for Gaussian mixture model with separated modes."""
+    return np.log(
+        0.5
+        * multivariate_normal.pdf(
+            x, mean=SEPARATED_MODES_MEANS[0], cov=SEPARATED_MODES_COVS[0]
+        )
+        + 0.5
+        * multivariate_normal.pdf(
+            x, mean=SEPARATED_MODES_MEANS[1], cov=SEPARATED_MODES_COVS[1]
+        )
+    )
+
+
+def gaussian_mixture_separated_modes_problem():
+    """Problem based on a mixture of Gaussians with far-separated modes."""
+
+    def nllh(x):
+        return -gaussian_mixture_separated_modes_llh(x)
+
+    objective = pypesto.Objective(fun=nllh)
+    problem = pypesto.Problem(
+        objective=objective,
+        lb=LB_GAUSSIAN_MODES,
+        ub=UB_GAUSSIAN_MODES,
+        x_names=X_NAMES,
+    )
+    return problem
+
+
+def rosenbrock_problem():
+    """Problem based on Rosenbrock objective."""
+    objective = pypesto.Objective(fun=optimize.rosen, grad=optimize.rosen_der)
+
+    dim_full = 2
+    lb = -5 * np.ones((dim_full, 1))
+    ub = 5 * np.ones((dim_full, 1))
+
+    problem = pypesto.Problem(
+        objective=objective,
+        lb=lb,
+        ub=ub,
+        x_fixed_indices=[1],
+        x_fixed_vals=[2],
+    )
+    return problem
+
+
+def create_petab_problem():
+    """Creates a petab problem."""
+    import os
+
+    import petab.v1 as petab
+
+    import pypesto.petab
+
+    current_path = os.path.dirname(os.path.realpath(__file__))
+    dir_path = os.path.abspath(
+        os.path.join(current_path, "..", "..", "doc", "example")
+    )
+
+    petab_problem = petab.Problem.from_yaml(
+        dir_path + "/conversion_reaction/conversion_reaction.yaml"
+    )
+
+    importer = pypesto.petab.PetabImporter(petab_problem)
+    problem = importer.create_problem()
+
+    return problem
+
+
+def prior(x):
+    """Calculates the prior."""
+    return multivariate_normal.pdf(x, mean=-1.0, cov=0.7)
+
+
+def likelihood(x):
+    """Calculates the likelihood."""
+    return uniform.pdf(x, loc=-10.0, scale=20.0)[0]
+
+
+def negative_log_posterior(x):
+    """Calculates the negative log posterior."""
+    return -np.log(likelihood(x)) - np.log(prior(x))
+
+
+def negative_log_prior(x):
+    """Calculates the negative log prior."""
+    return -np.log(prior(x))

--- a/test/sample/util.py
+++ b/test/sample/util.py
@@ -18,8 +18,6 @@ X_NAMES = ["x"]  # Parameter names
 MIXTURE_WEIGHTS = [0.3, 0.7]  # Weights for Gaussian mixture model
 MIXTURE_MEANS = [-1.5, 2.5]  # Means for Gaussian mixture model
 MIXTURE_COVS = [0.1, 0.2]  # Covariances for Gaussian mixture model
-SEPARATED_MODES_MEANS = [-1.0, 100.0]  # Means for separated modes
-SEPARATED_MODES_COVS = [0.7, 0.8]  # Covariances for separated modes
 
 # Constants for general testing
 N_STARTS_FEW = 5  # Number of starts for tests that dont require convergence
@@ -82,36 +80,6 @@ def gaussian_mixture_problem():
     objective = pypesto.Objective(fun=nllh)
     problem = pypesto.Problem(
         objective=objective, lb=LB_GAUSSIAN, ub=UB_GAUSSIAN, x_names=X_NAMES
-    )
-    return problem
-
-
-def gaussian_mixture_separated_modes_llh(x):
-    """Log-likelihood for Gaussian mixture model with separated modes."""
-    return np.log(
-        0.5
-        * multivariate_normal.pdf(
-            x, mean=SEPARATED_MODES_MEANS[0], cov=SEPARATED_MODES_COVS[0]
-        )
-        + 0.5
-        * multivariate_normal.pdf(
-            x, mean=SEPARATED_MODES_MEANS[1], cov=SEPARATED_MODES_COVS[1]
-        )
-    )
-
-
-def gaussian_mixture_separated_modes_problem():
-    """Problem based on a mixture of Gaussians with far-separated modes."""
-
-    def nllh(x):
-        return -gaussian_mixture_separated_modes_llh(x)
-
-    objective = pypesto.Objective(fun=nllh)
-    problem = pypesto.Problem(
-        objective=objective,
-        lb=LB_GAUSSIAN_MODES,
-        ub=UB_GAUSSIAN_MODES,
-        x_names=X_NAMES,
     )
     return problem
 

--- a/test/variational/test_variational.py
+++ b/test/variational/test_variational.py
@@ -1,29 +1,15 @@
 """Tests for `pypesto.sample` methods."""
 
-import pytest
 from scipy.stats import kstest
 
 import pypesto.optimize as optimize
 from pypesto.variational import variational_fit
 
-from ..sample.test_sample import (
-    gaussian_mixture_problem,
-    gaussian_problem,
-    rosenbrock_problem,
-)
+from ..sample.test_sample import problem  # noqa: F401, fixture from sampling
+from ..sample.util import STATISTIC_TOL, gaussian_problem
 
 
-@pytest.fixture(params=["gaussian", "gaussian_mixture", "rosenbrock"])
-def problem(request):
-    if request.param == "gaussian":
-        return gaussian_problem()
-    if request.param == "gaussian_mixture":
-        return gaussian_mixture_problem()
-    elif request.param == "rosenbrock":
-        return rosenbrock_problem()
-
-
-def test_pipeline(problem):
+def test_pipeline(problem):  # noqa: F811
     """Check that a typical pipeline runs through."""
     # optimization
     optimizer = optimize.ScipyOptimizer(options={"maxiter": 10})
@@ -35,7 +21,7 @@ def test_pipeline(problem):
     )
 
     # sample
-    result = variational_fit(
+    variational_fit(
         problem=problem,
         n_iterations=100,
         n_samples=10,
@@ -45,15 +31,15 @@ def test_pipeline(problem):
 
 def test_ground_truth():
     """Test whether we actually retrieve correct distributions."""
-    problem = gaussian_problem()
+    problem_gaussian = gaussian_problem()
 
     result = optimize.minimize(
-        problem,
+        problem_gaussian,
         progress_bar=False,
     )
 
     result = variational_fit(
-        problem,
+        problem_gaussian,
         n_iterations=10000,
         n_samples=5000,
         result=result,
@@ -65,8 +51,8 @@ def test_ground_truth():
     # test against different distributions
     statistic, pval = kstest(samples, "norm")
     print(statistic, pval)
-    assert statistic < 0.1
+    assert statistic < STATISTIC_TOL
 
     statistic, pval = kstest(samples, "uniform")
     print(statistic, pval)
-    assert statistic > 0.1
+    assert statistic > STATISTIC_TOL


### PR DESCRIPTION
- Moved problem definitions into a utility file
- Sped up Dynasty sampling in pipeline (kudos to Jonas)
- Removed the separated modes test, as it was less of a test, more of a showcase - covered in sampler_study.ipyn
- Moved harmonic mean to other evidence calculations

Should speed up most of the very slow tests in `base`, clean up the code and thereby adress #1475 