### PR TITLE
Hierarchical: fix no error if inner observable parameter in noise formula & viceversa

### DIFF
--- a/pypesto/hierarchical/petab.py
+++ b/pypesto/hierarchical/petab.py
@@ -640,7 +640,10 @@ def validate_observable_data_types(petab_problem: petab.Problem) -> None:
             other_data_type,
             other_observables,
         ) in observables_by_data_type.items():
-            if data_type == other_data_type:
+            if data_type == other_data_type or (
+                data_type in CENSORING_TYPES
+                and other_data_type in CENSORING_TYPES
+            ):
                 continue
             if observables & other_observables:
                 raise ValueError(


### PR DESCRIPTION
If an inner observable parameter was present in the noise formula, there was no error, even though that's not compatible with hierarchical optimization. This was caused by not searching for observable placeholders, overrides, and inner parameters in noise formulas and vice versa.