### PR TITLE
SacessOptimizer: More efficient saving of intermediate results

### DIFF
--- a/pypesto/optimize/ess/__init__.py
+++ b/pypesto/optimize/ess/__init__.py
@@ -1,6 +1,6 @@
 """Enhanced Scatter Search."""
 
-from .ess import ESSOptimizer
+from .ess import ESSExitFlag, ESSOptimizer
 from .function_evaluator import (
     FunctionEvaluator,
     FunctionEvaluatorMP,

--- a/pypesto/optimize/ess/ess.py
+++ b/pypesto/optimize/ess/ess.py
@@ -27,17 +27,21 @@ __all__ = ["ESSOptimizer", "ESSExitFlag"]
 
 
 class ESSExitFlag(int, enum.Enum):
-    """Exit flags used by :class:`ESSOptimizer`."""
+    """Scatter search exit flags.
+
+    Exit flags used by :class:`pypesto.ess.ESSOptimizer` and
+    :class:`pypesto.ess.SacessOptimizer`.
+    """
 
     # ESS did not run/finish yet
     DID_NOT_RUN = 0
-    # Exited after reaching maximum number of iterations
+    # Exited after reaching the maximum number of iterations
     MAX_ITER = -1
     # Exited after exhausting function evaluation budget
     MAX_EVAL = -2
     # Exited after exhausting wall-time budget
     MAX_TIME = -3
-    # Termination because for other reason than exit criteria
+    # Termination because of other reasons than exit criteria
     ERROR = -99
 
 
@@ -242,6 +246,8 @@ class ESSOptimizer:
         # Overall best function value found so far
         self.fx_best: float = np.inf
         # Results from local searches (only those with finite fval)
+        # (there is potential to save memory here by only keeping the
+        # parameters in memory and not the full result)
         self.local_solutions: list[OptimizerResult] = []
         # Index of current iteration
         self.n_iter: int = 0

--- a/pypesto/visualize/optimizer_history.py
+++ b/pypesto/visualize/optimizer_history.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections.abc import Iterable
 from typing import Optional, Union
 
@@ -501,6 +502,8 @@ def sacess_history(
     The plot axes. `ax` or a new axes if `ax` was `None`.
     """
     ax = ax or plt.subplot()
+    if len(histories) == 0:
+        warnings.warn("No histories to plot.", stacklevel=2)
 
     # plot overall minimum
     # merge results
@@ -530,6 +533,9 @@ def sacess_history(
     # plot steps of individual workers
     for worker_idx, history in enumerate(histories):
         x, y = history.get_time_trace(), history.get_fval_trace()
+        if len(x) == 0:
+            warnings.warn(f"No trace for worker #{worker_idx}.", stacklevel=2)
+            continue
         # extend from last decrease to last timepoint
         x = np.append(x, [np.max(t)])
         y = np.append(y, [np.min(y)])

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -20,6 +20,7 @@ import pypesto
 import pypesto.optimize as optimize
 from pypesto import Objective
 from pypesto.optimize.ess import (
+    ESSExitFlag,
     ESSOptimizer,
     FunctionEvaluatorMP,
     RefSet,
@@ -501,12 +502,14 @@ def test_ess(problem, local_optimizer, ess_type, request):
                 adaptation_sent_coeff=5,
             ),
         )
+
     else:
         raise ValueError(f"Unsupported ESS type {ess_type}.")
 
     res = ess.minimize(
         problem=problem,
     )
+    assert ess.exit_flag in (ESSExitFlag.MAX_TIME, ESSExitFlag.MAX_ITER)
     print("ESS result: ", res.summary())
 
     # best values roughly: cr: 4.701; rosen 7.592e-10

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -1220,7 +1220,7 @@ def test_time_trajectory_model():
 @close_fig
 def test_sacess_history():
     """Test pypesto.visualize.optimizer_history.sacess_history"""
-    from pypesto.optimize.ess.sacess import SacessOptimizer
+    from pypesto.optimize.ess.sacess import ESSExitFlag, SacessOptimizer
     from pypesto.visualize.optimizer_history import sacess_history
 
     problem = create_problem()
@@ -1228,6 +1228,7 @@ def test_sacess_history():
         max_walltime_s=1, num_workers=2, sacess_loglevel=logging.WARNING
     )
     sacess.minimize(problem)
+    assert sacess.exit_flag == ESSExitFlag.MAX_TIME
     sacess_history(sacess.histories)
 
 


### PR DESCRIPTION
Don't write old local optima again and again in every iteration to save time and to avoid huge fragmented files.

Some other smaller modifications/fixes:
* make sacess_history plotting more robust. 
* Set SacessOptimizer.exit_flag
