### PR TITLE
Relative: Fix calculate directly not scaling inner pars when applying to rdatas

### DIFF
--- a/pypesto/hierarchical/relative/solver.py
+++ b/pypesto/hierarchical/relative/solver.py
@@ -238,6 +238,8 @@ class RelativeInnerSolver(InnerSolver):
         """
         sim = [rdata["y"] for rdata in rdatas]
         sigma = [rdata["sigmay"] for rdata in rdatas]
+        inner_parameters = copy.deepcopy(inner_parameters)
+        inner_parameters = scale_back_value_dict(inner_parameters, problem)
 
         # apply offsets, scalings and sigmas
         for x in problem.get_xs_for_type(InnerParameterType.SCALING):


### PR DESCRIPTION
At the end of the `calculate_directly` method of the `RelativeAmiciCalculator` the inner parameters that are optimized need to be applied to the rdatas (compared to the re-simulation of `call_amici_twice` with non-dummy inner parameter values).

However, the inner parameters were not scaled accordingly in this step. E.g. if the scale of a scaling inner parameter (value = 10^-2) was set to LOG10 (log10 value -2), it would stay in LOG10 scale and be applied like that (multiplying its rdata by -2) instead of being scaled to LIN scale and then being applied to the rdatas.