### PR TITLE
GHA: fix `test_petabSimulator` failures with Python 3.10

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,10 @@ commands =
     python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@main
     python3 -m pip install git+https://github.com/pysb/pysb@master
     python3 -m pip install -U copasi-basico[petab]
+    # https://github.com/ICB-DCM/pyPESTO/issues/1569
+    # https://github.com/copasi/basico/issues/68
+    python3 -m pip install -U python-copasi==4.45.296
+    # upgrade after installing pysb which requires an older sympy
     python3 -m pip install -U sympy
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/petab


### PR DESCRIPTION
Workaround for https://github.com/ICB-DCM/pyPESTO/issues/1569.