### PR TITLE
Test with Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.13']
+        python-version: ['3.11', '3.14']
 
     steps:
     - name: Check out repository
@@ -64,7 +64,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - name: Check out repository
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - name: Check out repository
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.13']
+        python-version: ['3.11', '3.14']
 
     steps:
     - name: Check out repository
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - name: Check out repository
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.13']
+        python-version: ['3.11', '3.14']
 
     steps:
     - name: Check out repository
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.13']
+        python-version: ['3.11', '3.14']
 
     steps:
     - name: Check out repository
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - name: Check out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ deps =
 #    python3 -m pip install git+https://github.com/AMICI-dev/amici.git@main\#egg=amici&subdirectory=python/sdist
 commands_pre =
    python3 -m pip uninstall -y amici
-   python3 -m pip install git+https://github.com/AMICI-dev/amici.git@v0.34.1\#egg=amici&subdirectory=python/sdist
+   python3 -m pip install git+https://github.com/AMICI-dev/amici.git@v0.34.2\#egg=amici&subdirectory=python/sdist
 
 commands =
 # FIXME: Until we have proper PEtab v2 import


### PR DESCRIPTION
Test with Python 3.14, except for Julia tests.

Julia tests `test_petabJL_from_module` and `test_pyjulia_pipeline` still fail with 3.14.
