### PR TITLE
Fix setuptools DeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ license_files = LICENSE
 # Search tags
 classifiers =
     Development Status :: 4 - Beta
-    License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.12


### PR DESCRIPTION
Fixes `SetuptoolsDeprecationWarning: License classifiers are deprecated.`.