### PR TITLE
Fides optimizer: clarify use of Hessian and FIM

### DIFF
--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -1779,7 +1779,7 @@ class FidesOptimizer(Optimizer):
                 warnings.warn(
                     "A hybrid Hessian approximation strategy will be "
                     "employed. See the docstring for ``hessian_update`` in "
-                    "the class constructor for more details."
+                    "the class constructor for more details.",
                     stacklevel=1,
                 )
                 _hessian_update = fides.HybridFixed()

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -1701,13 +1701,14 @@ class FidesOptimizer(Optimizer):
             and :class:`fides.constants.Options` for details.
         hessian_update:
             Hessian update strategy. Defaults to a BFGS approximation if
-            ``problem.objective`` does not provide a Hessian. Otherwise, a
-            hybrid scheme that starts with the ``problem.objective`` provided
-            Hessian but switches to a BFGS approximation in later iterations
-            will be used -- this is useful when the ``problem.objective``
-            Hessian is an approximation such as the Fisher information matrix.
-            Use ``None`` to specify that the ``problem.objective`` provided
-            Hessian should be used exclusively.
+            ``problem.objective`` does not provide a Hessian. Otherwise, it is
+            assumed that the ``problem.objective`` Hessian is actually the
+            Fisher information matrix (FIM), and hence a Hessian approximation
+            strategy is the default, which uses the FIM initially but switches
+            to BFGS during later iterations.
+            If your ``problem.objective`` Hessian is actually the Hessian,
+            then use ``None`` to have Fides use the ``problem.objective``
+            Hessian for all iterations.
         """
         super().__init__()
 
@@ -1767,18 +1768,20 @@ class FidesOptimizer(Optimizer):
 
         if self.hessian_update == "default":
             if not problem.objective.has_hess:
-                warnings.warn(
+                logger.debug(
                     "Fides is using BFGS as hessian approximation, "
                     "as the problem does not provide a Hessian. "
-                    "Specify a Hessian to use a more efficient "
-                    "hybrid approximation scheme.",
+                    "Specify a Hessian (or Fisher information matrix, to use "
+                    "a more efficient hybrid approximation scheme. See the "
+                    "docstring for `hessian_update` in the class constructor "
+                    "for more details.",
                     stacklevel=1,
                 )
                 _hessian_update = fides.BFGS()
             else:
-                warnings.warn(
+                logger.debug(
                     "A hybrid Hessian approximation strategy will be "
-                    "employed. See the docstring for ``hessian_update`` in "
+                    "employed. See the docstring for `hessian_update` in "
                     "the class constructor for more details.",
                     stacklevel=1,
                 )

--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -1700,9 +1700,14 @@ class FidesOptimizer(Optimizer):
             Optimizer options. See :meth:`fides.minimize.Optimizer.minimize`
             and :class:`fides.constants.Options` for details.
         hessian_update:
-            Hessian update strategy. If this is ``None``, a hybrid approximation
-            that switches from the ``problem.objective`` provided Hessian (
-            approximation) to a BFGS approximation will be used.
+            Hessian update strategy. Defaults to a BFGS approximation if
+            ``problem.objective`` does not provide a Hessian. Otherwise, a
+            hybrid scheme that starts with the ``problem.objective`` provided
+            Hessian but switches to a BFGS approximation in later iterations
+            will be used -- this is useful when the ``problem.objective``
+            Hessian is an approximation such as the Fisher information matrix.
+            Use ``None`` to specify that the ``problem.objective`` provided
+            Hessian should be used exclusively.
         """
         super().__init__()
 
@@ -1771,6 +1776,12 @@ class FidesOptimizer(Optimizer):
                 )
                 _hessian_update = fides.BFGS()
             else:
+                warnings.warn(
+                    "A hybrid Hessian approximation strategy will be "
+                    "employed. See the docstring for ``hessian_update`` in "
+                    "the class constructor for more details."
+                    stacklevel=1,
+                )
                 _hessian_update = fides.HybridFixed()
         else:
             _hessian_update = self.hessian_update


### PR DESCRIPTION
Currently it looks like a user needs to specify `pypesto.optimize.FidesOptimizer(..., hessian_update=None)` to ensure Fides uses the provided Hessian. It appears that default behavior does not use the Hessian from the objective when possible.