### PR TITLE
Require Python3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.11', '3.13']
 
     steps:
     - name: Check out repository
@@ -64,7 +64,7 @@ jobs:
     runs-on: macos-13  # TODO: change to macos-latest after the next release
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - name: Check out repository
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - name: Check out repository
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.13']
 
     steps:
     - name: Check out repository
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.11', '3.13']
 
     # needed to allow julia-actions/cache to delete old caches that it has created
     permissions:
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - name: Check out repository
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.11', '3.13']
 
     steps:
     - name: Check out repository
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.11', '3.13']
 
     steps:
     - name: Check out repository
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - name: Check out repository
@@ -396,7 +396,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository
@@ -426,7 +426,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - name: Check out repository

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,9 @@ classifiers =
     Development Status :: 4 - Beta
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.10
 keywords =
     parameter inference
     optimization
@@ -57,7 +57,7 @@ install_requires =
     tqdm >= 4.46.0
     tabulate >= 0.8.10
 
-python_requires = >=3.10
+python_requires = >=3.11
 include_package_data = True
 
 # Where is my code

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ description =
 
 [testenv:base]
 extras = test,test_petab,amici,petab,emcee,dynesty,mltools,pymc,jax,fides,roadrunner
-
 deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
 # FIXME: Until we have proper PEtab v2 import

--- a/tox.ini
+++ b/tox.ini
@@ -68,8 +68,6 @@ description =
 
 [testenv:windows]
 extras = test
-deps =
-    numpy < 2.0
 commands =
     pytest \
         test/base/test_prior.py \
@@ -113,8 +111,6 @@ description =
 
 [testenv:optimize]
 extras = test,dlib,ipopt,pyswarm,cma,nlopt,fides,mpi,pyswarms,petab
-deps =
-    numpy < 2.0
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize
@@ -161,8 +157,6 @@ description =
 [testenv:doc]
 extras =
     doc,amici,petab,aesara,jax,select,roadrunner
-deps =
-    numpy < 2.0
 commands =
     sphinx-build -W -b html doc/ doc/_build/html
 description =


### PR DESCRIPTION
As per our Python support policy, we drop support for Python 3.10.

Also, run tests with Python 3.13 instead of 3.12.

