### PR TITLE
CI: don't cache amici; pytest ignore amici_models; passenv BNGPATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
     - name: Run tests
       timeout-minutes: 35
-      run: tox -e petab
+      run: tox -e petab && tox e -e petab -- pip uninstall -y amici
       env:
         CC: clang
         CXX: clang++

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 addopts = "--doctest-modules"
 filterwarnings =
     ignore:.*inspect.getargspec\(\) is deprecated.*:DeprecationWarning
+norecursedirs = amici_models

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ envlist =
 # Base-environment
 
 [testenv]
-passenv = AMICI_PARALLEL_COMPILE,CC,CXX,MPLBACKEND
+passenv = AMICI_PARALLEL_COMPILE,CC,CXX,MPLBACKEND,BNGPATH
 
 # Sub-environments
 #  inherit settings defined in the base
@@ -75,10 +75,14 @@ description =
     Test basic functionality on Windows
 
 [testenv:petab]
-extras = test,amici,petab,pyswarm,roadrunner
+extras = test,petab,pyswarm,roadrunner
 deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
-    git+https://github.com/AMICI-dev/amici.git@develop\#egg=amici&subdirectory=python/sdist
+# always install amici from develop branch, avoid caching
+#  to skip re-installation, run `tox -e petab --override testenv:petab.commands_pre=`
+commands_pre =
+    python3 -m pip uninstall -y amici
+    python3 -m pip install git+https://github.com/AMICI-dev/amici.git@develop\#egg=amici&subdirectory=python/sdist
 commands =
     python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@main
     python3 -m pip install git+https://github.com/pysb/pysb@master


### PR DESCRIPTION
* Don't cache the amici installation. We are using amici/develop on purpose to detect problems early on. E.g., #1520 should have been detected much earlier.
* Ignore `amici_models` when collecting tests
* Use external `BNGPATH` if set