### PR TITLE
Require h5py!=3.15.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     matplotlib >= 3.6.2
     more-itertools >= 9.0.0
     seaborn >= 0.11.2
-    h5py >= 3.1.0
+    h5py >= 3.1.0, != 3.15.0
     tqdm >= 4.46.0
     tabulate >= 0.8.10
 


### PR DESCRIPTION
There are issues with that release, at least on macos.

E.g. https://github.com/ICB-DCM/pyPESTO/actions/runs/18525367177/job/52794829574