### PR TITLE
GHA: use macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         files: ./coverage.xml
 
   mac:
-    runs-on: macos-13  # TODO: change to macos-latest after the next release
+    runs-on: macos-latest
     strategy:
       matrix:
         python-version: ['3.13']


### PR DESCRIPTION
> GitHub Actions: macOS 13 runner image is closing down

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/