### PR TITLE
Update roadrunner installation hint

### DIFF
--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -623,8 +623,8 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
         if rr is None:
             if roadrunner is None:
                 raise ImportError(
-                    "The `roadrunner` package is required for this objective "
-                    "function."
+                    "The `roadrunner` package (on PyPI: `libroadrunner`) "
+                    "is required for this objective function."
                 )
             rr = roadrunner.RoadRunner()
         self.rr = rr


### PR DESCRIPTION
We need https://pypi.org/project/libroadrunner/ which is imported as `roadrunner`. We don't want https://pypi.org/project/roadrunner/.