### PR TITLE
Hierarchical: remove inner datas from relative calculator

### DIFF
--- a/pypesto/C.py
+++ b/pypesto/C.py
@@ -93,7 +93,6 @@ PETAB = "petab"
 # HIERARCHICAL SCALING + OFFSET
 
 INNER_PARAMETERS = "inner_parameters"
-INNER_RDATAS = "inner_rdatas"
 PARAMETER_TYPE = "parameterType"
 RELATIVE = "relative"
 

--- a/pypesto/hierarchical/relative/calculator.py
+++ b/pypesto/hierarchical/relative/calculator.py
@@ -21,7 +21,6 @@ from ...C import (
     GRAD,
     HESS,
     INNER_PARAMETERS,
-    INNER_RDATAS,
     RDATAS,
     RES,
     SRES,
@@ -365,6 +364,6 @@ class RelativeAmiciCalculator(AmiciCalculator):
             rdatas=rdatas,
             inner_parameters=inner_parameters,
         )
-        inner_result[INNER_RDATAS] = rdatas
+        inner_result[RDATAS] = rdatas
 
         return inner_result, inner_parameters


### PR DESCRIPTION
Don't think there's any need for the `inner_rdatas` as well as `rdatas` in the output of the calculator. Looks like an artifact of something from before.