### PR TITLE
Select: set optimal point to fixed vals if no parameters are estimated

### DIFF
--- a/pypesto/select/model_problem.py
+++ b/pypesto/select/model_problem.py
@@ -176,12 +176,28 @@ class ModelProblem:
         self.model.set_criterion(Criterion.NLLH, float(self.best_start.fval))
         self.model.compute_criterion(criterion=self.criterion)
 
+        # TODO quickfix while pyPESTO returns an empty list in the case
+        # of no estimated parameters.
+        best_start_x = self.best_start.x
+        if len(self.pypesto_problem.x_names) != len(self.best_start.x):
+            # Assume only fixed parameters
+            if (
+                len(self.pypesto_problem.x_names)
+                != len(self.pypesto_problem.x_fixed_vals)
+            ):
+                raise ValueError("Unknown issue. Contact us.")
+            # Assume empty best optimized point.
+            if len(self.best_start.x):
+                raise ValueError("Unknown issue. Contact us.")
+            best_start_x = list(self.pypesto_problem.x_fixed_vals)
+
         estimated_parameters = {
             id: float(value)
             for index, (id, value) in enumerate(
                 zip(
                     self.pypesto_problem.x_names,
-                    self.best_start.x,
+                    best_start_x,
+                    strict=True,
                 )
             )
             if index in self.pypesto_problem.x_free_indices

--- a/test/select/test_select.py
+++ b/test/select/test_select.py
@@ -375,8 +375,10 @@ def test_model_problem_fake_result():
     """Test fake results for models with no estimated parameters."""
     expected_fval = 100.0
 
+    expected_x_fixed_vals = [0, 1, 2]
     fake_result = model_problem.create_fake_pypesto_result_from_fval(
         fval=expected_fval,
+        x_fixed_vals=expected_x_fixed_vals,
     )
     # There is only one start in the result.
     fake_start = one(fake_result.optimize_result.list)
@@ -386,7 +388,7 @@ def test_model_problem_fake_result():
     # The fake start has the expected fake ID.
     assert test_id == expected_id
 
-    expected_x = []
+    expected_x = expected_x_fixed_vals
     test_x = fake_start.x.tolist()
     # The fake start has the expected zero estimated parameters.
     assert test_x == expected_x

--- a/test/select/test_select.py
+++ b/test/select/test_select.py
@@ -390,7 +390,7 @@ def test_model_problem_fake_result():
 
     expected_x = expected_x_fixed_vals
     test_x = fake_start.x.tolist()
-    # The fake start has the expected zero estimated parameters.
+    # The fake start has the expected parameters.
     assert test_x == expected_x
 
     test_fval = fake_start.fval


### PR DESCRIPTION
Models with no estimated parameters can appear during model selection. This ensures the fixed values are assigned as the optimal point in this case.