### PR TITLE
Fix test_deepcopy_objective, test_preeq_guesses

### DIFF
--- a/test/base/test_engine.py
+++ b/test/base/test_engine.py
@@ -86,7 +86,14 @@ def test_deepcopy_objective():
         )
     )
     factory = petab_importer.create_objective_creator()
-    objective = factory.create_objective()
+    amici_model = factory.create_model()
+    amici_model.setSteadyStateSensitivityMode(
+        amici.SteadyStateSensitivityMode.integrateIfNewtonFails
+    )
+    amici_model.setSteadyStateComputationMode(
+        amici.SteadyStateComputationMode.integrateIfNewtonFails
+    )
+    objective = factory.create_objective(model=amici_model)
 
     objective.amici_solver.setSensitivityMethod(
         amici.SensitivityMethod_adjoint

--- a/test/petab/test_amici_objective.py
+++ b/test/petab/test_amici_objective.py
@@ -86,12 +86,21 @@ def test_preeq_guesses():
     importer = pypesto.petab.PetabImporter.from_yaml(
         os.path.join(models.MODELS_DIR, model_name, model_name + ".yaml")
     )
-    problem = importer.create_problem()
-    obj = problem.objective
-    obj.amici_solver.setNewtonMaxSteps(0)
+    obj_creator = importer.create_objective_creator()
+    amici_model = obj_creator.create_model()
+    amici_model.setSteadyStateComputationMode(
+        amici.SteadyStateComputationMode.integrateIfNewtonFails
+    )
+    amici_model.setSteadyStateSensitivityMode(
+        amici.SteadyStateSensitivityMode.integrateIfNewtonFails
+    )
+    obj = obj_creator.create_objective(model=amici_model)
+    problem = importer.create_problem(objective=obj)
     obj.amici_model.setSteadyStateSensitivityMode(
         amici.SteadyStateSensitivityMode.integrationOnly
     )
+    obj = problem.objective
+    obj.amici_solver.setNewtonMaxSteps(0)
     obj.amici_solver.setAbsoluteTolerance(1e-12)
     obj.amici_solver.setRelativeTolerance(1e-12)
 


### PR DESCRIPTION
* Fix test_deepcopy_objective (Fixes #1520)
* Fix test_preeq_guesses 

Failures were related to changes in amici's default steady-state settings.