### PR TITLE
Fix remaining AMICI 1.0 calls and extend tests

### DIFF
--- a/pypesto/hierarchical/inner_calculator_collector.py
+++ b/pypesto/hierarchical/inner_calculator_collector.py
@@ -475,7 +475,7 @@ class InnerCalculatorCollector(AmiciCalculator):
                     "Cannot use least squares solver with"
                     "parameter dependent sigma! Support can be "
                     "enabled via "
-                    "amici_model.setAddSigmaResiduals()."
+                    "amici_model.set_add_sigma_residuals()."
                 )
             self._known_least_squares_safe = True  # don't check this again
 

--- a/pypesto/hierarchical/ordinal/solver.py
+++ b/pypesto/hierarchical/ordinal/solver.py
@@ -236,7 +236,7 @@ class OrdinalInnerSolver(InnerSolver):
         par_sim_ids:
             Ids of outer simulation parameters, includes fixed parameters.
         par_edata_indices:
-            Indices of parameters from `amici_model.getParameterIds()` that are needed for
+            Indices of parameters from `amici_model.get_parameter_ids()` that are needed for
             sensitivity calculation. Comes from `edata.plist` for each condition.
         snllh:
             A zero-initialized vector of the same length as ``par_opt_ids`` to store the

--- a/pypesto/hierarchical/ordinal/solver.py
+++ b/pypesto/hierarchical/ordinal/solver.py
@@ -236,7 +236,7 @@ class OrdinalInnerSolver(InnerSolver):
         par_sim_ids:
             Ids of outer simulation parameters, includes fixed parameters.
         par_edata_indices:
-            Indices of parameters from `amici_model.get_parameter_ids()` that are needed for
+            Indices of parameters from `amici_model.get_free_parameter_ids()` that are needed for
             sensitivity calculation. Comes from `edata.plist` for each condition.
         snllh:
             A zero-initialized vector of the same length as ``par_opt_ids`` to store the

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -139,7 +139,7 @@ class AmiciObjective(ObjectiveBase):
             derivatives.
         amici_reporting:
             Determines which quantities will be computed by AMICI,
-            see ``amici.Solver.setReturnDataReportingMode``. Set to ``None``
+            see ``amici.Solver.set_return_data_reporting_mode``. Set to ``None``
             to compute only the minimum required information.
         """
         import amici

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -137,7 +137,7 @@ class AmiciCalculator:
                     "Cannot use least squares solver with"
                     "parameter dependent sigma! Support can be "
                     "enabled via "
-                    "amici_model.setAddSigmaResiduals()."
+                    "amici_model.set_add_sigma_residuals()."
                 )
             self._known_least_squares_safe = True  # don't check this again
 

--- a/pypesto/visualize/model_fit.py
+++ b/pypesto/visualize/model_fit.py
@@ -301,7 +301,7 @@ def _get_simulation_rdatas(
     """
     # add timepoints as needed
     if simulation_timepoints is None:
-        end_time = max(problem.objective.edatas[0].getTimepoints())
+        end_time = max(problem.objective.edatas[0].get_timepoints())
         simulation_timepoints = np.linspace(start=0, stop=end_time, num=1000)
 
     # get optimization result
@@ -338,10 +338,10 @@ def _get_simulation_rdatas(
 
         # disable sensitivities to improve computation time
         amici_solver = copy.deepcopy(problem.objective.amici_solver)
-        amici_solver.setSensitivityOrder(asd.SensitivityOrder.none)
+        amici_solver.set_sensitivity_order(asd.SensitivityOrder.none)
 
         for j in range(len(edatas)):
-            edatas[j].setTimepoints(simulation_timepoints)
+            edatas[j].set_timepoints(simulation_timepoints)
 
         fill_in_parameters(
             edatas=edatas,
@@ -413,7 +413,7 @@ def _time_trajectory_model_with_states(
         ]
     if state_names is not None:
         state_indices_by_name = [
-            model.getStateNames().index(state_name)
+            model.get_state_names().index(state_name)
             for state_name in state_names
         ]
     state_indices = list(set(state_indices_by_id + state_indices_by_name))

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -1191,6 +1191,9 @@ def test_get_simulation_rdatas_default_timepoints():
     result = optimize.minimize(
         problem=problem,
         n_starts=1,
+        optimizer=optimize.ScipyOptimizer(
+            method="L-BFGS-B", options={"maxiter": 1}
+        ),
         progress_bar=False,
     )
 

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -25,6 +25,7 @@ from pypesto.testing.examples import (
     get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds,
 )
 from pypesto.visualize.model_fit import (
+    _get_simulation_rdatas,
     time_trajectory_model,
     visualize_optimized_model_fit,
 )
@@ -1183,6 +1184,22 @@ def test_sampling_prediction_trajectories():
 
 
 @close_fig
+def test_get_simulation_rdatas_default_timepoints():
+    """Regression test for default AMICI timepoint access in model-fit plots."""
+    problem = create_petab_problem()
+
+    result = optimize.minimize(
+        problem=problem,
+        n_starts=1,
+        progress_bar=False,
+    )
+
+    rdatas = _get_simulation_rdatas(result=result, problem=problem)
+
+    assert len(rdatas) == len(problem.objective.edatas)
+
+
+@close_fig
 def test_visualize_optimized_model_fit():
     """Test pypesto.visualize.visualize_optimized_model_fit"""
     current_path = os.path.dirname(os.path.realpath(__file__))
@@ -1291,7 +1308,41 @@ def test_time_trajectory_model():
     )
 
     # test call of time_trajectory_model
-    time_trajectory_model(result=result)
+    axes = time_trajectory_model(result=result)
+    assert axes is not None
+
+    # test call of time_trajectory_model for hierarchical problems
+    hierarchical_petab_problem = (
+        get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds()
+    )
+    importer = pypesto.petab.PetabImporter(
+        hierarchical_petab_problem, hierarchical=True
+    )
+    helper_problem = importer.create_problem()
+
+    x_guesses = np.asarray(hierarchical_petab_problem.x_nominal_scaled)[
+        helper_problem.x_free_indices
+    ]
+    problem = importer.create_problem(x_guesses=[x_guesses])
+
+    result = optimize.minimize(
+        problem=problem,
+        n_starts=1,
+        optimizer=optimize.ScipyOptimizer(
+            method="L-BFGS-B", options={"maxiter": 1}
+        ),
+        progress_bar=False,
+    )
+
+    first_state_name = problem.objective.amici_model.get_state_names()[0]
+
+    axes = time_trajectory_model(
+        result=result,
+        problem=problem,
+        state_names=[first_state_name],
+    )
+
+    assert axes is not None
 
 
 def test_monotonic_history():

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -1321,12 +1321,19 @@ def test_time_trajectory_model():
     importer = pypesto.petab.PetabImporter(
         hierarchical_petab_problem, hierarchical=True
     )
-    helper_problem = importer.create_problem()
+    problem = importer.create_problem()
 
-    x_guesses = np.asarray(hierarchical_petab_problem.x_nominal_scaled)[
-        helper_problem.x_free_indices
-    ]
-    problem = importer.create_problem(x_guesses=[x_guesses])
+    # Set nominal values as start point, mapped by name to avoid ordering
+    # assumptions about where inner parameters sit in x_nominal_scaled
+    x_nominal_by_id = dict(
+        zip(
+            hierarchical_petab_problem.x_ids,
+            hierarchical_petab_problem.x_nominal_scaled,
+            strict=True,
+        )
+    )
+    x_guess = np.array([x_nominal_by_id[xid] for xid in problem.x_names])
+    problem.set_x_guesses([x_guess])
 
     result = optimize.minimize(
         problem=problem,


### PR DESCRIPTION
Some small changes to fix some bugs that occurred recently.

I updated the remaining AMICI calls in the model-fit visualization code (get_timepoints, set_sensitivity_order, set_timepoints, get_state_names) and aligns related docstrings and error messages with the same naming.

Also I expanded visualization test coverage by:
- directly covering _get_simulation_rdatas(..., simulation_timepoints=None) to exercise default AMICI timepoint handling 
- extending time_trajectory_model(...) coverage to include hierarchical problems and named-state selection