### PR TITLE
Make parameters_correlation_matrix more customizable

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -102,6 +102,7 @@ intersphinx_mapping = {
     "petab_select": ("https://petab-select.readthedocs.io/en/develop/", None),
     "python": ("https://docs.python.org/3", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "seaborn": ("https://seaborn.pydata.org/", None),
 }
 
 

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -608,7 +608,7 @@ def parameters_correlation_matrix(
         Whether to return the parameter table additionally for further
         inspection.
     heatmap_kwargs:
-        Additional keyword arguments to `seaborn.heatmap`.
+        Additional keyword arguments to :func:`seaborn.heatmap`.
 
     Returns
     -------

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -584,6 +584,7 @@ def parameters_correlation_matrix(
     cmap: Colormap | str = "bwr",
     return_table: bool = False,
     heatmap_kwargs: dict | None = None,
+    size: tuple[float, float] | None = None,
 ) -> matplotlib.axes.Axes:
     """
     Plot correlation of optimized parameters.
@@ -609,6 +610,8 @@ def parameters_correlation_matrix(
         inspection.
     heatmap_kwargs:
         Additional keyword arguments to :func:`seaborn.heatmap`.
+    size:
+        Figure size (width, height) in inches.
 
     Returns
     -------
@@ -643,9 +646,13 @@ def parameters_correlation_matrix(
         "linewidth": 1,
     } | (heatmap_kwargs or {})
     if cluster:
+        if size is not None:
+            heatmap_kwargs["figsize"] = size
         ax = sns.clustermap(**heatmap_kwargs)
     else:
         ax = sns.heatmap(**heatmap_kwargs)
+        if size is not None:
+            ax.figure.set_size_inches(*size)
     if return_table:
         return ax, df
     return ax

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -583,6 +583,7 @@ def parameters_correlation_matrix(
     cluster: bool = True,
     cmap: Colormap | str = "bwr",
     return_table: bool = False,
+    heatmap_kwargs: dict | None = None,
 ) -> matplotlib.axes.Axes:
     """
     Plot correlation of optimized parameters.
@@ -597,8 +598,8 @@ def parameters_correlation_matrix(
         List of integers specifying the multistarts to be plotted or
         int specifying up to which start index should be plotted
     method:
-        The method to compute correlation. Allowed are `pearson, kendall,
-        spearman` or a callable function.
+        The method to compute correlation. Allowed values are ``pearson``,
+        ``kendall``, ``spearman`` or a callable.
     cluster:
         Whether to cluster the correlation matrix.
     cmap:
@@ -606,6 +607,8 @@ def parameters_correlation_matrix(
     return_table:
         Whether to return the parameter table additionally for further
         inspection.
+    heatmap_kwargs:
+        Additional keyword arguments to `seaborn.heatmap`.
 
     Returns
     -------
@@ -631,14 +634,18 @@ def parameters_correlation_matrix(
     ]
     df = pd.DataFrame(parameters, columns=x_labels)
     corr_matrix = df.corr(method=method)
+    heatmap_kwargs = {
+        "data": corr_matrix,
+        "yticklabels": True,
+        "vmin": -1,
+        "vmax": 1,
+        "cmap": cmap,
+        "linewidth": 1,
+    } | (heatmap_kwargs or {})
     if cluster:
-        ax = sns.clustermap(
-            data=corr_matrix, yticklabels=True, vmin=-1, vmax=1, cmap=cmap
-        )
+        ax = sns.clustermap(**heatmap_kwargs)
     else:
-        ax = sns.heatmap(
-            data=corr_matrix, yticklabels=True, vmin=-1, vmax=1, cmap=cmap
-        )
+        ax = sns.heatmap(**heatmap_kwargs)
     if return_table:
         return ax, df
     return ax


### PR DESCRIPTION
* Forward heatmap kwargs
* Use non-zero linewidth (for old behavior, pass `heatmap_kwargs={"linewidth": 0}`)
* enable documentation cross references to seaborn
* add  `size` argument

Turns 
<img width="423" height="428" alt="image" src="https://github.com/user-attachments/assets/2f324fef-70c3-40f4-8ff9-9943cdedf940" />
into
<img width="423" height="428" alt="image" src="https://github.com/user-attachments/assets/ca00fb0e-fef4-4a8d-8ea8-cd8fa407269b" />
