### PR TITLE
Don't modify sys.path for amici model imports

### DIFF
--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -7,7 +7,6 @@ import numbers
 import os
 import re
 import shutil
-import sys
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
@@ -144,10 +143,6 @@ class AmiciObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
                 f"Refusing to remove {self.output_folder} for model "
                 f"compilation: Not a folder."
             )
-
-        # add module to path
-        if self.output_folder not in sys.path:
-            sys.path.insert(0, self.output_folder)
 
         # compile
         if self._must_compile(force_compile):

--- a/test/petab/test_amici_predictor.py
+++ b/test/petab/test_amici_predictor.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import sys
 
 import amici
 import libsbml
@@ -34,13 +33,10 @@ def conversion_reaction_model():
 
     # try to import the exisiting model, if possible
     try:
-        sys.path.insert(0, os.path.abspath(model_output_dir))
         model_module = amici.import_model_module(model_name, model_output_dir)
         model = model_module.getModel()
     except ValueError:
         # read in and adapt the sbml slightly
-        if os.path.abspath(model_output_dir) in sys.path:
-            sys.path.remove(os.path.abspath(model_output_dir))
         sbml_importer = amici.SbmlImporter(sbml_file)
 
         # add observables to sbml model
@@ -95,7 +91,6 @@ def conversion_reaction_model():
         )
 
         # Importing the module and loading the model
-        sys.path.insert(0, os.path.abspath(model_output_dir))
         model_module = amici.import_model_module(model_name, model_output_dir)
         model = model_module.getModel()
     except RuntimeError as err:
@@ -107,7 +102,6 @@ def conversion_reaction_model():
             "Delete the conversion_reaction_enhanced model from your python "
             "path and retry. Your python path is currently:"
         )
-        print(sys.path)
         print("Original error message:")
         raise err
 

--- a/test/petab/test_sbml_conversion.py
+++ b/test/petab/test_sbml_conversion.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import unittest
 import warnings
 
@@ -10,8 +9,6 @@ import pypesto
 import pypesto.optimize
 
 from ..util import load_amici_objective
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 optimizers = {
     "scipy": [


### PR DESCRIPTION
Not necessary when using `amici.import_model_module`.