### PR TITLE
Pin petab-select

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -167,9 +167,9 @@ select =
     # Remove when vis is moved to PEtab Select
     networkx >= 2.5.1
     # End remove
-    #petab-select >= 0.1.12
-    # FIXME before merge
-    petab-select @ git+https://github.com/PEtab-dev/petab_select.git@develop
+    # TODO: pinned until https://github.com/ICB-DCM/pyPESTO/pull/1530 is done
+    # petab-select @ git+https://github.com/PEtab-dev/petab_select.git@develop
+    petab-select == 0.2.1
 test =
     pytest >= 5.4.3
     pytest-cov >= 2.10.0


### PR DESCRIPTION
Tests fail because of incompatible un-released changes in petab-select.

To be removed in #1530.