### PR TITLE
GHA: fix sphinx deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.13']
 
     steps:
     - name: Check out repository

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,4 +26,4 @@ build:
     - libhdf5-serial-dev
     - swig
   tools:
-    python: "3.11"
+    python: "3.13"

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ envlist =
 
 [testenv]
 passenv = AMICI_PARALLEL_COMPILE,BNGPATH,CC,CXX,GITHUB_ACTIONS,MPLBACKEND
+commands_pre =
+    python -m pip list
 
 # Sub-environments
 #  inherit settings defined in the base
@@ -85,6 +87,7 @@ deps =
 commands_pre =
    python3 -m pip uninstall -y amici
    python3 -m pip install git+https://github.com/AMICI-dev/amici.git@main\#egg=amici&subdirectory=python/sdist
+   python -m pip list
 commands =
 # FIXME: Until we have proper PEtab v2 import
 #  we need `10ffb050380933b60ac192962bf9550a9df65a9c`


### PR DESCRIPTION
Fixed by upgrading to Python3.13, which seems to allow for some newer package versions that don't have this issue.

Also add some debugging output to tox envs for dealing with future issues.


[Error was](https://github.com/ICB-DCM/pyPESTO/actions/runs/23067136411/job/67074735398?pr=1697#logs):
```
/home/runner/work/pyPESTO/pyPESTO/.tox/doc/lib/python3.11/site-packages/sphinx_autodoc_typehints/_parser.py:30: RemovedInSphinx10Warning: 'sphinx_autodoc_typehints._parser._RstSnippetParser.set_application' is deprecated. Check CHANGES for Sphinx API modifications.
  parser.set_application(settings.env.app)
```