### PR TITLE
maint: require amici<1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ all_optimizers =
     %(pyswarms)s
     %(fides)s
 amici =
-    amici >= 0.21.0
+    amici >= 0.21.0, < 1.0.0
 roadrunner =
     libroadrunner >= 2.7.0
     %(petab)s

--- a/tox.ini
+++ b/tox.ini
@@ -77,14 +77,15 @@ description =
     Test basic functionality on Windows
 
 [testenv:petab]
-extras = test,petab,pyswarm,roadrunner
+extras = test,petab,pyswarm,roadrunner,amici
 deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
 # always install amici from main branch, avoid caching
 #  to skip re-installation, run `tox -e petab --override testenv:petab.commands_pre=`
-commands_pre =
-    python3 -m pip uninstall -y amici
-    python3 -m pip install git+https://github.com/AMICI-dev/amici.git@main\#egg=amici&subdirectory=python/sdist
+# TODO: once amici 1.0 is out, re-enable the following lines and remove "amici" from extras
+# commands_pre =
+#    python3 -m pip uninstall -y amici
+#    python3 -m pip install git+https://github.com/AMICI-dev/amici.git@main\#egg=amici&subdirectory=python/sdist
 commands =
 # FIXME: Until we have proper PEtab v2 import
 #  we need `10ffb050380933b60ac192962bf9550a9df65a9c`


### PR DESCRIPTION
Soonishly, there will be amici 1.0.0, which will break some things here. Require <1.0.0 until everything is updated (-> #1619).