### PR TITLE
Improve exception-handling in SacessOptimizer

### DIFF
--- a/pypesto/optimize/ess/ess.py
+++ b/pypesto/optimize/ess/ess.py
@@ -37,6 +37,8 @@ class ESSExitFlag(int, enum.Enum):
     MAX_EVAL = -2
     # Exited after exhausting wall-time budget
     MAX_TIME = -3
+    # Termination because for other reason than exit criteria
+    ERROR = -99
 
 
 class OptimizerFactory(Protocol):


### PR DESCRIPTION
Previously, uncaught exceptions in SacessOptimizer worker processes would have resulted in deadlocks in `SacessOptimizer.minimize`.

These changes will (in most cases) prevent deadlocks and other errors due to missing results from individual workers. Furthermore, this will lead to termination of minimize() relatively soon after an error occurred on some worker - not only after some other exit criterion is met.

Closes #1512.