### PR TITLE
PEtab: Fix warning from `fill_in_parameters` with fixed parameters

### DIFF
--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -707,3 +707,9 @@ class AmiciObjective(ObjectiveBase):
             ) in condition_mapping.map_sim_var.items():
                 if (val := id_to_val.get(mapped_to_par)) is not None:
                     condition_mapping.map_sim_var[model_par] = val
+            for (
+                model_par,
+                mapped_to_par,
+            ) in condition_mapping.map_sim_fix.items():
+                if (val := id_to_val.get(mapped_to_par)) is not None:
+                    condition_mapping.map_sim_fix[model_par] = val

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -479,12 +479,13 @@ class AmiciObjective(ObjectiveBase):
             edatas = self.edatas
         if parameter_mapping is None:
             parameter_mapping = self.parameter_mapping
+        # Some parameters may appear estimated in the original compiled model,
+        # but then are fixed during parameter estimation. These can be
+        # removed from the parameter vector.
+        x_dct_free = x_dct.copy()
+        x_dct_fixed = {k: x_dct_free.pop(k) for k in self._fixed_parameter_ids}
         ret = self.calculator(
-            x_dct={
-                par_id: val
-                for par_id, val in x_dct.items()
-                if par_id not in self._fixed_parameter_ids
-            },
+            x_dct=x_dct_free,
             sensi_orders=sensi_orders,
             mode=mode,
             amici_model=self.amici_model,
@@ -494,6 +495,7 @@ class AmiciObjective(ObjectiveBase):
             x_ids=self.x_ids,
             parameter_mapping=parameter_mapping,
             fim_for_hess=self.fim_for_hess,
+            ensure_fixed_values=x_dct_fixed,
         )
 
         nllh = ret[FVAL]

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -184,6 +184,7 @@ class AmiciObjective(ObjectiveBase):
         self.parameter_mapping = parameter_mapping
         # parameter mapping independent of fixed parameters
         self._parameter_mapping_full = copy.deepcopy(parameter_mapping)
+        self._fixed_parameter_ids = []
         # If supported, enable `guess_steadystate` by default. If not
         #  supported, disable by default. If requested but unsupported, raise.
         if (
@@ -479,7 +480,11 @@ class AmiciObjective(ObjectiveBase):
         if parameter_mapping is None:
             parameter_mapping = self.parameter_mapping
         ret = self.calculator(
-            x_dct=x_dct,
+            x_dct={
+                par_id: val
+                for par_id, val in x_dct.items()
+                if par_id not in self._fixed_parameter_ids
+            },
             sensi_orders=sensi_orders,
             mode=mode,
             amici_model=self.amici_model,
@@ -679,6 +684,7 @@ class AmiciObjective(ObjectiveBase):
         #  and replace the IDs of all fixed parameters by their respective
         #  values.
         self.parameter_mapping = copy.deepcopy(self._parameter_mapping_full)
+        self._fixed_parameter_ids = [self.x_ids[i] for i in x_fixed_indices]
         if not len(x_fixed_indices):
             return
 

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -58,7 +58,6 @@ class AmiciCalculator:
         x_ids: Sequence[str],
         parameter_mapping: ParameterMapping,
         fim_for_hess: bool,
-        ensure_fixed_values: dict[str, float] = None,
     ):
         """Perform the actual AMICI call.
 
@@ -87,13 +86,8 @@ class AmiciCalculator:
         fim_for_hess:
             Whether to use the FIM (if available) instead of the Hessian (if
             requested).
-        ensure_fixed_values:
-            Ensure fixed parameters take a certain value. Keys are parameter
-            IDs, values are the fixed parameter values.
         """
         import amici.petab.conditions
-
-        ensure_fixed_values = ensure_fixed_values or {}
 
         # set order in solver
         sensi_order = 0
@@ -114,16 +108,6 @@ class AmiciCalculator:
             parameter_mapping=parameter_mapping,
             amici_model=amici_model,
         )
-
-        for par_id, val0 in ensure_fixed_values.items():
-            par_idx = amici_model.getParameterIds().index(par_id)
-            for edata in edatas:
-                if (val1 := edata.parameters[par_idx]) != val0:
-                    raise AssertionError(
-                        f"Unexpected error. The parameter `{par_id}` is "
-                        f"expected to be fixed to `{val0}`, but is `{val1}`, "
-                        f"in AMICI edata: {edata.id}."
-                    )
 
         # run amici simulation
         rdatas = amici.runAmiciSimulations(

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -119,10 +119,10 @@ class AmiciCalculator:
             par_idx = amici_model.getParameterIds().index(par_id)
             for edata in edatas:
                 if (val1 := edata.parameters[par_idx]) != val0:
-                    raise ValueError(
+                    raise AssertionError(
                         f"Unexpected error. The parameter `{par_id}` is "
-                        f"expected to be fixed to {val0}, but is `{val1},"
-                        f"in AMICI edata: {edata}"
+                        f"expected to be fixed to `{val0}`, but is `{val1}`, "
+                        f"in AMICI edata: {edata.id}."
                     )
 
         # run amici simulation

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -120,7 +120,7 @@ class AmiciCalculator:
             for edata in edatas:
                 if (val1 := edata.parameters[par_idx]) != val0:
                     raise ValueError(
-                        "Unexpected error. The parameter `{par_id}` is "
+                        f"Unexpected error. The parameter `{par_id}` is "
                         f"expected to be fixed to {val0}, but is `{val1},"
                         f"in AMICI edata: {edata}"
                     )


### PR DESCRIPTION
Fixes a warning `RuntimeWarning: The following problem parameters were not used: {[...]}
  amici.petab.conditions.fill_in_parameters(` in case of fixed parameters.
The warning was issued since https://github.com/ICB-DCM/pyPESTO/pull/1493. 

This also fills in the fixed parameter values in the parameter mapping for the fixed parameters that was missing in https://github.com/ICB-DCM/pyPESTO/pull/1493.