### PR TITLE
Removed matplotlib.cm.get_cmap

### DIFF
--- a/pypesto/visualize/ordinal_categories.py
+++ b/pypesto/visualize/ordinal_categories.py
@@ -874,8 +874,8 @@ def _plot_observable_fit_for_multiple_conditions(
                 colors.append(line.get_color())
     # Get as many colors as there are conditions
     else:
-        rainbow = plt.colormaps["rainbow"]
-        colors = rainbow(np.linspace(0, 1, len(simulation_all)))
+        cmap = plt.colormaps["rainbow"]
+        colors = cmap(np.linspace(0, 1, len(simulation_all)))
 
     if measurement_type == CENSORED:
         quantitative_data_flattened = inner_problem.groups[group][

--- a/pypesto/visualize/ordinal_categories.py
+++ b/pypesto/visualize/ordinal_categories.py
@@ -874,7 +874,8 @@ def _plot_observable_fit_for_multiple_conditions(
                 colors.append(line.get_color())
     # Get as many colors as there are conditions
     else:
-        colors = plt.cm.rainbow(np.linspace(0, 1, len(simulation_all)))
+        rainbow = plt.colormaps["rainbow"]
+        colors = rainbow(np.linspace(0, 1, len(simulation_all)))
 
     if measurement_type == CENSORED:
         quantitative_data_flattened = inner_problem.groups[group][

--- a/pypesto/visualize/parameters.py
+++ b/pypesto/visualize/parameters.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Callable, Iterable, Sequence
 
+import matplotlib
 import matplotlib.axes
 import numpy as np
 import pandas as pd
@@ -718,7 +719,7 @@ def optimization_scatter(
     fvals = np.array([result.optimize_result[i].fval for i in start_indices])
 
     # continuous colormap: viridis, low fval (best) → yellow, high fval (worst) → dark
-    cmap = mpl_cm.viridis_r
+    cmap = matplotlib.colormaps["viridis_r"]
     min_fval_range = 1.0
     fval_min = fvals.min()
     fval_max = fvals.max()

--- a/pypesto/visualize/profile_cis.py
+++ b/pypesto/visualize/profile_cis.py
@@ -1,8 +1,8 @@
 from collections.abc import Sequence
 from typing import Literal
 
+import matplotlib
 import matplotlib.axes
-import matplotlib.cm as cm
 import numpy as np
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Patch, Rectangle
@@ -149,7 +149,7 @@ def profile_nested_cis(
     n_cls = len(confidence_levels)
     ws = [(0.6 / n_cls) * i for i in range(1, n_cls + 1)]
     if colors is None:
-        blues = cm.get_cmap("Blues")
+        blues = matplotlib.colormaps["Blues"]
         colors = [blues(i) for i in ws]
 
     # ensure that the confidence levels are sorted in decreasing order

--- a/pypesto/visualize/sampling.py
+++ b/pypesto/visualize/sampling.py
@@ -711,8 +711,9 @@ def _handle_colors(
     cmap_max = 0.85 * (RGBA_MAX - RGBA_MIN) + RGBA_MIN  # exclude yellows
 
     # define colormap
+    viridis = plt.colormaps["viridis"]
     variable_colors = [
-        list(matplotlib.cm.viridis(v))[:LEN_RGB]
+        list(viridis(v))[:LEN_RGB]
         for v in np.linspace(cmap_min, cmap_max, n_variables)
     ]
 
@@ -1021,7 +1022,8 @@ def sampling_parameter_cis(
     levels_sorted = sorted(confidence_levels, reverse=True)
     # define colormap
     evenly_spaced_interval = np.linspace(0, 1, len(levels_sorted))
-    colors = [plt.cm.tab20c_r(x) for x in evenly_spaced_interval]
+    tab20c_r = plt.colormaps["tab20c_r"]
+    colors = [tab20c_r(x) for x in evenly_spaced_interval]
     # number of sampled parameters
     n_pars = result.sample_result.trace_x.shape[-1]
 


### PR DESCRIPTION
the function was removed in matplotlib 3.11 (https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.11.0.html#removals)