### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v6
 
-    - name: Remove direct dependencies from setup.cfg
+    - name: Remove direct dependencies from pyproject.toml
       # Remove any "git+https"-based dependencies that are not supported
       #  by PyPI and are only required for testing.
-      run: sed -i '/git+https/d' setup.cfg
+      run: sed -i '/git+https/d' pyproject.toml
 
     - name: Prepare python ${{ matrix.python-version }}
       uses: actions/setup-python@v6


### PR DESCRIPTION
https://github.com/ICB-DCM/pyPESTO/pull/1679 broke the deployment workflow. pypesto 0.5.9 was not deployed to PyPI (https://github.com/ICB-DCM/pyPESTO/actions/runs/22439382257), I just uploaded it manually.

This updates the deployment workflow to work with the current `pyproject.toml`.