### PR TITLE
Fix startpoint selection and neval in scatter search

### DIFF
--- a/pypesto/optimize/ess/ess.py
+++ b/pypesto/optimize/ess/ess.py
@@ -564,7 +564,7 @@ class ESSOptimizer:
             self.n_iter >= self.local_n1
             and self.n_iter - self.last_local_search_niter >= self.local_n2
         ):
-            quality_order = np.argsort(fx_best_children)
+            quality_order = np.argsort(fx_best_children).argsort()
             # compute minimal distance between the best children and all local
             #  optima found so far
             min_distances = (
@@ -588,7 +588,7 @@ class ESSOptimizer:
                 else np.zeros(len(x_best_children))
             )
             # sort by furthest distance to existing local optima
-            diversity_order = np.argsort(min_distances)[::-1]
+            diversity_order = np.argsort(min_distances)[::-1].argsort()
             # compute priority, balancing quality and diversity
             #  (smaller value = higher priority)
             priority = (

--- a/pypesto/optimize/ess/function_evaluator.py
+++ b/pypesto/optimize/ess/function_evaluator.py
@@ -84,8 +84,6 @@ class FunctionEvaluator:
         The objective function values in the same order as the inputs.
         """
         res = np.fromiter(map(self.single, xs), dtype=float)
-        self.n_eval += len(xs)
-        self.n_eval_round += len(xs)
         return res
 
     def single_random(self) -> tuple[np.array, float]:
@@ -222,10 +220,10 @@ class FunctionEvaluatorMT(FunctionEvaluator):
                 ),
                 dtype=float,
             )
+            self.n_eval += len(xs)
+            self.n_eval_round += len(xs)
         else:
             res = np.fromiter(map(self.single, xs), dtype=float)
-        self.n_eval += len(xs)
-        self.n_eval_round += len(xs)
         return res
 
 


### PR DESCRIPTION
Fixes two bugs affecting `ESSOptimizer` and `SacessOptimizer`:

* The ranking of candidates for local optimization startpoints was wrong in many cases. Only relevant if a local optimizer was used.
* In some cases, objective evaluations were counted twice. Resulting in incorrect reporting of the total number of evaluations and not fully exhausting the objective evaluations budget.