### PR TITLE
CI: xfail test/petab/test_petabSimulator.py::test_petab_case[0020-sbml-v1.0.0]

### DIFF
--- a/test/petab/test_petabSimulator.py
+++ b/test/petab/test_petabSimulator.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 )
 def test_petab_case(case, model_type, version):
     """Wrapper for _execute_case for handling test outcomes"""
+    # FIXME https://github.com/ICB-DCM/pyPESTO/issues/1583
+    if model_type == "sbml" and version == "v1.0.0" and case == "0020":
+        pytest.xfail(reason="https://github.com/ICB-DCM/pyPESTO/issues/1583")
+
     try:
         _execute_case(case, model_type, version)
     except Exception as e:


### PR DESCRIPTION
Mark as xfail to unblock other PRs. The underlying problem still has to be fixed. See https://github.com/ICB-DCM/pyPESTO/issues/1583.