### PR TITLE
Fix import in doc/example/synthetic_data.ipynb

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ python:
         - doc
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   apt_packages:
     - clang
     - libatlas-base-dev

--- a/doc/example/synthetic_data.ipynb
+++ b/doc/example/synthetic_data.ipynb
@@ -37,8 +37,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import amici.petab_simulate\n",
     "import petab\n",
+    "from amici.petab.simulator import PetabSimulator\n",
     "\n",
     "import pypesto.optimize\n",
     "import pypesto.petab\n",
@@ -83,9 +83,7 @@
      "name": "#%% md\n"
     }
    },
-   "source": [
-    "**2.** Load a PEtab problem. The synthetic data returned by the PEtab-derived synthetic data generator (later, an instance of `amici.petab_simulate.PetabSimulator`) will be equivalent to replacing the measurements in the PEtab problem's measurements table with simulated values."
-   ]
+   "source": "**2.** Load a PEtab problem. The synthetic data returned by the PEtab-derived synthetic data generator (later, an instance of `amici.petab.simulator.PetabSimulator`) will be equivalent to replacing the measurements in the PEtab problem's measurement table with simulated values."
   },
   {
    "cell_type": "code",
@@ -242,7 +240,7 @@
     "    synthetic_parameters\n",
     ")\n",
     "\n",
-    "simulator = amici.petab_simulate.PetabSimulator(petab_problem_synthetic)\n",
+    "simulator = PetabSimulator(petab_problem_synthetic)\n",
     "# Optional: the AMICI simulator is provided a model, to avoid recompilation\n",
     "petab_problem_synthetic.measurement_df = simulator.simulate(\n",
     "    noise=True,\n",


### PR DESCRIPTION
The previous import was long deprecated and the respective module has been moved in amici 0.32.0.

Also build the documentation on a more recent Ubuntu with a more recent version of SWIG.