### PR TITLE
Fix `test/petab/test_amici_predictor.py` failures

### DIFF
--- a/test/petab/test_amici_predictor.py
+++ b/test/petab/test_amici_predictor.py
@@ -128,7 +128,7 @@ def edata_objects(conversion_reaction_model):
     ]
     # create rdatas and edatas from those
     for fp in fixedParameters:
-        testmodel.setFixedParameters(amici.DoubleVector(fp))
+        testmodel.setFixedParameters(fp)
         rdata = amici.runAmiciSimulation(testmodel, solver)
         rdatas.append(rdata)
         edatas.append(amici.ExpData(rdata, 1.0, 0))


### PR DESCRIPTION
Fixes recent test failures probably related to the recent swig-4.4.1:

```
>           testmodel.setFixedParameters(amici.DoubleVector(fp))

test/petab/test_amici_predictor.py:131:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <amici.amici.ModelPtr; proxy of <Swig Object of type 'std::unique_ptr< amici::Model > *' at 0x7f719c1d4970> >
k = <Swig Object of type 'std::vector< double > *' at 0x7f719e83ad30; array([2., 0.]) >

    def setFixedParameters(self, k: Sequence[float]):
        """
        Set values for constants.
        :param k: Vector of fixed parameters
        """
>       return _amici.ModelPtr_setFixedParameters(self, k)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: in method 'ModelPtr_setFixedParameters', argument 2 of type 'std::vector< amici::realtype,std::allocator< amici::realtype > > const &'
```