### PR TITLE
make print parameter summary nicer

### DIFF
--- a/pypesto/problem/base.py
+++ b/pypesto/problem/base.py
@@ -495,6 +495,13 @@ class Problem:
                     ],
                     "lb_full": self.lb_full,
                     "ub_full": self.ub_full,
+                    "scale": self.x_scales,
+                    "fixedVal (scaled)": [
+                        self.get_full_vector(np.zeros(self.dim))[idx]
+                        if idx in self.x_fixed_indices
+                        else "-"
+                        for idx in range(self.dim_full)
+                    ],
                 },
             )
         )


### PR DESCRIPTION
This pull request includes a small update to the `print_parameter_summary` method in the `pypesto/problem/base.py` file to add more detailed information about the parameters. I added the fields `scale` and `fixedVal (scaled)`. This can be used to verify that the problem is loaded as expected. Any other wishes what to include here?