### PR TITLE
Pymc improved

### DIFF
--- a/pypesto/sample/pymc.py
+++ b/pypesto/sample/pymc.py
@@ -34,11 +34,11 @@ else:
 # https://www.pymc.io/projects/examples/en/latest/case_studies/blackbox_external_likelihood_numpy.html
 
 
-def _eval_cached(
+def _eval_last_evaluation(
     objective: ObjectiveBase,
     beta: float,
     theta: np.ndarray,
-    cache: dict,
+    last_evaluation: dict,
 ) -> dict:
     """Evaluate log-posterior value and gradient, caching the last result.
 
@@ -57,22 +57,22 @@ def _eval_cached(
         Inverse temperature (e.g. in parallel tempering).
     theta:
         Parameter vector.
-    cache:
+    last_evaluation:
         Mutable dict shared between the value and gradient Op, holding the
         last evaluated parameter vector and the corresponding (scaled) value
         and gradient.
 
     Returns
     -------
-    The (updated) cache, with keys ``"key"``, ``"fval"`` and ``"grad"``.
+    The (updated) last_evaluation, with keys ``"key"``, ``"fval"`` and ``"grad"``.
     """
     key = theta.tobytes()
-    if cache.get("key") != key:
+    if last_evaluation.get("key") != key:
         fval, grad = objective(theta, sensi_orders=(0, 1))
-        cache["key"] = key
-        cache["fval"] = -beta * np.asarray(fval)
-        cache["grad"] = -beta * np.asarray(grad)
-    return cache
+        last_evaluation["key"] = key
+        last_evaluation["fval"] = -beta * np.asarray(fval)
+        last_evaluation["grad"] = -beta * np.asarray(grad)
+    return last_evaluation
 
 
 # TODO: once Python 3.11 support is dropped, require only ArviZ >=1.1.0
@@ -136,14 +136,18 @@ class PymcObjectiveWithGradientOp(PymcObjectiveOp):
 
         # cache shared with the gradient Op, so value and gradient at the same
         # theta require only a single objective (simulator) evaluation
-        self._cache: dict = {}
-        self._log_prob_grad = PymcGradientOp(objective, beta, self._cache)
+        self._last_evaluation: dict = {}
+        self._log_prob_grad = PymcGradientOp(
+            objective, beta, self._last_evaluation
+        )
 
     def perform(self, node, inputs, outputs, params=None):
         """Calculate the objective function value (reusing the shared cache)."""
         (theta,) = inputs
-        cache = _eval_cached(self._objective, self._beta, theta, self._cache)
-        outputs[0][0] = np.array(cache["fval"])
+        last_evaluation = _eval_last_evaluation(
+            self._objective, self._beta, theta, self._last_evaluation
+        )
+        outputs[0][0] = np.array(last_evaluation["fval"])
 
     def grad(self, inputs, g):  # noqa
         """Calculate the vector-Jacobian product."""
@@ -163,7 +167,10 @@ class PymcGradientOp(_PT_OP_BASE):
     otypes = [pt.dvector] if pt is not None else None
 
     def __init__(
-        self, objective: ObjectiveBase, beta: float, cache: dict | None = None
+        self,
+        objective: ObjectiveBase,
+        beta: float,
+        last_evaluation: dict | None = None,
     ):
         # Check dependencies
         if not _HAS_PYMC:
@@ -172,14 +179,16 @@ class PymcGradientOp(_PT_OP_BASE):
         self._beta: float = beta
         # shared with the value Op so that value and gradient at the same theta
         # require only a single objective (simulator) evaluation
-        self._cache: dict = cache if cache is not None else {}
+        self._last_evaluation: dict = last_evaluation or {}
 
     def perform(self, node, inputs, outputs, params=None):
         """Calculate the gradients of the objective function."""
         (theta,) = inputs
         # calculate gradients (reusing the shared cache)
-        cache = _eval_cached(self._objective, self._beta, theta, self._cache)
-        outputs[0][0] = cache["grad"]
+        last_evaluation = _eval_last_evaluation(
+            self._objective, self._beta, theta, self._last_evaluation
+        )
+        outputs[0][0] = last_evaluation["grad"]
 
 
 class PymcSampler(Sampler):

--- a/pypesto/sample/pymc.py
+++ b/pypesto/sample/pymc.py
@@ -287,9 +287,7 @@ class PymcSampler(Sampler):
             # convert parameters to PyTensor tensor variable
             theta = pt.as_tensor_variable(_k)
 
-            # evaluate the log-posterior once and reuse the same node, so the
-            # objective is not evaluated separately for the density and the
-            # recorded function values
+            # evaluate the log-posterior once and reuse the same node
             log_post_theta = log_post(theta)
 
             # define distribution with log-posterior as density

--- a/pypesto/sample/pymc.py
+++ b/pypesto/sample/pymc.py
@@ -34,6 +34,47 @@ else:
 # https://www.pymc.io/projects/examples/en/latest/case_studies/blackbox_external_likelihood_numpy.html
 
 
+def _eval_cached(
+    objective: ObjectiveBase,
+    beta: float,
+    theta: np.ndarray,
+    cache: dict,
+) -> dict:
+    """Evaluate log-posterior value and gradient, caching the last result.
+
+    For gradient-based samplers (e.g. NUTS) pymc evaluates the log-posterior
+    and its gradient at the same ``theta`` within a single function call. As
+    the function value is computed anyway during a sensitivity run, both are
+    obtained via a single ``sensi_orders=(0, 1)`` call and cached, so the
+    objective (and hence the simulator) is evaluated only once per ``theta``
+    instead of once for the value and once for the gradient.
+
+    Parameters
+    ----------
+    objective:
+        Objective function (negative log-likelihood or -posterior).
+    beta:
+        Inverse temperature (e.g. in parallel tempering).
+    theta:
+        Parameter vector.
+    cache:
+        Mutable dict shared between the value and gradient Op, holding the
+        last evaluated parameter vector and the corresponding (scaled) value
+        and gradient.
+
+    Returns
+    -------
+    The (updated) cache, with keys ``"key"``, ``"fval"`` and ``"grad"``.
+    """
+    key = theta.tobytes()
+    if cache.get("key") != key:
+        fval, grad = objective(theta, sensi_orders=(0, 1))
+        cache["key"] = key
+        cache["fval"] = -beta * np.asarray(fval)
+        cache["grad"] = -beta * np.asarray(grad)
+    return cache
+
+
 # TODO: once Python 3.11 support is dropped, require only ArviZ >=1.1.0
 #  and simplify this helper to `data.posterior.to_dataset()`.
 def _get_posterior_dataset(data: Any) -> Any:
@@ -93,7 +134,16 @@ class PymcObjectiveWithGradientOp(PymcObjectiveOp):
     def __init__(self, objective: ObjectiveBase, beta: float = 1.0):
         super().__init__(objective, beta)
 
-        self._log_prob_grad = PymcGradientOp(objective, beta)
+        # cache shared with the gradient Op, so value and gradient at the same
+        # theta require only a single objective (simulator) evaluation
+        self._cache: dict = {}
+        self._log_prob_grad = PymcGradientOp(objective, beta, self._cache)
+
+    def perform(self, node, inputs, outputs, params=None):
+        """Calculate the objective function value (reusing the shared cache)."""
+        (theta,) = inputs
+        cache = _eval_cached(self._objective, self._beta, theta, self._cache)
+        outputs[0][0] = np.array(cache["fval"])
 
     def grad(self, inputs, g):  # noqa
         """Calculate the vector-Jacobian product."""
@@ -112,19 +162,24 @@ class PymcGradientOp(_PT_OP_BASE):
     # outputs a single scalar value (the log prob)
     otypes = [pt.dvector] if pt is not None else None
 
-    def __init__(self, objective: ObjectiveBase, beta: float):
+    def __init__(
+        self, objective: ObjectiveBase, beta: float, cache: dict | None = None
+    ):
         # Check dependencies
         if not _HAS_PYMC:
             raise SamplerImportError("pymc")
         self._objective: ObjectiveBase = objective
         self._beta: float = beta
+        # shared with the value Op so that value and gradient at the same theta
+        # require only a single objective (simulator) evaluation
+        self._cache: dict = cache if cache is not None else {}
 
     def perform(self, node, inputs, outputs, params=None):
         """Calculate the gradients of the objective function."""
         (theta,) = inputs
-        # calculate gradients
-        log_prob_grad = -self._beta * self._objective(theta, sensi_orders=(1,))
-        outputs[0][0] = log_prob_grad
+        # calculate gradients (reusing the shared cache)
+        cache = _eval_cached(self._objective, self._beta, theta, self._cache)
+        outputs[0][0] = cache["grad"]
 
 
 class PymcSampler(Sampler):
@@ -168,8 +223,8 @@ class PymcSampler(Sampler):
         options:
             Options configuring the sampler.
         """
-        if not options:
-            options = {"chains": 1}
+        options = dict(options or {})
+        options.setdefault("chains", 1)
         return options
 
     def initialize(self, problem: Problem, x0: np.ndarray):
@@ -232,11 +287,16 @@ class PymcSampler(Sampler):
             # convert parameters to PyTensor tensor variable
             theta = pt.as_tensor_variable(_k)
 
+            # evaluate the log-posterior once and reuse the same node, so the
+            # objective is not evaluated separately for the density and the
+            # recorded function values
+            log_post_theta = log_post(theta)
+
             # define distribution with log-posterior as density
-            pymc.Potential("potential", log_post(theta))
+            pymc.Potential("potential", log_post_theta)
 
             # record function values
-            pymc.Deterministic("loggyposty", log_post(theta))
+            pymc.Deterministic("loggyposty", log_post_theta)
 
             # step, by default automatically determined by pymc
             step = None


### PR DESCRIPTION
This pull request introduces an optimization for PyMC samplers in `pypesto` by implementing a shared cache for objective function evaluations. This ensures that when both the log-posterior value and its gradient are needed at the same parameter vector, the objective is only evaluated once, significantly improving efficiency for gradient-based sampling methods.