### PR TITLE
Add deprecation warning in SacessOptimizer and ESSOptimizer

### DIFF
--- a/pypesto/optimize/ess/ess.py
+++ b/pypesto/optimize/ess/ess.py
@@ -199,6 +199,15 @@ class ESSOptimizer:
             RefSet, or just the local search results and the overall best
             parameters.
         """
+        warn(
+            "Using pypesto.optimize.ess.ESSOptimizer is deprecated "
+            "and will be removed in a future release. "
+            "Use pyscat.ESSOptimizer instead "
+            "(https://github.com/ICB-DCM/pyscat/, `pip install pyscat`).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if max_eval is None and max_walltime_s is None and max_iter is None:
             # in this case, we'd run forever
             raise ValueError(

--- a/pypesto/optimize/ess/sacess.py
+++ b/pypesto/optimize/ess/sacess.py
@@ -176,6 +176,15 @@ class SacessOptimizer:
         options:
             Further optimizer hyperparameters, see :class:`SacessOptions`.
         """
+        warn(
+            "Using pypesto.optimize.ess.SacessOptimizer is deprecated "
+            "and will be removed in a future release. "
+            "Use pyscat.SacessOptimizer instead "
+            "(https://github.com/ICB-DCM/pyscat/, `pip install pyscat`).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if (num_workers is None and ess_init_args is None) or (
             num_workers is not None and ess_init_args is not None
         ):


### PR DESCRIPTION
Now available from https://github.com/ICB-DCM/pyscat/. Closes #1641.