### PR TITLE
Change cluster assignment and improve waterfallplot efficiency using scatter.

### DIFF
--- a/pypesto/util.py
+++ b/pypesto/util.py
@@ -218,28 +218,14 @@ def assign_clusters(vals):
     elif len(vals) == 1:
         return np.array([0]), np.array([1.0])
 
-    # linkage requires (n, 1) data array
-    vals = np.reshape(vals, (-1, 1))
+    # sort values
+    vals = np.sort(vals)
 
-    # however: clusters are sorted by size, not by value... Resort.
-    # Create preallocated object first
-    cluster_indices = np.zeros(vals.size, dtype=int)
+    # assign cluster to first element and then assign new cluster every time distance is greater 0.1 
+    cluster_indices = np.append([0], np.cumsum(np.diff(vals) > 0.1))
 
-    # get clustering based on distance
-    clust = cluster.hierarchy.fcluster(
-        cluster.hierarchy.linkage(vals), t=0.1, criterion="distance"
-    )
-
-    # get unique clusters
-    _, ind_clust = np.unique(clust, return_index=True)
-    unique_clust = clust[np.sort(ind_clust)]
-    cluster_size = np.zeros(unique_clust.size, dtype=int)
-
-    # loop over clusters: resort and count number of entries
-    for index, i_clust in enumerate(unique_clust):
-        cluster_indices[np.where(clust == i_clust)] = index
-        cluster_size[index] = sum(clust == i_clust)
-
+    # get cluster sizes
+    _, cluster_size = np.unique(cluster_indices, return_counts=True)
     return cluster_indices, cluster_size
 
 

--- a/pypesto/util.py
+++ b/pypesto/util.py
@@ -12,7 +12,6 @@ from operator import itemgetter
 from typing import Any, Callable, Optional, Union
 
 import numpy as np
-from scipy import cluster
 from tqdm import tqdm as _tqdm
 
 
@@ -221,7 +220,7 @@ def assign_clusters(vals):
     # sort values
     vals = np.sort(vals)
 
-    # assign cluster to first element and then assign new cluster every time distance is greater 0.1 
+    # assign cluster to first element and then assign new cluster every time distance is greater 0.1
     cluster_indices = np.append([0], np.cumsum(np.diff(vals) > 0.1))
 
     # get cluster sizes

--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -255,7 +255,16 @@ def waterfall_lowlevel(
         ax.plot(start_indices, fvals, color=[0.7, 0.7, 0.7, 0.6])
 
     # Overlay with scatter points with individual colors
-    ax.scatter(start_indices, fvals, c=colors, marker="o", linewidth=1.0, label=legend_text, zorder=2.0, alpha=1.0)
+    ax.scatter(
+        start_indices,
+        fvals,
+        c=colors,
+        marker="o",
+        linewidth=1.0,
+        label=legend_text,
+        zorder=2.0,
+        alpha=1.0,
+    )
 
     # check if y-axis has a reasonable scale
     y_min, y_max = ax.get_ylim()

--- a/pypesto/visualize/waterfall.py
+++ b/pypesto/visualize/waterfall.py
@@ -250,28 +250,12 @@ def waterfall_lowlevel(
     # plot line
     if scale_y == "log10":
         ax.semilogy(start_indices, fvals, color=[0.7, 0.7, 0.7, 0.6])
+        ax.set_yscale("log")
     else:
         ax.plot(start_indices, fvals, color=[0.7, 0.7, 0.7, 0.6])
 
-    # plot points
-    for j in start_indices:
-        # parse data for plotting
-        color = colors[start_indices.index(j)]
-        fval = fvals[start_indices.index(j)]
-        if j == start_indices[0]:
-            tmp_legend = legend_text
-        else:
-            tmp_legend = None
-
-        # line plot (linear or logarithmic)
-        if scale_y == "log10":
-            ax.semilogy(
-                j, fval, color=color, marker="o", label=tmp_legend, alpha=1.0
-            )
-        else:
-            ax.plot(
-                j, fval, color=color, marker="o", label=tmp_legend, alpha=1.0
-            )
+    # Overlay with scatter points with individual colors
+    ax.scatter(start_indices, fvals, c=colors, marker="o", linewidth=1.0, label=legend_text, zorder=2.0, alpha=1.0)
 
     # check if y-axis has a reasonable scale
     y_min, y_max = ax.get_ylim()


### PR DESCRIPTION
Related to #1603 I updated the plotting function for waterfall plots.

First I changed the assignment of clusters. Since we only get 1-d arrays, one does not need to rely on memory heavy or algorithmic clustering, but can just take a fast numpy approach.

Second, looping over all points and colors and then using `plot` takes a long time. A more efficient way using `scatter`, which also excepts a list of colors, is now implemented.

This should make the plotting of the waterfall plot even for very large results feasible. (Locally `waterfall_lowlevel` now took only around 10sek for 500.000 values).

