### PR TITLE
Make `id` optional in `Optimizer.minimize`

### DIFF
--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -95,7 +95,7 @@ def history_decorator(minimize):
     ):
         if history_options is None:
             history_options = HistoryOptions()
-        if id is None:
+        if history_options.storage_file is not None and id is None:
             raise ValueError("id must be provided for history tracking.")
 
         objective = problem.objective


### PR DESCRIPTION
If no history filename is set, the ID is not used, so we shouldn't require it.