### PR TITLE
Make CmaOptimizer respect wall time limits and max evals under SacessOptimizer

### DIFF
--- a/pypesto/optimize/ess/__init__.py
+++ b/pypesto/optimize/ess/__init__.py
@@ -8,6 +8,7 @@ from .function_evaluator import (
 )
 from .refset import RefSet
 from .sacess import (
+    SacessCmaFactory,
     SacessFidesFactory,
     SacessOptimizer,
     SacessOptions,

--- a/test/optimize/test_optimize.py
+++ b/test/optimize/test_optimize.py
@@ -29,6 +29,7 @@ from pypesto.optimize.ess import (
     SacessOptions,
     get_default_ess_options,
 )
+from pypesto.optimize.ess.sacess import SacessCmaFactory
 from pypesto.optimize.util import (
     assign_ids,
 )
@@ -462,7 +463,12 @@ def test_history_beats_optimizer():
 @pytest.mark.parametrize("ess_type", ["ess", "sacess"])
 @pytest.mark.parametrize(
     "local_optimizer",
-    [None, optimize.FidesOptimizer(), SacessFidesFactory()],
+    [
+        None,
+        optimize.FidesOptimizer(),
+        SacessFidesFactory(),
+        SacessCmaFactory(),
+    ],
 )
 @pytest.mark.flaky(reruns=3)
 def test_ess(problem, local_optimizer, ess_type, request):


### PR DESCRIPTION
Adds `SacessCmaFactory` so that the wall time and function evaluation budget of `SacessOptimizer`/`ESSOptimizer` can be passed on to `CmaOptimizer`.