### PR TITLE
Make validate_inner_parameter_pairings pandas 3 compatible

### DIFF
--- a/pypesto/hierarchical/petab.py
+++ b/pypesto/hierarchical/petab.py
@@ -152,10 +152,10 @@ def validate_inner_parameter_pairings(
     scalings_with_offsets = {}
     offsets_with_scalings = {}
 
-    for _, row in inner_parameter_df.iterrows():
-        offset = row[InnerParameterType.OFFSET]
-        scaling = row[InnerParameterType.SCALING]
-        sigma = row[InnerParameterType.SIGMA]
+    for row in inner_parameter_df.itertuples():
+        offset = getattr(row, InnerParameterType.OFFSET)
+        scaling = getattr(row, InnerParameterType.SCALING)
+        sigma = getattr(row, InnerParameterType.SIGMA)
 
         # Ensures each scaling is only ever paired with one sigma.
         if scaling is not None and sigma is not None:


### PR DESCRIPTION
For reasons I don't fully understand, `None` gets converted to `nan` in `iterrows` in pandas 3.0.1 [breaking](https://github.com/ICB-DCM/pyPESTO/actions/runs/23039704731/job/66915208725) this function. This is not the case with `itertuples`.