### PR TITLE
Fix SacessOptimizer relative fval improvement check

### DIFF
--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -838,7 +838,7 @@ class SacessWorker:
             or (self._best_known_fx == 0 and fx < 0)
             or (
                 fx < self._best_known_fx
-                and abs((self._best_known_fx - fx) / fx)
+                and abs((self._best_known_fx - fx) / self._best_known_fx)
                 > self._options.worker_acceptance_threshold
             )
         ):


### PR DESCRIPTION
Fix calculation of the relative objective improvement. Not expecting a substantial impact in practice.

Avoids division potential division-by-0 warnings.

Also, add a test for the SacessOptimizer adaptation step.