### PR TITLE
Revert "GHA: fix `test_petabSimulator` failures with Python 3.10 (#15…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -87,9 +87,6 @@ commands =
     python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@main
     python3 -m pip install git+https://github.com/pysb/pysb@master
     python3 -m pip install -U copasi-basico[petab]
-    # https://github.com/ICB-DCM/pyPESTO/issues/1569
-    # https://github.com/copasi/basico/issues/68
-    python3 -m pip install -U python-copasi==4.45.296
     # upgrade after installing pysb which requires an older sympy
     python3 -m pip install -U sympy
     pytest --cov=pypesto --cov-report=xml --cov-append \


### PR DESCRIPTION
…71)"

This reverts commit 1de62106d4e4e531bad55e258852432bcfe508c5.

The issue has been fixed upstream (https://github.com/copasi/python-petab-importer/issues/3#issuecomment-2853809417).

Closes #1569.