### PR TITLE
Revise citation for pyPESTO in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ to pyPESTO check out
 When using pyPESTO in your project, please cite
 * Schälte, Y., Fröhlich, F., Jost, P. J., Vanhoefer, J., Pathirana, D., Stapor, P.,
   Lakrisenko, P., Wang, D., Raimúndez, E., Merkt, S., Schmiester, L., Städter, P.,
-  Grein, S., Dudkin, E., Doresic, D., Weindl, D., & Hasenauer, J. (2023). pyPESTO: A
-  modular and scalable tool for parameter estimation for dynamic models,
-  Bioinformatics, 2023, btad711, [doi:10.1093/bioinformatics/btad711](https://doi.org/10.1093/bioinformatics/btad711)
+  Grein, S., Dudkin, E., Doresic, D., Weindl, D., & Hasenauer, J.
+  pyPESTO: A modular and scalable tool for parameter estimation for dynamic models,
+  Bioinformatics, Volume 39, Issue 11, 2023, btad711,
+  [doi:10.1093/bioinformatics/btad711](https://doi.org/10.1093/bioinformatics/btad711)
 
 When presenting work that employs pyPESTO, feel free to use one of the icons in
 [doc/logo/](doc/logo):


### PR DESCRIPTION
Updated citation format for pyPESTO reference in README.

Year was duplicated, volume and number were missing.