### PR TITLE
Fix IndexError in waterfall for all-non-finite values

### DIFF
--- a/pypesto/visualize/misc.py
+++ b/pypesto/visualize/misc.py
@@ -206,7 +206,9 @@ def process_y_limits(ax, y_limits):
         data_limits = ax.dataLim.ymin, ax.dataLim.ymax
 
         # Check if data fits to axes and adapt limits, if necessary
-        if ax_limits[0] > data_limits[0] or ax_limits[1] < data_limits[1]:
+        if np.isfinite(data_limits).all() and (
+            ax_limits[0] > data_limits[0] or ax_limits[1] < data_limits[1]
+        ):
             # Get range of data
             data_range = data_limits[1] - data_limits[0]
             if ax.get_yscale() == "log":
@@ -374,7 +376,7 @@ def process_start_indices(
             "Some start indices were removed due to inf or nan function values."
         )
 
-    return np.asarray(start_indices)
+    return np.asarray(start_indices, dtype=int)
 
 
 def process_parameter_indices(

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -2,6 +2,7 @@ import functools
 import logging
 import os
 from collections.abc import Sequence
+from copy import deepcopy
 from functools import wraps
 from pathlib import Path
 
@@ -285,6 +286,15 @@ def test_waterfall_with_nan_inf():
 
     # test plotting of lists
     visualize.waterfall([result_1, result_2])
+
+    # test all-non-finite
+    result_no_finite = deepcopy(result_1)
+    result_no_finite.optimize_result.list = [
+        or_
+        for or_ in result_no_finite.optimize_result.list
+        if not np.isfinite(or_.fval)
+    ]
+    visualize.waterfall(result_no_finite)
 
 
 @close_fig


### PR DESCRIPTION
Previously, an optimization result with only non-finite values would result in an IndexError. Now this is handled more gracefully. Closes #1599.