### PR TITLE
CI: require jax < 0.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,8 @@ pymc =
     aesara >= 2.8.6
     pymc >= 4.2.1
 jax =
-    jax >= 0.4.1
+    # < 0.6.0: https://github.com/ICB-DCM/pyPESTO/issues/1568
+    jax >= 0.4.1, < 0.6.0
     jaxlib >= 0.4.1
 emcee =
     emcee >= 3.0.2


### PR DESCRIPTION
Workaround for https://github.com/ICB-DCM/pyPESTO/issues/1568.