### PR TITLE
Exclude nlopt==2.9.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,8 @@ ipopt =
 dlib =
     dlib >= 19.19.0
 nlopt =
-    nlopt >= 2.6.2
+    # != 2.9.0: https://github.com/stevengj/nlopt/issues/575
+    nlopt >= 2.6.2, != 2.9.0
 pyswarm =
     pyswarm >= 0.6
 cma =


### PR DESCRIPTION
We want to avoid nlopt-python 2.9.0 because it does not match nlopt v2.9.0 and is affected by https://github.com/stevengj/nlopt/issues/575.

Closes #1511.