### PR TITLE
CI: pin petab_test_suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,9 +50,14 @@ description =
 
 [testenv:base]
 extras = test,test_petab,amici,petab,emcee,dynesty,mltools,aesara,pymc,jax,fides,roadrunner
+
 deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
-    git+https://github.com/PEtab-dev/petab_test_suite@main
+# FIXME: Until we have proper PEtab v2 import
+#  we need `10ffb050380933b60ac192962bf9550a9df65a9c`
+#  with the pseudo-v2 format for pysb tests instead of `main`
+#    git+https://github.com/PEtab-dev/petab_test_suite@main
+    git+https://github.com/PEtab-dev/petab_test_suite@10ffb050380933b60ac192962bf9550a9df65a9c
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/base --durations=0 \
@@ -84,7 +89,11 @@ commands_pre =
     python3 -m pip uninstall -y amici
     python3 -m pip install git+https://github.com/AMICI-dev/amici.git@main\#egg=amici&subdirectory=python/sdist
 commands =
-    python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@main
+# FIXME: Until we have proper PEtab v2 import
+#  we need `10ffb050380933b60ac192962bf9550a9df65a9c`
+#  with the pseudo-v2 format for pysb tests instead of `main`
+#    python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@main
+    python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@10ffb050380933b60ac192962bf9550a9df65a9c
     python3 -m pip install git+https://github.com/pysb/pysb@master
     python3 -m pip install -U copasi-basico[petab]
     # upgrade after installing pysb which requires an older sympy


### PR DESCRIPTION
We don't support the updated PEtab v2 tests yet.