### PR TITLE
Optimize: support pyswarm 1.0 return format

### DIFF
--- a/pypesto/optimize/optimizer.py
+++ b/pypesto/optimize/optimizer.py
@@ -1004,9 +1004,13 @@ class PyswarmOptimizer(Optimizer):
 
         check_finite_bounds(lb, ub)
 
-        xopt, fopt = pyswarm.pso(
+        result = pyswarm.pso(
             problem.objective.get_fval, lb, ub, **self.options
         )
+        if hasattr(result, "x") and hasattr(result, "fun"):
+            xopt, fopt = result.x, result.fun
+        else:
+            xopt, fopt = result
 
         optimizer_result = OptimizerResult(
             x=np.array(xopt), fval=fopt, optimizer=str(self)


### PR DESCRIPTION
`pyswarm 1.0` changed `pso` to return an object with `x` and `fun` instead of the old `(xopt, fopt)` tuple.

This keeps support for both formats, so older `pyswarm` versions still work while CI can also use the new release.
I considered changing requirements to pyswarm >= 1.0.0, but it seems there is no more installation wheel for intel macs there anymore, so instead I decided to suggest keeping support for all versions.