### PR TITLE
Fix handling of PEtab fixed parameters

### DIFF
--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -713,3 +713,9 @@ class AmiciObjective(ObjectiveBase):
             ) in condition_mapping.map_sim_fix.items():
                 if (val := id_to_val.get(mapped_to_par)) is not None:
                     condition_mapping.map_sim_fix[model_par] = val
+            for (
+                model_par,
+                mapped_to_par,
+            ) in condition_mapping.map_preeq_fix.items():
+                if (val := id_to_val.get(mapped_to_par)) is not None:
+                    condition_mapping.map_preeq_fix[model_par] = val

--- a/test/petab/test_petab_import.py
+++ b/test/petab/test_petab_import.py
@@ -36,12 +36,13 @@ class PetabImportTest(unittest.TestCase):
         cls.obj_edatas = []
 
     def test_0_import(self):
-        for model_name in ["Zheng_PNAS2012", "Boehm_JProteomeRes2014"]:
+        for model_name in [
+            "Zheng_PNAS2012",
+            "Boehm_JProteomeRes2014",
+            "Weber_BMC2015",
+        ]:
             # test yaml import for one model:
-            yaml_config = os.path.join(
-                models.MODELS_DIR, model_name, model_name + ".yaml"
-            )
-            petab_problem = petab.Problem.from_yaml(yaml_config)
+            petab_problem = models.get_problem(model_name)
             self.petab_problems.append(petab_problem)
 
     def test_1_compile(self):


### PR DESCRIPTION
Follow-up to #1493 and #1509, which only filled in PEtab-fixed parameters for simulation but not preequilibration in the parameter mapping.

Adding Weber_BMC2015 to the PEtab tests, where this issue popped up.