### PR TITLE
Long Mac Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         files: ./coverage.xml
 
   mac:
-    runs-on: macos-15
+    runs-on: macos-14
     strategy:
       matrix:
         python-version: ['3.13']
@@ -84,13 +84,17 @@ jobs:
         key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-        pip install tox
+      run: .github/workflows/install_deps.sh amici
 
     - name: Run tests
-      timeout-minutes: 10
-      run: tox -e windows
+      timeout-minutes: 45
+      run: ulimit -n 65536 65536 && tox -e base
+
+    - name: Coverage
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,17 +84,13 @@ jobs:
         key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-ci-${{ github.job }}"
 
     - name: Install dependencies
-      run: .github/workflows/install_deps.sh amici
+      run: |
+        pip install --upgrade pip
+        pip install tox
 
     - name: Run tests
-      timeout-minutes: 45
-      run: ulimit -n 65536 65536 && tox -e base
-
-    - name: Coverage
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.xml
+      timeout-minutes: 10
+      run: tox -e windows
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       run: .github/workflows/install_deps.sh amici
 
     - name: Run tests
-      timeout-minutes: 45
+      timeout-minutes: 30
       run: ulimit -n 65536 65536 && tox -e base
 
     - name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       run: .github/workflows/install_deps.sh amici
 
     - name: Run tests
-      timeout-minutes: 30
+      timeout-minutes: 45
       run: ulimit -n 65536 65536 && tox -e base
 
     - name: Coverage

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ description =
 [testenv:windows]
 extras = test
 commands =
-    pytest \
+    pytest --durations=10 \
         test/base/test_prior.py \
         test/base/test_problem.py \
         test/base/test_workflow.py
@@ -100,7 +100,7 @@ commands =
     python3 -m pip install -U copasi-basico[petab]
     # upgrade after installing pysb which requires an older sympy
     python3 -m pip install -U sympy
-    pytest --cov=pypesto --cov-report=xml --cov-append \
+    pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
         test/petab
 description =
     Test PEtab functionality
@@ -109,7 +109,7 @@ description =
 extras = test,julia
 commands =
     python -c "import julia; julia.install()"
-    python-jl -m pytest --cov=pypesto --cov-report=xml --cov-append \
+    python-jl -m pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
         test/julia
 description =
     Test Julia interface
@@ -117,7 +117,7 @@ description =
 [testenv:optimize]
 extras = test,dlib,ipopt,pyswarm,cma,nlopt,fides,mpi,pyswarms,petab
 commands =
-    pytest --cov=pypesto --cov-report=xml --cov-append \
+    pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
         test/optimize
 description =
     Test optimization module
@@ -128,7 +128,7 @@ deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
 commands =
     # workaround as ipopt has incomplete build
-    pytest --cov=pypesto --cov-report=xml --cov-append \
+    pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
         test/hierarchical
 description =
     Test hierarchical optimization module
@@ -136,7 +136,7 @@ description =
 [testenv:select]
 extras = test,amici,petab,select,fides
 commands =
-    pytest -svvv --cov=pypesto --cov-report=xml --cov-append \
+    pytest -svvv --cov=pypesto --cov-report=xml --cov-append --durations=10 \
         test/select
 description =
     Test model selection functionality

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ description =
 [testenv:windows]
 extras = test
 commands =
-    pytest --durations=10 \
+    pytest \
         test/base/test_prior.py \
         test/base/test_problem.py \
         test/base/test_workflow.py
@@ -100,7 +100,7 @@ commands =
     python3 -m pip install -U copasi-basico[petab]
     # upgrade after installing pysb which requires an older sympy
     python3 -m pip install -U sympy
-    pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
+    pytest --cov=pypesto --cov-report=xml --cov-append \
         test/petab
 description =
     Test PEtab functionality
@@ -109,7 +109,7 @@ description =
 extras = test,julia
 commands =
     python -c "import julia; julia.install()"
-    python-jl -m pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
+    python-jl -m pytest --cov=pypesto --cov-report=xml --cov-append \
         test/julia
 description =
     Test Julia interface
@@ -117,7 +117,7 @@ description =
 [testenv:optimize]
 extras = test,dlib,ipopt,pyswarm,cma,nlopt,fides,mpi,pyswarms,petab
 commands =
-    pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
+    pytest --cov=pypesto --cov-report=xml --cov-append \
         test/optimize
 description =
     Test optimization module
@@ -128,7 +128,7 @@ deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
 commands =
     # workaround as ipopt has incomplete build
-    pytest --cov=pypesto --cov-report=xml --cov-append --durations=10 \
+    pytest --cov=pypesto --cov-report=xml --cov-append \
         test/hierarchical
 description =
     Test hierarchical optimization module
@@ -136,7 +136,7 @@ description =
 [testenv:select]
 extras = test,amici,petab,select,fides
 commands =
-    pytest -svvv --cov=pypesto --cov-report=xml --cov-append --durations=10 \
+    pytest -svvv --cov=pypesto --cov-report=xml --cov-append \
         test/select
 description =
     Test model selection functionality


### PR DESCRIPTION
Added description of top 10 longest tests to CI and (for now) increased test time to 45 min. This will be changed down, if any bottleneck can be identified!