### PR TITLE
PEtab v2 import via AMICI (finish #1634)

### DIFF
--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
 import numpy as np
+import pandas as pd
 
 from ...C import (
     FVAL,
@@ -36,6 +37,8 @@ from .amici_util import (
 )
 
 if TYPE_CHECKING:
+    import amici.importers.petab
+
     from ...hierarchical import InnerCalculatorCollector
 
 try:
@@ -718,3 +721,67 @@ class AmiciObjective(ObjectiveBase):
             ) in condition_mapping.map_preeq_fix.items():
                 if (val := id_to_val.get(mapped_to_par)) is not None:
                     condition_mapping.map_preeq_fix[model_par] = val
+
+
+class AmiciPetabV2Objective(AmiciObjective):
+    """An AMICI objective constructed from a PEtab v2 problem."""
+
+    def __init__(
+        self,
+        petab_importer: amici.importers.petab.PetabImporter,
+        **kwargs,
+    ) -> None:
+        from .amici_calculator import AmiciCalculatorPetabV2
+
+        self._petab_simulator: amici.petab.petab_importer.PetabSimulator = (
+            petab_importer.create_simulator()
+        )
+        self.petab_problem = petab_importer.petab_problem
+        amici_model = self._petab_simulator.model
+        amici_solver = self._petab_simulator.solver
+        edatas = self._petab_simulator.exp_man.create_edatas()
+
+        super().__init__(
+            amici_model=amici_model,
+            amici_solver=amici_solver,
+            edatas=edatas,
+            calculator=AmiciCalculatorPetabV2(self._petab_simulator),
+            **kwargs,
+        )
+
+    def __deepcopy__(self, memo=None):
+        """Override AmiciObjective.__deepcopy__."""
+        if memo is None:
+            memo = {}
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            setattr(result, k, copy.deepcopy(v, memo))
+        return result
+
+    def __getstate__(self) -> dict:
+        """Use Python's default pickling semantics (shallow copy of instance dict)."""
+        return dict(self.__dict__)
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore state using the instance dict (default unpickling behaviour)."""
+        self.__dict__.update(state)
+
+    def rdatas_to_simulation_df(
+        self,
+        rdatas: Sequence[amici.ReturnData],
+    ) -> pd.DataFrame:
+        """
+        See :meth:`rdatas_to_measurement_df`.
+
+        Except a petab simulation dataframe is created, i.e. the measurement
+        column label is adjusted.
+        """
+        from amici.importers.petab import rdatas_to_simulation_df
+
+        return rdatas_to_simulation_df(
+            rdatas,
+            self._petab_simulator._model,
+            self._petab_simulator._petab_problem,
+        )

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -725,7 +725,33 @@ class AmiciObjective(ObjectiveBase):
 
 
 class AmiciPetabV2Objective(AmiciObjective):
-    """An AMICI objective constructed from a PEtab v2 problem."""
+    """An AMICI objective constructed from a PEtab v2 problem.
+
+    The objective value is the negative log-likelihood, or the unnormalized
+    negative log-posterior if the PEtab problem defines parameter priors (see
+    :meth:`PetabImporter.create_problem`, which adds the prior terms).
+
+    .. warning::
+
+        PEtab v2 support is still under development, and this interface may
+        change while the following limitations are addressed:
+
+        * Sensitivities are computed for every parameter that is estimated in
+          the PEtab problem, including those fixed in the
+          :class:`pypesto.Problem`. Unlike for PEtab v1, ``plist`` cannot be
+          narrowed down from pyPESTO, since it is set by
+          :meth:`amici.sim.sundials.petab.ExperimentManager.apply_parameters`.
+          This costs performance, in particular for profile likelihoods.
+        * Steady-state guessing (``guess_steadystate``) is not available: the
+          PEtab simulator creates its own :class:`amici.ExpData` objects for
+          every simulation, so guesses cannot be passed on to it.
+        * Hierarchical optimization and non-quantitative data types (ordinal,
+          censored, semiquantitative) are not supported.
+        * Predictors (:class:`pypesto.predict.AmiciPredictor`) and the
+          conversion of predictions to PEtab dataframes are not supported.
+        * Custom timepoints (:meth:`AmiciObjective.set_custom_timepoints`)
+          have no effect, for the same reason as steady-state guessing.
+    """
 
     def __init__(
         self,

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -751,17 +751,27 @@ class AmiciPetabV2Objective(AmiciObjective):
             petab_importer.create_simulator(force_import=force_compile)
         )
         self.petab_problem = petab_importer.petab_problem
-        amici_model = self._petab_simulator.model
-        amici_solver = self._petab_simulator.solver
-        edatas = self._petab_simulator.exp_man.create_edatas()
+
+        # the simulator creates its own ExpData objects for every simulation,
+        #  so steady-state guesses cannot be passed on to it
+        kwargs.setdefault("guess_steadystate", False)
 
         super().__init__(
-            amici_model=amici_model,
-            amici_solver=amici_solver,
-            edatas=edatas,
+            amici_model=self._petab_simulator.model,
+            amici_solver=self._petab_simulator.solver,
+            edatas=self._petab_simulator.exp_man.create_edatas(),
             calculator=AmiciCalculatorPetabV2(self._petab_simulator),
             **kwargs,
         )
+        # `AmiciObjective` works on clones of the model and the solver, but the
+        #  simulation is run by the simulator. Discard the clones, so that
+        #  settings applied to `self.amici_model` / `self.amici_solver`
+        #  (sensitivity order, reporting mode, sigma residuals, ...) take
+        #  effect. The simulator is created here and not shared with any other
+        #  objective, so there is nothing to isolate ourselves from.
+        self.amici_model = self._petab_simulator.model
+        self.amici_solver = self._petab_simulator.solver
+        self._petab_simulator.num_threads = self.n_threads
 
     def update_from_problem(
         self,
@@ -772,28 +782,68 @@ class AmiciPetabV2Objective(AmiciObjective):
     ) -> None:
         """Handle fixed parameters.
 
-        In addition to the base class behaviour, forward the fixed parameter
-        values to the calculator. The PEtab v2 calculator drives the
-        simulation through the PEtab simulator, which ignores the AMICI
-        ``parameter_mapping`` that the base class updates; without this, fixed
-        parameters would be simulated at their PEtab nominal values.
+        The implementation of :class:`AmiciObjective` is deliberately bypassed:
+        there is no AMICI ``parameter_mapping`` to update -- the mapping of
+        PEtab problem parameters to model parameters is done by the PEtab
+        simulator. Parameters that are fixed in the pyPESTO problem are simply
+        simulated at their fixed values, which are part of the (full)
+        parameter vector passed to the objective. The calculator only needs to
+        know which parameters are free, to be able to tell whether all
+        required sensitivities are available.
         """
-        super().update_from_problem(
+        ObjectiveBase.update_from_problem(
+            self,
             dim_full=dim_full,
             x_free_indices=x_free_indices,
             x_fixed_indices=x_fixed_indices,
             x_fixed_vals=x_fixed_vals,
         )
-        self.calculator.fixed_parameters = dict(
-            zip(
-                (self.x_ids[i] for i in x_fixed_indices),
-                x_fixed_vals,
-                strict=True,
+        self.calculator.free_parameter_ids = {
+            self.x_ids[ix] for ix in x_free_indices
+        }
+
+    def check_gradients_match_finite_differences(
+        self, *args, x: np.ndarray = None, **kwargs
+    ) -> bool:
+        """Check if gradients match finite differences (FDs).
+
+        Parameters
+        ----------
+        x: The parameters for which to evaluate the gradient. Defaults to the
+           nominal parameters of the PEtab problem.
+
+        Returns
+        -------
+        bool
+            Indicates whether gradients match (True) FDs or not (False)
+        """
+        if x is None:
+            # PEtab v2 does not have parameter scales
+            x_nominal = self.petab_problem.get_x_nominal_dict()
+            x = np.array([x_nominal[x_id] for x_id in self.x_ids])
+            x_free_ids = set(self.petab_problem.x_free_ids)
+            kwargs.setdefault(
+                "x_free",
+                [
+                    ix
+                    for ix, x_id in enumerate(self.x_ids)
+                    if x_id in x_free_ids
+                ],
             )
+        return ObjectiveBase.check_gradients_match_finite_differences(
+            self, *args, x=x, **kwargs
         )
 
     def __deepcopy__(self, memo=None):
-        """Override AmiciObjective.__deepcopy__."""
+        """Copy the objective.
+
+        :class:`AmiciObjective` re-creates the model, the solver and the
+        ``ExpData`` objects, which would leave the copied objective and its
+        PEtab simulator with different model and solver instances. AMICI
+        objects support ``deepcopy``, so a plain deep copy of the instance
+        dictionary is used instead -- ``memo`` keeps the objects that are
+        shared with the simulator shared in the copy.
+        """
         if memo is None:
             memo = {}
         cls = self.__class__
@@ -804,7 +854,12 @@ class AmiciPetabV2Objective(AmiciObjective):
         return result
 
     def __getstate__(self) -> dict:
-        """Use Python's default pickling semantics (shallow copy of instance dict)."""
+        """Use Python's default pickling semantics.
+
+        See :meth:`__deepcopy__` -- rebuilding the AMICI objects from the
+        ``amici_object_builder``, as :class:`AmiciObjective` does, would
+        disconnect them from the PEtab simulator.
+        """
         return dict(self.__dict__)
 
     def __setstate__(self, state: dict) -> None:
@@ -825,6 +880,6 @@ class AmiciPetabV2Objective(AmiciObjective):
 
         return rdatas_to_simulation_df(
             rdatas,
-            self._petab_simulator._model,
-            self._petab_simulator._petab_problem,
+            self.amici_model,
+            self._petab_simulator.exp_man.petab_problem,
         )

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -38,6 +38,7 @@ from .amici_util import (
 
 if TYPE_CHECKING:
     import amici.importers.petab
+    import amici.sim.sundials.petab
 
     from ...hierarchical import InnerCalculatorCollector
 
@@ -729,12 +730,25 @@ class AmiciPetabV2Objective(AmiciObjective):
     def __init__(
         self,
         petab_importer: amici.importers.petab.PetabImporter,
+        force_compile: bool = False,
         **kwargs,
     ) -> None:
+        """Initialize the objective.
+
+        Parameters
+        ----------
+        petab_importer:
+            The AMICI PEtab importer for the (v2) PEtab problem.
+        force_compile:
+            If ``True``, force (re-)import/compilation of the AMICI model even
+            if a compiled model already exists.
+        kwargs:
+            Additional arguments passed on to :class:`AmiciObjective`.
+        """
         from .amici_calculator import AmiciCalculatorPetabV2
 
-        self._petab_simulator: amici.petab.petab_importer.PetabSimulator = (
-            petab_importer.create_simulator()
+        self._petab_simulator: amici.sim.sundials.petab.PetabSimulator = (
+            petab_importer.create_simulator(force_import=force_compile)
         )
         self.petab_problem = petab_importer.petab_problem
         amici_model = self._petab_simulator.model
@@ -747,6 +761,35 @@ class AmiciPetabV2Objective(AmiciObjective):
             edatas=edatas,
             calculator=AmiciCalculatorPetabV2(self._petab_simulator),
             **kwargs,
+        )
+
+    def update_from_problem(
+        self,
+        dim_full: int,
+        x_free_indices: Sequence[int],
+        x_fixed_indices: Sequence[int],
+        x_fixed_vals: Sequence[float],
+    ) -> None:
+        """Handle fixed parameters.
+
+        In addition to the base class behaviour, forward the fixed parameter
+        values to the calculator. The PEtab v2 calculator drives the
+        simulation through the PEtab simulator, which ignores the AMICI
+        ``parameter_mapping`` that the base class updates; without this, fixed
+        parameters would be simulated at their PEtab nominal values.
+        """
+        super().update_from_problem(
+            dim_full=dim_full,
+            x_free_indices=x_free_indices,
+            x_fixed_indices=x_fixed_indices,
+            x_fixed_vals=x_fixed_vals,
+        )
+        self.calculator.fixed_parameters = dict(
+            zip(
+                (self.x_ids[i] for i in x_fixed_indices),
+                x_fixed_vals,
+                strict=True,
+            )
         )
 
     def __deepcopy__(self, memo=None):

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -154,6 +154,163 @@ class AmiciCalculator:
         )
 
 
+class AmiciCalculatorPetabV2(AmiciCalculator):
+    """Class to perform the AMICI call and obtain objective function values."""
+
+    def __init__(
+        self,
+        petab_simulator: amici.petab.petab_importer.PetabSimulator,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.petab_simulator = petab_simulator
+
+    def __call__(
+        self,
+        x_dct: dict,
+        sensi_orders: tuple[int],
+        mode: ModeType,
+        amici_model: AmiciModel,
+        amici_solver: AmiciSolver,
+        edatas: list[amici.ExpData],
+        n_threads: int,
+        x_ids: Sequence[str],
+        parameter_mapping: ParameterMapping,
+        fim_for_hess: bool,
+    ):
+        """Perform the actual AMICI call.
+
+        Called within the :func:`AmiciObjective.__call__` method.
+
+        Parameters
+        ----------
+        x_dct:
+            Parameters for which to compute function value and derivatives.
+        sensi_orders:
+            Tuple of requested sensitivity orders.
+        mode:
+            Call mode (function value or residual based).
+        amici_model:
+            The AMICI model.
+        amici_solver:
+            The AMICI solver.
+        edatas:
+            The experimental data.
+        n_threads:
+            Number of threads for AMICI call.
+        x_ids:
+            Ids of optimization parameters.
+        parameter_mapping:
+            Mapping of optimization to simulation parameters.
+        fim_for_hess:
+            Whether to use the FIM (if available) instead of the Hessian (if
+            requested).
+        """
+        amici_solver = self.petab_simulator._solver
+
+        if mode != MODE_FUN:
+            raise NotImplementedError(
+                "Only function value mode is currently supported for "
+                f"PEtab v2. Got mode {mode}."
+            )
+
+        # TODO: -> method
+        # set order in solver
+        sensi_order = 0
+        if sensi_orders:
+            sensi_order = max(sensi_orders)
+
+        if sensi_order == 2 and fim_for_hess:
+            # we use the FIM
+            amici_solver.set_sensitivity_order(sensi_order - 1)
+        else:
+            amici_solver.set_sensitivity_order(sensi_order)
+
+        dim = len(x_ids)
+
+        # run amici simulation
+        result = self.petab_simulator.simulate(x_dct)
+        rdatas = result.rdatas
+
+        # check if the simulation failed
+        if any(rdata["status"] < 0.0 for rdata in rdatas):
+            return get_error_output(
+                amici_model, edatas, rdatas, sensi_orders, mode, dim
+            )
+
+        nllh, snllh, s2nllh, chi2, res, sres = init_return_values(
+            sensi_orders, mode, dim
+        )
+        nllh = -result.llh
+
+        if (
+            not self._known_least_squares_safe
+            and mode == MODE_RES
+            and 1 in sensi_orders
+        ):
+            if not amici_model.get_add_sigma_residuals() and any(
+                (
+                    (r["ssigmay"] is not None and np.any(r["ssigmay"]))
+                    or (r["ssigmaz"] is not None and np.any(r["ssigmaz"]))
+                )
+                for r in rdatas
+            ):
+                raise RuntimeError(
+                    "Cannot use least squares solver with"
+                    "parameter dependent sigma! Support can be "
+                    "enabled via "
+                    "amici_model.setAddSigmaResiduals()."
+                )
+            self._known_least_squares_safe = True  # don't check this again
+
+        # TODO: compute res, sres
+
+        if 1 in sensi_orders:
+            if result.sllh is None and np.isnan(result["llh"]):
+                # TODO: to amici -- set sllh even if llh is nan?
+                snllh = np.full(len(x_ids), np.nan)
+            else:
+                try:
+                    # llh to nllh, dict to array
+                    snllh = -np.array(
+                        [
+                            result.sllh[
+                                x_id
+                            ]  # if x_id in res["sllh"] else 0.0
+                            for x_id in x_ids
+                            if x_id in x_dct.keys()
+                        ]
+                    )
+                except KeyError as e:
+                    # A requested sensitivity is missing.
+                    # Probably the affected parameter is a fixed parameter
+                    # in amici instead of a sensitivity parameter
+                    # (non_estimated_parameters_as_constants=True ?).
+                    # In this case, only max(sensi_orders) == 0 is supported
+                    # unless this parameter is fixed in the pypesto problem.
+                    raise ValueError(
+                        f"Cannot compute gradient, missing entry for "
+                        f"{set(result.sllh) - set(x_dct.keys())}."
+                    ) from e
+        if 2 in sensi_orders:
+            if result.s2llh is None and np.isnan(result.llh):
+                # TODO: to amici -- set s2llh even if llh is nan?
+                s2nllh = np.full((len(x_ids), len(x_ids)), np.nan)
+            else:
+                s2nllh = -result.s2llh
+
+        ret = {
+            FVAL: nllh,
+            GRAD: snllh,
+            HESS: s2nllh,
+            RES: res,
+            SRES: sres,
+            RDATAS: rdatas,
+        }
+
+        return filter_return_dict(ret)
+
+
 def calculate_function_values(
     rdatas,
     sensi_orders: tuple[int, ...],

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -300,40 +300,6 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
                 amici_model, edatas, rdatas, sensi_orders, mode, dim
             )
 
-        # `result.sllh`, `result.s2llh` and `result.sres` refer to the
-        #  parameters estimated in the *PEtab* problem. Parameters that are
-        #  fixed in the pyPESTO problem are still estimated in the PEtab
-        #  problem; parameters that are not estimated in the PEtab problem have
-        #  no sensitivities and keep their zero entries here (they are always
-        #  fixed in the pyPESTO problem, and are dropped downstream).
-        # TODO: sensitivities are computed for all parameters estimated in the
-        #  PEtab problem, also for those fixed in the pyPESTO problem. Unlike
-        #  for PEtab v1, `plist` cannot be narrowed down from here, since it is
-        #  set by `ExperimentManager.apply_parameters`.
-        petab_free_ids = self.petab_simulator.exp_man.petab_problem.x_free_ids
-        petab_ix = {x_id: ix for ix, x_id in enumerate(petab_free_ids)}
-        # positions in the pyPESTO parameter vector and the corresponding
-        #  positions in the PEtab sensitivity arrays
-        opt_ix_sel = [ix for ix, x_id in enumerate(x_ids) if x_id in petab_ix]
-        sim_ix_sel = [petab_ix[x_ids[ix]] for ix in opt_ix_sel]
-
-        if (
-            self.free_parameter_ids is not None
-            and sensi_orders
-            and max(sensi_orders) > 0
-        ):
-            # a parameter that is free in the pyPESTO problem, but not
-            #  estimated in the PEtab problem, is a constant in the AMICI model
-            #  (non_estimated_parameters_as_constants=True) -- there are no
-            #  sensitivities for it, and only sensi_order 0 is supported
-            if missing := self.free_parameter_ids - set(petab_ix):
-                raise ValueError(
-                    f"Cannot compute gradient, missing entry for {missing}. "
-                    "Those parameters are not estimated in the PEtab problem "
-                    "-- fix them in the pyPESTO problem, or request "
-                    "`sensi_orders=(0,)` only."
-                )
-
         if mode == MODE_FUN:
             if 1 in sensi_orders:
                 if missing := {x_ids[ix] for ix in opt_ix_sel} - set(

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -155,7 +155,21 @@ class AmiciCalculator:
 
 
 class AmiciCalculatorPetabV2(AmiciCalculator):
-    """Class to perform the AMICI call and obtain objective function values."""
+    """Perform the AMICI call for a PEtab v2 problem.
+
+    For PEtab v2, the mapping between PEtab problem parameters and AMICI model
+    parameters lives entirely inside
+    :class:`amici.sim.sundials.petab.PetabSimulator`; there is no PEtab v1
+    style ``ParameterMapping`` that :class:`AmiciCalculator` could use. This
+    calculator therefore delegates simulation *and* the aggregation of the
+    results across experiments to the simulator and only translates the
+    outcome into pyPESTO's return dict.
+
+    The simulator is expected to operate on the same model and solver
+    instances as the objective (see :class:`AmiciPetabV2Objective`), so that
+    the sensitivity order and the return-data reporting mode set by the
+    objective take effect in the simulation.
+    """
 
     def __init__(
         self,
@@ -164,9 +178,12 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
     ):
         super().__init__(**kwargs)
         self.petab_simulator = petab_simulator
-        # fixed-parameter values (set by update_from_problem); merged into the
-        #  simulation so the simulator doesn't fall back to PEtab nominal values
-        self.fixed_parameters: dict[str, float] = {}
+        #: IDs of the parameters that are free in the pyPESTO problem, i.e.,
+        #: those for which sensitivities are required. Set by
+        #: :class:`AmiciPetabV2Objective` as soon as the objective is part of
+        #: a :class:`pypesto.Problem`; ``None`` disables the check for
+        #: missing sensitivities.
+        self.free_parameter_ids: set[str] | None = None
 
     def __call__(
         self,
@@ -209,29 +226,65 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
             Whether to use the FIM (if available) instead of the Hessian (if
             requested).
         """
-        amici_solver = self.petab_simulator._solver
+        # set order in solver
+        sensi_order = 0
+        if sensi_orders:
+            sensi_order = max(sensi_orders)
 
-        # request the full return data (llh, sllh, FIM, residuals, sres); this
-        #  is the simulator default, set explicitly to be robust to prior state
-        amici_solver.set_return_data_reporting_mode(asd.RDataReporting.full)
-
-        # set the sensitivity order in the solver
-        sensi_order = max(sensi_orders) if sensi_orders else 0
         if sensi_order == 2 and fim_for_hess:
-            # use the FIM instead of the Hessian
+            # we use the FIM
             amici_solver.set_sensitivity_order(sensi_order - 1)
         else:
             amici_solver.set_sensitivity_order(sensi_order)
 
+        # full optimization problem dimension (including fixed parameters)
         dim = len(x_ids)
 
-        # add back fixed-parameter values (stripped from x_dct by the objective)
-        #  so the simulator doesn't fall back to the PEtab nominal values
-        problem_parameters = {**self.fixed_parameters, **x_dct}
-        result = self.petab_simulator.simulate(problem_parameters)
-        rdatas = result.rdatas
+        # `result.sllh`, `result.s2llh` and `result.sres` refer to the
+        #  parameters estimated in the *PEtab* problem. Parameters that are
+        #  fixed in the pyPESTO problem are still estimated in the PEtab
+        #  problem; parameters that are not estimated in the PEtab problem have
+        #  no sensitivities and keep their zero entries below (they can only be
+        #  fixed in the pyPESTO problem, see the check further down).
+        # TODO: sensitivities are computed for all parameters estimated in the
+        #  PEtab problem, also for those fixed in the pyPESTO problem. Unlike
+        #  for PEtab v1, `plist` cannot be narrowed down from here, since it is
+        #  set by `ExperimentManager.apply_parameters`.
+        petab_ix = {
+            x_id: ix
+            for ix, x_id in enumerate(
+                self.petab_simulator.exp_man.petab_problem.x_free_ids
+            )
+        }
+        # positions in the pyPESTO parameter vector and the corresponding
+        #  positions in the PEtab sensitivity arrays
+        opt_ix_sel = [ix for ix, x_id in enumerate(x_ids) if x_id in petab_ix]
+        sim_ix_sel = [petab_ix[x_ids[ix]] for ix in opt_ix_sel]
 
-        # check whether the simulation failed
+        if self.free_parameter_ids is not None and sensi_order > 0:
+            # a parameter that is free in the pyPESTO problem, but not
+            #  estimated in the PEtab problem, is a constant in the AMICI model
+            #  (non_estimated_parameters_as_constants=True) -- there are no
+            #  sensitivities for it, and only sensi_order 0 is supported
+            if missing := self.free_parameter_ids - set(petab_ix):
+                raise ValueError(
+                    f"Cannot compute gradient, missing entry for {missing}. "
+                    "Those parameters are not estimated in the PEtab problem "
+                    "-- fix them in the pyPESTO problem, or request "
+                    "`sensi_orders=(0,)` only."
+                )
+
+        # run amici simulation; parameter mapping and the aggregation of the
+        #  results across experiments are handled by the PEtab simulator
+        result = self.petab_simulator.simulate(x_dct)
+        rdatas = result.rdatas
+        # the simulator creates its own ExpData objects
+        edatas = result.edatas
+
+        for data_ix, rdata in enumerate(rdatas):
+            log_simulation(data_ix, rdata)
+
+        # check if the simulation failed
         if any(rdata["status"] < 0.0 for rdata in rdatas):
             return get_error_output(
                 amici_model, edatas, rdatas, sensi_orders, mode, dim
@@ -242,76 +295,93 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
         )
         nllh = -result.llh
 
-        # column indices of the free optimization parameters within the
-        #  estimated-parameter ordering used by result.sllh/s2llh/sres
-        estimated_ids = list(self.petab_simulator._petab_problem.x_free_ids)
-        free_ids = [x_id for x_id in x_ids if x_id in x_dct]
+        if mode == MODE_FUN and not np.isfinite(nllh):
+            return get_error_output(
+                amici_model, edatas, rdatas, sensi_orders, mode, dim
+            )
 
-        def _free_block_indices() -> list[int]:
-            try:
-                return [estimated_ids.index(x_id) for x_id in free_ids]
-            except ValueError as e:
+        # `result.sllh`, `result.s2llh` and `result.sres` refer to the
+        #  parameters estimated in the *PEtab* problem. Parameters that are
+        #  fixed in the pyPESTO problem are still estimated in the PEtab
+        #  problem; parameters that are not estimated in the PEtab problem have
+        #  no sensitivities and keep their zero entries here (they are always
+        #  fixed in the pyPESTO problem, and are dropped downstream).
+        # TODO: sensitivities are computed for all parameters estimated in the
+        #  PEtab problem, also for those fixed in the pyPESTO problem. Unlike
+        #  for PEtab v1, `plist` cannot be narrowed down from here, since it is
+        #  set by `ExperimentManager.apply_parameters`.
+        petab_free_ids = self.petab_simulator.exp_man.petab_problem.x_free_ids
+        petab_ix = {x_id: ix for ix, x_id in enumerate(petab_free_ids)}
+        # positions in the pyPESTO parameter vector and the corresponding
+        #  positions in the PEtab sensitivity arrays
+        opt_ix_sel = [ix for ix, x_id in enumerate(x_ids) if x_id in petab_ix]
+        sim_ix_sel = [petab_ix[x_ids[ix]] for ix in opt_ix_sel]
+
+        if (
+            self.free_parameter_ids is not None
+            and sensi_orders
+            and max(sensi_orders) > 0
+        ):
+            # a parameter that is free in the pyPESTO problem, but not
+            #  estimated in the PEtab problem, is a constant in the AMICI model
+            #  (non_estimated_parameters_as_constants=True) -- there are no
+            #  sensitivities for it, and only sensi_order 0 is supported
+            if missing := self.free_parameter_ids - set(petab_ix):
                 raise ValueError(
-                    "Missing sensitivities for free parameters "
-                    f"{set(free_ids) - set(estimated_ids)}. A free parameter "
-                    "is likely constant in the AMICI model "
-                    "(non_estimated_parameters_as_constants=True)."
-                ) from e
+                    f"Cannot compute gradient, missing entry for {missing}. "
+                    "Those parameters are not estimated in the PEtab problem "
+                    "-- fix them in the pyPESTO problem, or request "
+                    "`sensi_orders=(0,)` only."
+                )
 
         if mode == MODE_FUN:
             if 1 in sensi_orders:
-                if result.sllh is None and np.isnan(result.llh):
-                    snllh = np.full(len(x_ids), np.nan)
-                else:
-                    try:
-                        # llh-gradient (dict) -> nllh-gradient (array over the
-                        #  free parameters)
-                        snllh = -np.array(
-                            [result.sllh[x_id] for x_id in free_ids]
-                        )
-                    except KeyError as e:
-                        raise ValueError(
-                            "Cannot compute gradient, missing entry for "
-                            f"{set(free_ids) - set(result.sllh)}."
-                        ) from e
+                if missing := {x_ids[ix] for ix in opt_ix_sel} - set(
+                    result.sllh or {}
+                ):
+                    raise ValueError(
+                        f"Cannot compute gradient, missing entry for {missing}."
+                    )
+                # llh to nllh, dict to array
+                snllh[opt_ix_sel] = [
+                    -result.sllh[x_ids[ix]] for ix in opt_ix_sel
+                ]
             if 2 in sensi_orders:
-                if result.s2llh is None and np.isnan(result.llh):
-                    s2nllh = np.full((len(x_ids), len(x_ids)), np.nan)
-                else:
-                    # result.s2llh is the FIM (~Hessian of the negative
-                    #  log-likelihood, so no sign flip), ordered by the
-                    #  estimated PEtab parameters; select the free block
-                    sel = _free_block_indices()
-                    s2nllh = result.s2llh[np.ix_(sel, sel)]
+                if result.s2llh is None:
+                    raise ValueError("The Hessian (FIM) was not computed.")
+                # `result.s2llh` is the FIM, i.e. an approximation of the
+                #  Hessian of the *negative* log-likelihood -- no sign flip
+                s2nllh[np.ix_(opt_ix_sel, opt_ix_sel)] = result.s2llh[
+                    np.ix_(sim_ix_sel, sim_ix_sel)
+                ]
         elif mode == MODE_RES:
             if 1 in sensi_orders and not self._known_least_squares_safe:
-                # least-squares residuals only match the likelihood for
+                # the least-squares residuals only match the likelihood for
                 #  parameter-independent sigma, unless sigma residuals are
                 #  added to the model
-                if (
-                    not self.petab_simulator._model.get_add_sigma_residuals()
-                    and any(
+                if not amici_model.get_add_sigma_residuals() and any(
+                    (
                         (r["ssigmay"] is not None and np.any(r["ssigmay"]))
                         or (r["ssigmaz"] is not None and np.any(r["ssigmaz"]))
-                        for r in rdatas
                     )
+                    for r in rdatas
                 ):
                     raise RuntimeError(
                         "Cannot use the least-squares solver with parameter-"
                         "dependent sigma. Enable sigma residuals on the model "
                         "via `set_add_sigma_residuals(True)`."
                     )
-                self._known_least_squares_safe = True
+                self._known_least_squares_safe = True  # don't check this again
             if 0 in sensi_orders:
-                res = result.res
+                if (res := result.res) is None:
+                    raise ValueError("The residuals were not computed.")
             if 1 in sensi_orders:
                 if result.sres is None:
                     raise ValueError(
-                        "Residual sensitivities (sres) were not computed."
+                        "The residual sensitivities were not computed."
                     )
-                # result.sres has one column per estimated PEtab parameter;
-                #  select the free-parameter columns
-                sres = result.sres[:, _free_block_indices()]
+                sres = np.zeros((result.sres.shape[0], dim))
+                sres[:, opt_ix_sel] = result.sres[:, sim_ix_sel]
 
         ret = {
             FVAL: nllh,

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -159,11 +159,14 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
 
     def __init__(
         self,
-        petab_simulator: amici.petab.petab_importer.PetabSimulator,
+        petab_simulator: amici.sim.sundials.petab.PetabSimulator,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.petab_simulator = petab_simulator
+        # fixed-parameter values (set by update_from_problem); merged into the
+        #  simulation so the simulator doesn't fall back to PEtab nominal values
+        self.fixed_parameters: dict[str, float] = {}
 
     def __call__(
         self,
@@ -208,31 +211,27 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
         """
         amici_solver = self.petab_simulator._solver
 
-        if mode != MODE_FUN:
-            raise NotImplementedError(
-                "Only function value mode is currently supported for "
-                f"PEtab v2. Got mode {mode}."
-            )
+        # request the full return data (llh, sllh, FIM, residuals, sres); this
+        #  is the simulator default, set explicitly to be robust to prior state
+        amici_solver.set_return_data_reporting_mode(asd.RDataReporting.full)
 
-        # TODO: -> method
-        # set order in solver
-        sensi_order = 0
-        if sensi_orders:
-            sensi_order = max(sensi_orders)
-
+        # set the sensitivity order in the solver
+        sensi_order = max(sensi_orders) if sensi_orders else 0
         if sensi_order == 2 and fim_for_hess:
-            # we use the FIM
+            # use the FIM instead of the Hessian
             amici_solver.set_sensitivity_order(sensi_order - 1)
         else:
             amici_solver.set_sensitivity_order(sensi_order)
 
         dim = len(x_ids)
 
-        # run amici simulation
-        result = self.petab_simulator.simulate(x_dct)
+        # add back fixed-parameter values (stripped from x_dct by the objective)
+        #  so the simulator doesn't fall back to the PEtab nominal values
+        problem_parameters = {**self.fixed_parameters, **x_dct}
+        result = self.petab_simulator.simulate(problem_parameters)
         rdatas = result.rdatas
 
-        # check if the simulation failed
+        # check whether the simulation failed
         if any(rdata["status"] < 0.0 for rdata in rdatas):
             return get_error_output(
                 amici_model, edatas, rdatas, sensi_orders, mode, dim
@@ -243,61 +242,76 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
         )
         nllh = -result.llh
 
-        if (
-            not self._known_least_squares_safe
-            and mode == MODE_RES
-            and 1 in sensi_orders
-        ):
-            if not amici_model.get_add_sigma_residuals() and any(
-                (
-                    (r["ssigmay"] is not None and np.any(r["ssigmay"]))
-                    or (r["ssigmaz"] is not None and np.any(r["ssigmaz"]))
-                )
-                for r in rdatas
-            ):
-                raise RuntimeError(
-                    "Cannot use least squares solver with"
-                    "parameter dependent sigma! Support can be "
-                    "enabled via "
-                    "amici_model.setAddSigmaResiduals()."
-                )
-            self._known_least_squares_safe = True  # don't check this again
+        # column indices of the free optimization parameters within the
+        #  estimated-parameter ordering used by result.sllh/s2llh/sres
+        estimated_ids = list(self.petab_simulator._petab_problem.x_free_ids)
+        free_ids = [x_id for x_id in x_ids if x_id in x_dct]
 
-        # TODO: compute res, sres
+        def _free_block_indices() -> list[int]:
+            try:
+                return [estimated_ids.index(x_id) for x_id in free_ids]
+            except ValueError as e:
+                raise ValueError(
+                    "Missing sensitivities for free parameters "
+                    f"{set(free_ids) - set(estimated_ids)}. A free parameter "
+                    "is likely constant in the AMICI model "
+                    "(non_estimated_parameters_as_constants=True)."
+                ) from e
 
-        if 1 in sensi_orders:
-            if result.sllh is None and np.isnan(result["llh"]):
-                # TODO: to amici -- set sllh even if llh is nan?
-                snllh = np.full(len(x_ids), np.nan)
-            else:
-                try:
-                    # llh to nllh, dict to array
-                    snllh = -np.array(
-                        [
-                            result.sllh[
-                                x_id
-                            ]  # if x_id in res["sllh"] else 0.0
-                            for x_id in x_ids
-                            if x_id in x_dct.keys()
-                        ]
+        if mode == MODE_FUN:
+            if 1 in sensi_orders:
+                if result.sllh is None and np.isnan(result.llh):
+                    snllh = np.full(len(x_ids), np.nan)
+                else:
+                    try:
+                        # llh-gradient (dict) -> nllh-gradient (array over the
+                        #  free parameters)
+                        snllh = -np.array(
+                            [result.sllh[x_id] for x_id in free_ids]
+                        )
+                    except KeyError as e:
+                        raise ValueError(
+                            "Cannot compute gradient, missing entry for "
+                            f"{set(free_ids) - set(result.sllh)}."
+                        ) from e
+            if 2 in sensi_orders:
+                if result.s2llh is None and np.isnan(result.llh):
+                    s2nllh = np.full((len(x_ids), len(x_ids)), np.nan)
+                else:
+                    # result.s2llh is the FIM (~Hessian of the negative
+                    #  log-likelihood, so no sign flip), ordered by the
+                    #  estimated PEtab parameters; select the free block
+                    sel = _free_block_indices()
+                    s2nllh = result.s2llh[np.ix_(sel, sel)]
+        elif mode == MODE_RES:
+            if 1 in sensi_orders and not self._known_least_squares_safe:
+                # least-squares residuals only match the likelihood for
+                #  parameter-independent sigma, unless sigma residuals are
+                #  added to the model
+                if (
+                    not self.petab_simulator._model.get_add_sigma_residuals()
+                    and any(
+                        (r["ssigmay"] is not None and np.any(r["ssigmay"]))
+                        or (r["ssigmaz"] is not None and np.any(r["ssigmaz"]))
+                        for r in rdatas
                     )
-                except KeyError as e:
-                    # A requested sensitivity is missing.
-                    # Probably the affected parameter is a fixed parameter
-                    # in amici instead of a sensitivity parameter
-                    # (non_estimated_parameters_as_constants=True ?).
-                    # In this case, only max(sensi_orders) == 0 is supported
-                    # unless this parameter is fixed in the pypesto problem.
+                ):
+                    raise RuntimeError(
+                        "Cannot use the least-squares solver with parameter-"
+                        "dependent sigma. Enable sigma residuals on the model "
+                        "via `set_add_sigma_residuals(True)`."
+                    )
+                self._known_least_squares_safe = True
+            if 0 in sensi_orders:
+                res = result.res
+            if 1 in sensi_orders:
+                if result.sres is None:
                     raise ValueError(
-                        f"Cannot compute gradient, missing entry for "
-                        f"{set(result.sllh) - set(x_dct.keys())}."
-                    ) from e
-        if 2 in sensi_orders:
-            if result.s2llh is None and np.isnan(result.llh):
-                # TODO: to amici -- set s2llh even if llh is nan?
-                s2nllh = np.full((len(x_ids), len(x_ids)), np.nan)
-            else:
-                s2nllh = -result.s2llh
+                        "Residual sensitivities (sres) were not computed."
+                    )
+                # result.sres has one column per estimated PEtab parameter;
+                #  select the free-parameter columns
+                sres = result.sres[:, _free_block_indices()]
 
         ret = {
             FVAL: nllh,

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -20,6 +20,8 @@ try:
 except ImportError:
     roadrunner = None
 
+from petab import v2
+
 from ..C import (
     AMICI,
     CENSORED,
@@ -39,6 +41,7 @@ from ..result import PredictionResult
 from ..startpoint import StartpointMethod
 from .objective_creator import (
     AmiciObjectiveCreator,
+    AmiciPetabV2ObjectiveCreator,
     ObjectiveCreator,
     PetabSimulatorObjectiveCreator,
     RoadRunnerObjectiveCreator,
@@ -69,7 +72,7 @@ class PetabImporter:
 
     def __init__(
         self,
-        petab_problem: petab.Problem,
+        petab_problem: petab.Problem | v2.Problem,
         output_folder: str | None = None,
         model_name: str | None = None,
         validate_petab: bool = True,
@@ -116,6 +119,12 @@ class PetabImporter:
         self.petab_problem = petab_problem
         self._hierarchical = hierarchical
 
+        if self._hierarchical and isinstance(self.petab_problem, v2.Problem):
+            raise NotImplementedError(
+                "Hierarchical optimization is not yet supported "
+                "for PEtab v2 problems."
+            )
+
         self._non_quantitative_data_types = (
             get_petab_non_quantitative_data_types(petab_problem)
         )
@@ -148,8 +157,19 @@ class PetabImporter:
 
         self.validate_petab = validate_petab
         if self.validate_petab:
-            if petab.lint_problem(petab_problem):
+            if isinstance(petab_problem, petab.Problem) and petab.lint_problem(
+                petab_problem
+            ):
                 raise ValueError("Invalid PEtab problem.")
+            if (
+                isinstance(petab_problem, v2.Problem)
+                and (
+                    validation_result := petab_problem.validate()
+                ).has_errors()
+            ):
+                validation_result.log(logger=logger)
+                raise ValueError("Invalid PEtab v2 problem.")
+
         if self._hierarchical and validate_petab_hierarchical:
             from ..hierarchical.petab import (
                 validate_hierarchical_petab_problem,
@@ -185,7 +205,15 @@ class PetabImporter:
         simulator_type: str = AMICI,
     ) -> PetabImporter:
         """Simplified constructor using a petab yaml file."""
-        petab_problem = petab.Problem.from_yaml(yaml_config)
+        from petab.versions import get_major_version
+
+        match get_major_version(yaml_config):
+            case 1:
+                petab_problem = petab.Problem.from_yaml(yaml_config)
+            case 2:
+                petab_problem = v2.Problem.from_yaml(yaml_config)
+            case _:
+                raise ValueError("Only PEtab v1 and v2 are supported.")
 
         return PetabImporter(
             petab_problem=petab_problem,
@@ -277,6 +305,42 @@ class PetabImporter:
         else:
             return None
 
+    def _create_prior_v2(self) -> NegLogParameterPriors | None:
+        """Create prior for PEtab v2 problem."""
+        import petab.v2.C as petab_c
+
+        import pypesto.C as pypesto_c
+
+        petab_to_pypesto = {
+            petab_c.LAPLACE: pypesto_c.LAPLACE,
+            petab_c.LOG_LAPLACE: pypesto_c.LOG_LAPLACE,
+            petab_c.LOG_NORMAL: pypesto_c.LOG_NORMAL,
+            petab_c.LOG_UNIFORM: pypesto_c.LOG_UNIFORM,
+            petab_c.NORMAL: pypesto_c.NORMAL,
+            petab_c.UNIFORM: pypesto_c.UNIFORM,
+        }
+
+        prior_list = []
+        for parameter in self.petab_problem.parameters:
+            if not parameter.estimate or parameter.prior_distribution is None:
+                continue
+
+            prior_list.append(
+                get_parameter_prior_dict(
+                    index=len(prior_list),
+                    # TODO map names
+                    prior_type=petab_to_pypesto.get(
+                        str(parameter.prior_distribution),
+                        str(parameter.prior_distribution),
+                    ),
+                    prior_parameters=parameter.prior_parameters,
+                    parameter_scale="lin",
+                )
+            )
+        if prior_list:
+            return NegLogParameterPriors(prior_list)
+        return None
+
     def create_startpoint_method(self, **kwargs) -> StartpointMethod:
         """Create a startpoint method.
 
@@ -306,6 +370,22 @@ class PetabImporter:
             has to be provided. Otherwise the argument is not used.
 
         """
+        if isinstance(self.petab_problem, v2.Problem):
+            if simulator_type != AMICI:
+                raise ValueError(
+                    "Only 'amici' simulator type is supported for PEtab v2 "
+                    "problems."
+                )
+            return AmiciPetabV2ObjectiveCreator(
+                petab_problem=self.petab_problem,
+                output_folder=self.output_folder,
+                model_name=self.model_name,
+                hierarchical=self._hierarchical,
+                inner_options=self.inner_options,
+                non_quantitative_data_types=self._non_quantitative_data_types,
+                validate_petab=self.validate_petab,
+            )
+
         if simulator_type == AMICI:
             return AmiciObjectiveCreator(
                 petab_problem=self.petab_problem,
@@ -364,10 +444,19 @@ class PetabImporter:
             objective = self.objective_constructor.create_objective(**kwargs)
 
         x_fixed_indices = self.petab_problem.x_fixed_indices
-        x_fixed_vals = self.petab_problem.x_nominal_fixed_scaled
         x_ids = self.petab_problem.x_ids
-        lb = self.petab_problem.lb_scaled
-        ub = self.petab_problem.ub_scaled
+
+        if isinstance(self.petab_problem, petab.Problem):
+            # PEtab v1
+            x_fixed_vals = self.petab_problem.x_nominal_fixed_scaled
+            lb = self.petab_problem.lb_scaled
+            ub = self.petab_problem.ub_scaled
+            prior = self.create_prior()
+        else:
+            x_fixed_vals = self.petab_problem.x_nominal_fixed
+            lb = self.petab_problem.lb
+            ub = self.petab_problem.ub
+            prior = self._create_prior_v2()
 
         # Raise error if the correct calculator is not used.
         if self._hierarchical:
@@ -395,18 +484,24 @@ class PetabImporter:
                 map(x_ids.index, self.petab_problem.x_fixed_ids)
             )
 
-        x_scales = [
-            self.petab_problem.parameter_df.loc[x_id, petab.PARAMETER_SCALE]
-            for x_id in x_ids
-        ]
+        # parameter scales -- only for outer parameters
+        if isinstance(self.petab_problem, petab.Problem):
+            # PEtab v1
+            x_scales = [
+                self.petab_problem.parameter_df.loc[
+                    x_id, petab.PARAMETER_SCALE
+                ]
+                for x_id in x_ids
+            ]
+        else:
+            # PEtab v2 -- no parameter scaling
+            x_scales = [petab.LIN for x_id in x_ids]
 
         if problem_kwargs is None:
             problem_kwargs = {}
 
         if startpoint_kwargs is None:
             startpoint_kwargs = {}
-
-        prior = self.create_prior()
 
         if prior is not None:
             if self._hierarchical:

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -317,7 +317,6 @@ class PetabImporter:
             petab_c.LOG_NORMAL: pypesto_c.LOG_NORMAL,
             petab_c.LOG_UNIFORM: pypesto_c.LOG_UNIFORM,
             petab_c.NORMAL: pypesto_c.NORMAL,
-            petab_c.UNIFORM: pypesto_c.UNIFORM,
         }
 
         # the prior index refers to the position of the parameter in the full
@@ -329,6 +328,16 @@ class PetabImporter:
         prior_list = []
         for parameter in self.petab_problem.parameters:
             if not parameter.estimate or parameter.prior_distribution is None:
+                continue
+
+            if str(parameter.prior_distribution) == petab_c.UNIFORM:
+                # A uniform prior only adds a constant to the objective inside
+                #  the parameter bounds, which are enforced by the pyPESTO
+                #  problem anyway. Skipping it keeps the objective comparable
+                #  to the PEtab v1 path, which skips `parameterScaleUniform`
+                #  for the same reason. Upgraded v1 problems can carry such
+                #  priors for every parameter, which would otherwise offset
+                #  the objective by `sum(log(ub - lb))`.
                 continue
 
             prior_list.append(

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -317,6 +317,7 @@ class PetabImporter:
             petab_c.LOG_NORMAL: pypesto_c.LOG_NORMAL,
             petab_c.LOG_UNIFORM: pypesto_c.LOG_UNIFORM,
             petab_c.NORMAL: pypesto_c.NORMAL,
+            petab_c.UNIFORM: pypesto_c.UNIFORM,
         }
 
         # the prior index refers to the position of the parameter in the full
@@ -328,16 +329,6 @@ class PetabImporter:
         prior_list = []
         for parameter in self.petab_problem.parameters:
             if not parameter.estimate or parameter.prior_distribution is None:
-                continue
-
-            if str(parameter.prior_distribution) == petab_c.UNIFORM:
-                # A uniform prior only adds a constant to the objective inside
-                #  the parameter bounds, which are enforced by the pyPESTO
-                #  problem anyway. Skipping it keeps the objective comparable
-                #  to the PEtab v1 path, which skips `parameterScaleUniform`
-                #  for the same reason. Upgraded v1 problems can carry such
-                #  priors for every parameter, which would otherwise offset
-                #  the objective by `sum(log(ub - lb))`.
                 continue
 
             prior_list.append(

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -320,6 +320,12 @@ class PetabImporter:
             petab_c.UNIFORM: pypesto_c.UNIFORM,
         }
 
+        # the prior index refers to the position of the parameter in the full
+        #  parameter vector (see get_parameter_prior_dict)
+        id_to_index = {
+            x_id: index for index, x_id in enumerate(self.petab_problem.x_ids)
+        }
+
         prior_list = []
         for parameter in self.petab_problem.parameters:
             if not parameter.estimate or parameter.prior_distribution is None:
@@ -327,13 +333,13 @@ class PetabImporter:
 
             prior_list.append(
                 get_parameter_prior_dict(
-                    index=len(prior_list),
-                    # TODO map names
+                    index=id_to_index[parameter.id],
                     prior_type=petab_to_pypesto.get(
                         str(parameter.prior_distribution),
                         str(parameter.prior_distribution),
                     ),
                     prior_parameters=parameter.prior_parameters,
+                    # PEtab v2 does not support parameter scales
                     parameter_scale="lin",
                 )
             )

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -18,6 +18,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import petab.v1 as petab
+from petab import v2
 from petab.v1.C import (
     OBSERVABLE_FORMULA,
     PREEQUILIBRATION_CONDITION_ID,
@@ -589,6 +590,453 @@ class AmiciObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
             model = predictor.amici_objective.amici_model
 
         return self.rdatas_to_measurement_df(rdatas, model)
+
+    def prediction_to_petab_simulation_df(
+        self,
+        prediction: PredictionResult,
+        predictor: AmiciPredictor = None,
+    ) -> pd.DataFrame:
+        """
+        See :meth:`prediction_to_petab_measurement_df`.
+
+        Except a PEtab simulation dataframe is created, i.e. the measurement
+        column label is adjusted.
+        """
+        return self.prediction_to_petab_measurement_df(
+            prediction, predictor
+        ).rename(columns={petab.MEASUREMENT: petab.SIMULATION})
+
+
+class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
+    """ObjectiveCreator for creating an amici objective function."""
+
+    def __init__(
+        self,
+        petab_problem: v2.Problem,
+        hierarchical: bool = False,
+        non_quantitative_data_types: Iterable[str] | None = None,
+        inner_options: dict[str, Any] | None = None,
+        output_folder: str | None = None,
+        model_name: str | None = None,
+        validate_petab: bool = True,
+    ):
+        """
+        Initialize the creator.
+
+        Parameters
+        ----------
+        petab_problem:
+            The PEtab problem.
+        hierarchical:
+            Whether to use hierarchical optimization.
+        non_quantitative_data_types:
+            The non-quantitative data types to consider.
+        inner_options:
+            Options for the inner optimization.
+        output_folder:
+            The output folder for the compiled model.
+        model_name:
+            The name of the AMICI model module.
+        validate_petab:
+            Whether to check the PEtab problem for errors.
+        """
+        if hierarchical or non_quantitative_data_types or inner_options:
+            raise NotImplementedError()
+
+        self.petab_problem = petab_problem
+        self._hierarchical = hierarchical
+        self._non_quantitative_data_types = non_quantitative_data_types
+        self.inner_options = inner_options
+        self.output_folder = output_folder
+        self.model_name = model_name
+        self.validate_petab = validate_petab
+
+    def create_model(
+        self,
+        force_compile: bool = False,
+        verbose: bool = True,
+        **kwargs,
+    ) -> amici.Model:
+        """
+        Import amici model.
+
+        Parameters
+        ----------
+        force_compile:
+            If False, the model is compiled only if the output folder does not
+            exist yet. If True, the output folder is deleted and the model
+            (re-)compiled in either case.
+
+            .. warning::
+                If `force_compile`, then an existing folder of that name will
+                be deleted.
+        verbose:
+            Passed to AMICI's model compilation. If True, the compilation
+            progress is printed.
+        kwargs:
+            Extra arguments passed to amici.SbmlImporter.sbml2amici
+        """
+        # courtesy check whether target is folder
+        if os.path.exists(self.output_folder) and not os.path.isdir(
+            self.output_folder
+        ):
+            raise AssertionError(
+                f"Refusing to remove {self.output_folder} for model "
+                f"compilation: Not a folder."
+            )
+
+        # compile
+        if self._must_compile(force_compile):
+            logger.info(
+                f"Compiling amici model to folder {self.output_folder}."
+            )
+            if self.petab_problem.model.type_id == MODEL_TYPE_SBML:
+                self.compile_model(
+                    validate=self.validate_petab,
+                    verbose=verbose,
+                    **kwargs,
+                )
+            else:
+                self.compile_model(verbose=verbose, **kwargs)
+        else:
+            logger.debug(
+                f"Using existing amici model in folder {self.output_folder}."
+            )
+
+        return self._create_model()
+
+    def _create_model(self) -> amici.Model:
+        """Load model module and return the model, no checks/compilation."""
+        # load moduĺe
+        module = amici.import_model_module(
+            module_name=self.model_name, module_path=self.output_folder
+        )
+        model = module.get_model()
+
+        from amici.importers.petab.v1._import_helpers import check_model
+
+        check_model(
+            amici_model=model,
+            petab_problem=self.petab_problem,
+        )
+
+        return model
+
+    def _must_compile(self, force_compile: bool):
+        """Check whether the model needs to be compiled first."""
+        # asked by user
+        if force_compile:
+            return True
+
+        # folder does not exist
+        if not os.path.exists(self.output_folder) or not os.listdir(
+            self.output_folder
+        ):
+            return True
+
+        # try to import (in particular checks version)
+        try:
+            # importing will already raise an exception if version wrong
+            amici.import_model_module(self.model_name, self.output_folder)
+        except ModuleNotFoundError:
+            return True
+        except amici.AmiciVersionError as e:
+            logger.info(
+                f"amici model will be re-imported due to version mismatch: {e}"
+            )
+            return True
+
+        # no need to (re-)compile
+        return False
+
+    def compile_model(self, **kwargs):
+        """
+        Compile the model.
+
+        If the output folder exists already, it is first deleted.
+
+        Parameters
+        ----------
+        kwargs:
+            Extra arguments passed to :meth:`amici.sbml_import.SbmlImporter.sbml2amici`
+            or :func:`amici.pysb_import.pysb2amici`.
+        """
+        # delete output directory
+        if os.path.exists(self.output_folder):
+            shutil.rmtree(self.output_folder)
+
+        petab_importer = self._create_amici_importer()
+        petab_importer.import_module(force_import=True)
+
+    def _create_amici_importer(
+        self,
+    ) -> amici.petab.petab_importer.PetabImporter:
+        """Create an AMICI PEtab importer."""
+        from amici.importers.petab import PetabImporter
+
+        petab_importer = PetabImporter(
+            self.petab_problem,
+            output_dir=self.output_folder,
+            module_name=self.model_name,
+        )
+        return petab_importer
+
+    def create_solver(
+        self,
+        model: amici.Model = None,
+        verbose: bool = True,
+    ) -> amici.Solver:
+        """Return model solver."""
+        # create model
+        if model is None:
+            model = self.create_model(verbose=verbose)
+
+        solver = model.create_solver()
+        return solver
+
+    def create_edatas(
+        self,
+        model: amici.Model = None,
+        simulation_conditions=None,
+        verbose: bool = True,
+    ) -> list[amici.ExpData]:
+        """Create list of :class:`amici.amici.ExpData` objects."""
+        # create model
+        # if model is None:
+        #     model = self.create_model(verbose=verbose)
+        #
+        # return amici.petab.conditions.create_edatas(
+        #     amici_model=model,
+        #     petab_problem=self.petab_problem,
+        #     simulation_conditions=simulation_conditions,
+        # )
+        raise NotImplementedError()
+
+    def create_objective(
+        self,
+        model: amici.Model = None,
+        solver: amici.Solver = None,
+        edatas: Sequence[amici.ExpData] = None,
+        force_compile: bool = False,
+        verbose: bool = True,
+        **kwargs,
+    ) -> AmiciObjective:
+        """Create a :class:`pypesto.objective.AmiciObjective`.
+
+        Parameters
+        ----------
+        model:
+            The AMICI model.
+        solver:
+            The AMICI solver.
+        edatas:
+            The experimental data in AMICI format.
+        force_compile:
+            Whether to force-compile the model if not passed.
+        verbose:
+            Passed to AMICI's model compilation. If True, the compilation
+            progress is printed.
+        **kwargs:
+            Additional arguments passed on to the objective. In case of ordinal
+            or semiquantitative measurements, ``inner_options`` can optionally
+            be passed here. If none are given, ``inner_options`` given to the
+            importer constructor (or inner defaults) will be chosen.
+
+        Returns
+        -------
+        A :class:`pypesto.objective.AmiciObjective` for the model and the data.
+        """
+        from ..objective.amici.amici import AmiciPetabV2Objective
+
+        petab_importer = self._create_amici_importer()
+
+        return AmiciPetabV2Objective(
+            petab_importer=petab_importer,
+            amici_object_builder=self,
+            x_ids=self.petab_problem.x_ids,
+        )
+
+        # TODO
+
+        simulation_conditions = petab.get_simulation_conditions(
+            self.petab_problem.measurement_df
+        )
+        if model is None:
+            model = self.create_model(
+                force_compile=force_compile, verbose=verbose
+            )
+        if solver is None:
+            solver = self.create_solver(model)
+        # create conditions and edatas from measurement data
+        if edatas is None:
+            edatas = self.create_edatas(
+                model=model, simulation_conditions=simulation_conditions
+            )
+        parameter_mapping = (
+            amici.petab.parameter_mapping.create_parameter_mapping(
+                petab_problem=self.petab_problem,
+                simulation_conditions=simulation_conditions,
+                scaled_parameters=True,
+                amici_model=model,
+                fill_fixed_parameters=False,
+            )
+        )
+        par_ids = self.petab_problem.x_ids
+
+        # fill in dummy parameters (this is needed since some objective
+        #  initialization e.g. checks for preeq parameters)
+        problem_parameters = dict(
+            zip(
+                self.petab_problem.x_ids,
+                self.petab_problem.x_nominal_scaled,
+                strict=True,
+            )
+        )
+        amici.petab.conditions.fill_in_parameters(
+            edatas=edatas,
+            problem_parameters=problem_parameters,
+            scaled_parameters=True,
+            parameter_mapping=parameter_mapping,
+            amici_model=model,
+        )
+
+        calculator = None
+        amici_reporting = None
+
+        if (
+            self._non_quantitative_data_types is not None
+            and self._hierarchical
+        ):
+            inner_options = kwargs.pop("inner_options", None)
+            inner_options = (
+                inner_options
+                if inner_options is not None
+                else self.inner_options
+            )
+            calculator = InnerCalculatorCollector(
+                self._non_quantitative_data_types,
+                self.petab_problem,
+                model,
+                edatas,
+                inner_options,
+            )
+            amici_reporting = amici.RDataReporting.full
+
+            # FIXME: currently not supported with hierarchical
+            if "guess_steadystate" in kwargs and kwargs["guess_steadystate"]:
+                warnings.warn(
+                    "`guess_steadystate` not supported with hierarchical "
+                    "optimization. Disabling `guess_steadystate`.",
+                    stacklevel=1,
+                )
+            kwargs["guess_steadystate"] = False
+            inner_parameter_ids = calculator.get_inner_par_ids()
+            par_ids = [x for x in par_ids if x not in inner_parameter_ids]
+
+        max_sensi_order = kwargs.get("max_sensi_order", None)
+
+        if (
+            self._non_quantitative_data_types is not None
+            and any(
+                data_type in self._non_quantitative_data_types
+                for data_type in [ORDINAL, CENSORED, SEMIQUANTITATIVE]
+            )
+            and max_sensi_order is not None
+            and max_sensi_order > 1
+        ):
+            raise ValueError(
+                "Ordinal, censored and semiquantitative data cannot be "
+                "used with second order sensitivities. Use a up to first order "
+                "method or disable ordinal, censored and semiquantitative "
+            )
+
+        # create objective
+        obj = AmiciObjective(
+            amici_model=model,
+            amici_solver=solver,
+            edatas=edatas,
+            x_ids=par_ids,
+            x_names=par_ids,
+            parameter_mapping=parameter_mapping,
+            amici_object_builder=self,
+            calculator=calculator,
+            amici_reporting=amici_reporting,
+            **kwargs,
+        )
+
+        return obj
+
+    def create_predictor(
+        self,
+        objective: AmiciObjective = None,
+        amici_output_fields: Sequence[str] = None,
+        post_processor: Callable | None = None,
+        post_processor_sensi: Callable | None = None,
+        post_processor_time: Callable | None = None,
+        max_chunk_size: int | None = None,
+        output_ids: Sequence[str] = None,
+        condition_ids: Sequence[str] = None,
+    ) -> AmiciPredictor:
+        """Create a :class:`pypesto.predict.AmiciPredictor`."""
+        raise NotImplementedError()
+
+    def rdatas_to_measurement_df(
+        self,
+        rdatas: Sequence[amici.ReturnData],
+        model: amici.Model = None,
+        verbose: bool = True,
+    ) -> pd.DataFrame:
+        """
+        Create a measurement dataframe in the petab format.
+
+        Parameters
+        ----------
+        rdatas:
+            A list of rdatas as produced by
+            ``pypesto.AmiciObjective.__call__(x, return_dict=True)['rdatas']``.
+        model:
+            The amici model.
+        verbose:
+            Passed to AMICI's model compilation. If True, the compilation
+            progress is printed.
+
+        Returns
+        -------
+        A dataframe built from the rdatas in the format as in
+        ``self.petab_problem.measurement_df``.
+        """
+        # create model
+        if model is None:
+            model = self.create_model(verbose=verbose)
+
+        measurement_df = self.petab_problem.measurement_df
+
+        return amici.petab.simulations.rdatas_to_measurement_df(
+            rdatas, model, measurement_df
+        )
+
+    def rdatas_to_simulation_df(
+        self,
+        rdatas: Sequence[amici.ReturnData],
+        model: amici.Model = None,
+    ) -> pd.DataFrame:
+        """
+        See :meth:`rdatas_to_measurement_df`.
+
+        Except a petab simulation dataframe is created, i.e. the measurement
+        column label is adjusted.
+        """
+        return self.rdatas_to_measurement_df(rdatas, model).rename(
+            columns={petab.MEASUREMENT: petab.SIMULATION}
+        )
+
+    def prediction_to_petab_measurement_df(
+        self,
+        prediction: PredictionResult,
+        predictor: AmiciPredictor = None,
+    ) -> pd.DataFrame:
+        """Not implemented yet."""
+        raise NotImplementedError()
 
     def prediction_to_petab_simulation_df(
         self,

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -809,7 +809,10 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
 
         return ExperimentManager(
             model=model,
-            petab_problem=self.petab_problem,
+            # the AMICI importer preprocesses the PEtab problem (e.g., the
+            #  experiment table is converted to the model), and only that
+            #  version matches the compiled model
+            petab_problem=self._create_amici_importer().petab_problem,
         ).create_edatas()
 
     def create_objective(
@@ -845,8 +848,14 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         """
         from ..objective.amici.amici import AmiciPetabV2Objective
 
-        # the objective builds its own simulator from the importer;
-        #  model/solver/edatas are ignored (kept for API compatibility)
+        # the objective creates its own simulator from the PEtab importer,
+        #  which in turn owns the model, the solver and the ExpData objects
+        if model is not None or solver is not None or edatas is not None:
+            warnings.warn(
+                "`model`, `solver` and `edatas` are not supported for PEtab "
+                "v2 problems and will be ignored.",
+                stacklevel=2,
+            )
         petab_importer = self._create_amici_importer()
 
         return AmiciPetabV2Objective(

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -654,26 +654,55 @@ class AmiciPetabV2ObjectiveCreator(AmiciObjectiveCreator):
         Parameters
         ----------
         kwargs:
-            Extra arguments passed to :meth:`amici.sbml_import.SbmlImporter.sbml2amici`
-            or :func:`amici.pysb_import.pysb2amici`.
+            Extra arguments passed to
+            :class:`amici.importers.petab.PetabImporter`, e.g. ``verbose`` or
+            ``non_estimated_parameters_as_constants``. Unlike for PEtab v1,
+            arguments for the underlying model importer (e.g.
+            ``generate_sensitivity_code``) are not supported; a warning is
+            issued for any argument that is not accepted.
         """
         # delete output directory
         if os.path.exists(self.output_folder):
             shutil.rmtree(self.output_folder)
 
-        petab_importer = self._create_amici_importer()
+        petab_importer = self._create_amici_importer(**kwargs)
         petab_importer.import_module(force_import=True)
 
     def _create_amici_importer(
-        self,
+        self, **kwargs
     ) -> amici.importers.petab.PetabImporter:
-        """Create an AMICI PEtab importer."""
+        """Create an AMICI PEtab importer.
+
+        Parameters
+        ----------
+        kwargs:
+            Extra arguments passed to
+            :class:`amici.importers.petab.PetabImporter`. Arguments that it
+            does not accept are dropped with a warning.
+        """
+        import inspect
+
         from amici.importers.petab import PetabImporter
+
+        kwargs.setdefault("validate", self.validate_petab)
+        # `PetabImporter` does not forward arguments to the model importer, so
+        #  anything it does not accept cannot be honoured -- say so instead of
+        #  dropping it silently
+        supported = inspect.signature(PetabImporter.__init__).parameters
+        if unsupported := {
+            k: kwargs.pop(k) for k in set(kwargs) - set(supported)
+        }:
+            warnings.warn(
+                f"Ignoring unsupported model import options for the PEtab v2 "
+                f"path: {sorted(unsupported)}.",
+                stacklevel=2,
+            )
 
         petab_importer = PetabImporter(
             self.petab_problem,
             output_dir=self.output_folder,
             module_name=self.model_name,
+            **kwargs,
         )
         return petab_importer
 

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -770,7 +770,7 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
 
     def _create_amici_importer(
         self,
-    ) -> amici.petab.petab_importer.PetabImporter:
+    ) -> amici.importers.petab.PetabImporter:
         """Create an AMICI PEtab importer."""
         from amici.importers.petab import PetabImporter
 
@@ -801,16 +801,16 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         verbose: bool = True,
     ) -> list[amici.ExpData]:
         """Create list of :class:`amici.amici.ExpData` objects."""
+        from amici.sim.sundials.petab import ExperimentManager
+
         # create model
-        # if model is None:
-        #     model = self.create_model(verbose=verbose)
-        #
-        # return amici.petab.conditions.create_edatas(
-        #     amici_model=model,
-        #     petab_problem=self.petab_problem,
-        #     simulation_conditions=simulation_conditions,
-        # )
-        raise NotImplementedError()
+        if model is None:
+            model = self.create_model(verbose=verbose)
+
+        return ExperimentManager(
+            model=model,
+            petab_problem=self.petab_problem,
+        ).create_edatas()
 
     def create_objective(
         self,
@@ -837,10 +837,7 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
             Passed to AMICI's model compilation. If True, the compilation
             progress is printed.
         **kwargs:
-            Additional arguments passed on to the objective. In case of ordinal
-            or semiquantitative measurements, ``inner_options`` can optionally
-            be passed here. If none are given, ``inner_options`` given to the
-            importer constructor (or inner defaults) will be chosen.
+            Additional arguments passed on to the objective.
 
         Returns
         -------
@@ -848,123 +845,17 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         """
         from ..objective.amici.amici import AmiciPetabV2Objective
 
+        # the objective builds its own simulator from the importer;
+        #  model/solver/edatas are ignored (kept for API compatibility)
         petab_importer = self._create_amici_importer()
 
         return AmiciPetabV2Objective(
             petab_importer=petab_importer,
             amici_object_builder=self,
             x_ids=self.petab_problem.x_ids,
-        )
-
-        # TODO
-
-        simulation_conditions = petab.get_simulation_conditions(
-            self.petab_problem.measurement_df
-        )
-        if model is None:
-            model = self.create_model(
-                force_compile=force_compile, verbose=verbose
-            )
-        if solver is None:
-            solver = self.create_solver(model)
-        # create conditions and edatas from measurement data
-        if edatas is None:
-            edatas = self.create_edatas(
-                model=model, simulation_conditions=simulation_conditions
-            )
-        parameter_mapping = (
-            amici.petab.parameter_mapping.create_parameter_mapping(
-                petab_problem=self.petab_problem,
-                simulation_conditions=simulation_conditions,
-                scaled_parameters=True,
-                amici_model=model,
-                fill_fixed_parameters=False,
-            )
-        )
-        par_ids = self.petab_problem.x_ids
-
-        # fill in dummy parameters (this is needed since some objective
-        #  initialization e.g. checks for preeq parameters)
-        problem_parameters = dict(
-            zip(
-                self.petab_problem.x_ids,
-                self.petab_problem.x_nominal_scaled,
-                strict=True,
-            )
-        )
-        amici.petab.conditions.fill_in_parameters(
-            edatas=edatas,
-            problem_parameters=problem_parameters,
-            scaled_parameters=True,
-            parameter_mapping=parameter_mapping,
-            amici_model=model,
-        )
-
-        calculator = None
-        amici_reporting = None
-
-        if (
-            self._non_quantitative_data_types is not None
-            and self._hierarchical
-        ):
-            inner_options = kwargs.pop("inner_options", None)
-            inner_options = (
-                inner_options
-                if inner_options is not None
-                else self.inner_options
-            )
-            calculator = InnerCalculatorCollector(
-                self._non_quantitative_data_types,
-                self.petab_problem,
-                model,
-                edatas,
-                inner_options,
-            )
-            amici_reporting = amici.RDataReporting.full
-
-            # FIXME: currently not supported with hierarchical
-            if "guess_steadystate" in kwargs and kwargs["guess_steadystate"]:
-                warnings.warn(
-                    "`guess_steadystate` not supported with hierarchical "
-                    "optimization. Disabling `guess_steadystate`.",
-                    stacklevel=1,
-                )
-            kwargs["guess_steadystate"] = False
-            inner_parameter_ids = calculator.get_inner_par_ids()
-            par_ids = [x for x in par_ids if x not in inner_parameter_ids]
-
-        max_sensi_order = kwargs.get("max_sensi_order", None)
-
-        if (
-            self._non_quantitative_data_types is not None
-            and any(
-                data_type in self._non_quantitative_data_types
-                for data_type in [ORDINAL, CENSORED, SEMIQUANTITATIVE]
-            )
-            and max_sensi_order is not None
-            and max_sensi_order > 1
-        ):
-            raise ValueError(
-                "Ordinal, censored and semiquantitative data cannot be "
-                "used with second order sensitivities. Use a up to first order "
-                "method or disable ordinal, censored and semiquantitative "
-            )
-
-        # create objective
-        obj = AmiciObjective(
-            amici_model=model,
-            amici_solver=solver,
-            edatas=edatas,
-            x_ids=par_ids,
-            x_names=par_ids,
-            parameter_mapping=parameter_mapping,
-            amici_object_builder=self,
-            calculator=calculator,
-            amici_reporting=amici_reporting,
+            force_compile=force_compile,
             **kwargs,
         )
-
-        return obj
 
     def create_predictor(
         self,
@@ -978,7 +869,9 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         condition_ids: Sequence[str] = None,
     ) -> AmiciPredictor:
         """Create a :class:`pypesto.predict.AmiciPredictor`."""
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "Creating a predictor is not yet supported for PEtab v2 problems."
+        )
 
     def rdatas_to_measurement_df(
         self,
@@ -1005,15 +898,13 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         A dataframe built from the rdatas in the format as in
         ``self.petab_problem.measurement_df``.
         """
+        from amici.importers.petab import rdatas_to_measurement_df
+
         # create model
         if model is None:
             model = self.create_model(verbose=verbose)
 
-        measurement_df = self.petab_problem.measurement_df
-
-        return amici.petab.simulations.rdatas_to_measurement_df(
-            rdatas, model, measurement_df
-        )
+        return rdatas_to_measurement_df(rdatas, model, self.petab_problem)
 
     def rdatas_to_simulation_df(
         self,
@@ -1026,9 +917,13 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         Except a petab simulation dataframe is created, i.e. the measurement
         column label is adjusted.
         """
-        return self.rdatas_to_measurement_df(rdatas, model).rename(
-            columns={petab.MEASUREMENT: petab.SIMULATION}
-        )
+        from amici.importers.petab import rdatas_to_simulation_df
+
+        # create model
+        if model is None:
+            model = self.create_model()
+
+        return rdatas_to_simulation_df(rdatas, model, self.petab_problem)
 
     def prediction_to_petab_measurement_df(
         self,
@@ -1036,7 +931,10 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         predictor: AmiciPredictor = None,
     ) -> pd.DataFrame:
         """Not implemented yet."""
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "Converting predictions to PEtab dataframes is not yet supported "
+            "for PEtab v2 problems."
+        )
 
     def prediction_to_petab_simulation_df(
         self,

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -607,8 +607,15 @@ class AmiciObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         ).rename(columns={petab.MEASUREMENT: petab.SIMULATION})
 
 
-class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
-    """ObjectiveCreator for creating an amici objective function."""
+class AmiciPetabV2ObjectiveCreator(AmiciObjectiveCreator):
+    """ObjectiveCreator for creating an amici objective from a PEtab v2 problem.
+
+    Model import and compilation are the same as for PEtab v1, except that they
+    go through :class:`amici.importers.petab.PetabImporter`. Everything that
+    depends on the PEtab version -- creating the ``ExpData`` objects, the
+    objective, and the conversion of AMICI results to PEtab dataframes -- is
+    overridden here.
+    """
 
     def __init__(
         self,
@@ -616,138 +623,27 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         hierarchical: bool = False,
         non_quantitative_data_types: Iterable[str] | None = None,
         inner_options: dict[str, Any] | None = None,
-        output_folder: str | None = None,
-        model_name: str | None = None,
-        validate_petab: bool = True,
+        **kwargs,
     ):
         """
         Initialize the creator.
 
-        Parameters
-        ----------
-        petab_problem:
-            The PEtab problem.
-        hierarchical:
-            Whether to use hierarchical optimization.
-        non_quantitative_data_types:
-            The non-quantitative data types to consider.
-        inner_options:
-            Options for the inner optimization.
-        output_folder:
-            The output folder for the compiled model.
-        model_name:
-            The name of the AMICI model module.
-        validate_petab:
-            Whether to check the PEtab problem for errors.
+        See :class:`AmiciObjectiveCreator`. Hierarchical optimization and
+        non-quantitative data types are not supported for PEtab v2 yet.
         """
         if hierarchical or non_quantitative_data_types or inner_options:
-            raise NotImplementedError()
-
-        self.petab_problem = petab_problem
-        self._hierarchical = hierarchical
-        self._non_quantitative_data_types = non_quantitative_data_types
-        self.inner_options = inner_options
-        self.output_folder = output_folder
-        self.model_name = model_name
-        self.validate_petab = validate_petab
-
-    def create_model(
-        self,
-        force_compile: bool = False,
-        verbose: bool = True,
-        **kwargs,
-    ) -> amici.Model:
-        """
-        Import amici model.
-
-        Parameters
-        ----------
-        force_compile:
-            If False, the model is compiled only if the output folder does not
-            exist yet. If True, the output folder is deleted and the model
-            (re-)compiled in either case.
-
-            .. warning::
-                If `force_compile`, then an existing folder of that name will
-                be deleted.
-        verbose:
-            Passed to AMICI's model compilation. If True, the compilation
-            progress is printed.
-        kwargs:
-            Extra arguments passed to amici.SbmlImporter.sbml2amici
-        """
-        # courtesy check whether target is folder
-        if os.path.exists(self.output_folder) and not os.path.isdir(
-            self.output_folder
-        ):
-            raise AssertionError(
-                f"Refusing to remove {self.output_folder} for model "
-                f"compilation: Not a folder."
+            raise NotImplementedError(
+                "Hierarchical optimization and non-quantitative data types "
+                "are not supported for PEtab v2 problems yet."
             )
 
-        # compile
-        if self._must_compile(force_compile):
-            logger.info(
-                f"Compiling amici model to folder {self.output_folder}."
-            )
-            if self.petab_problem.model.type_id == MODEL_TYPE_SBML:
-                self.compile_model(
-                    validate=self.validate_petab,
-                    verbose=verbose,
-                    **kwargs,
-                )
-            else:
-                self.compile_model(verbose=verbose, **kwargs)
-        else:
-            logger.debug(
-                f"Using existing amici model in folder {self.output_folder}."
-            )
-
-        return self._create_model()
-
-    def _create_model(self) -> amici.Model:
-        """Load model module and return the model, no checks/compilation."""
-        # load moduĺe
-        module = amici.import_model_module(
-            module_name=self.model_name, module_path=self.output_folder
+        super().__init__(
+            petab_problem=petab_problem,
+            hierarchical=hierarchical,
+            non_quantitative_data_types=non_quantitative_data_types,
+            inner_options=inner_options,
+            **kwargs,
         )
-        model = module.get_model()
-
-        from amici.importers.petab.v1._import_helpers import check_model
-
-        check_model(
-            amici_model=model,
-            petab_problem=self.petab_problem,
-        )
-
-        return model
-
-    def _must_compile(self, force_compile: bool):
-        """Check whether the model needs to be compiled first."""
-        # asked by user
-        if force_compile:
-            return True
-
-        # folder does not exist
-        if not os.path.exists(self.output_folder) or not os.listdir(
-            self.output_folder
-        ):
-            return True
-
-        # try to import (in particular checks version)
-        try:
-            # importing will already raise an exception if version wrong
-            amici.import_model_module(self.model_name, self.output_folder)
-        except ModuleNotFoundError:
-            return True
-        except amici.AmiciVersionError as e:
-            logger.info(
-                f"amici model will be re-imported due to version mismatch: {e}"
-            )
-            return True
-
-        # no need to (re-)compile
-        return False
 
     def compile_model(self, **kwargs):
         """
@@ -781,25 +677,12 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
         )
         return petab_importer
 
-    def create_solver(
-        self,
-        model: amici.Model = None,
-        verbose: bool = True,
-    ) -> amici.Solver:
-        """Return model solver."""
-        # create model
-        if model is None:
-            model = self.create_model(verbose=verbose)
-
-        solver = model.create_solver()
-        return solver
-
     def create_edatas(
         self,
-        model: amici.Model = None,
+        model: asd.Model = None,
         simulation_conditions=None,
         verbose: bool = True,
-    ) -> list[amici.ExpData]:
+    ) -> list[asd.ExpData]:
         """Create list of :class:`amici.amici.ExpData` objects."""
         from amici.sim.sundials.petab import ExperimentManager
 
@@ -817,9 +700,9 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
 
     def create_objective(
         self,
-        model: amici.Model = None,
-        solver: amici.Solver = None,
-        edatas: Sequence[amici.ExpData] = None,
+        model: asd.Model = None,
+        solver: asd.Solver = None,
+        edatas: Sequence[asd.ExpData] = None,
         force_compile: bool = False,
         verbose: bool = True,
         **kwargs,
@@ -884,8 +767,8 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
 
     def rdatas_to_measurement_df(
         self,
-        rdatas: Sequence[amici.ReturnData],
-        model: amici.Model = None,
+        rdatas: Sequence[asd.ReturnData],
+        model: asd.Model = None,
         verbose: bool = True,
     ) -> pd.DataFrame:
         """
@@ -917,8 +800,8 @@ class AmiciPetabV2ObjectiveCreator(ObjectiveCreator, AmiciObjectBuilder):
 
     def rdatas_to_simulation_df(
         self,
-        rdatas: Sequence[amici.ReturnData],
-        model: amici.Model = None,
+        rdatas: Sequence[asd.ReturnData],
+        model: asd.Model = None,
     ) -> pd.DataFrame:
         """
         See :meth:`rdatas_to_measurement_df`.

--- a/pypesto/petab/util.py
+++ b/pypesto/petab/util.py
@@ -4,10 +4,13 @@ import numpy as np
 
 try:
     import petab.v1 as petab
+    from petab import v2
     from petab.v1.C import (
         ESTIMATE,
+        LIN,
         NOISE_PARAMETERS,
         OBSERVABLE_ID,
+        PARAMETER_SCALE_UNIFORM,
     )
 except ImportError:
     petab = None
@@ -103,9 +106,9 @@ class PetabStartpoints(CheckedStartpoints):
     provided PEtab problem. The PEtab-problem is copied.
     """
 
-    def __init__(self, petab_problem: petab.Problem, **kwargs):
+    def __init__(self, petab_problem: petab.Problem | v2.Problem, **kwargs):
         super().__init__(**kwargs)
-        self._parameter_df = petab_problem.parameter_df.copy()
+        self._petab_problem = petab_problem
         self._priors: list[tuple] | None = None
         self._free_ids: list[str] | None = None
 
@@ -132,16 +135,33 @@ class PetabStartpoints(CheckedStartpoints):
 
         # update priors
         self._free_ids = current_free_ids
-        id_to_prior = dict(
-            zip(
-                self._parameter_df.index[self._parameter_df[ESTIMATE] == 1],
-                petab.parameters.get_priors_from_df(
-                    self._parameter_df, mode=petab.INITIALIZATION
-                ),
-                strict=True,
+        if isinstance(self._petab_problem, petab.Problem):
+            parameter_df = self._petab_problem.parameter_df
+            id_to_prior = dict(
+                zip(
+                    parameter_df.index[parameter_df[ESTIMATE] == 1],
+                    petab.parameters.get_priors_from_df(
+                        parameter_df, mode=petab.INITIALIZATION
+                    ),
+                    strict=True,
+                )
             )
-        )
-
+        else:
+            id_to_prior = {
+                parameter.id: (
+                    # prior_type, prior_pars, par_scale, par_bounds
+                    PARAMETER_SCALE_UNIFORM
+                    if parameter.prior_distribution is None
+                    else parameter.prior_distribution,
+                    (parameter.lb, parameter.ub)
+                    if parameter.prior_distribution is None
+                    else parameter.prior_parameters,
+                    LIN,
+                    (parameter.lb, parameter.ub),
+                )
+                for parameter in self._petab_problem.parameters
+                if parameter.estimate
+            }
         self._priors = list(map(id_to_prior.__getitem__, current_free_ids))
 
     def __call__(

--- a/pypesto/petab/util.py
+++ b/pypesto/petab/util.py
@@ -145,15 +145,12 @@ class PetabStartpoints(CheckedStartpoints):
                 )
             )
         else:
-            # PEtab v2: keep the prior distribution object (None -> uniform
-            #  over the bounds); sampled directly in `sample`, since the v1
-            #  `sample_from_prior` uses different distribution names
+            # PEtab v2: keep the prior distribution object (``None`` -> sample
+            #  uniformly over the current bounds); sampled directly in
+            #  `sample`, since the v1 `sample_from_prior` uses different
+            #  distribution names
             id_to_prior = {
-                parameter.id: (
-                    parameter.prior_dist,
-                    parameter.lb,
-                    parameter.ub,
-                )
+                parameter.id: parameter.prior_dist
                 for parameter in self._petab_problem.parameters
                 if parameter.estimate
             }
@@ -188,12 +185,16 @@ class PetabStartpoints(CheckedStartpoints):
             startpoints = list(map(sampler, self._priors))
         else:
             # PEtab v2 -- sample from the parameter prior distributions,
-            #  falling back to a uniform distribution over the bounds
+            #  falling back to a uniform distribution over the bounds of the
+            #  `pypesto.Problem`, which may be tighter than the PEtab bounds
+            #  (e.g. during profiling)
             startpoints = [
                 prior_dist.sample(n_starts)
                 if prior_dist is not None
-                else np.random.uniform(par_lb, par_ub, n_starts)
-                for prior_dist, par_lb, par_ub in self._priors
+                else np.random.uniform(cur_lb, cur_ub, n_starts)
+                for prior_dist, cur_lb, cur_ub in zip(
+                    self._priors, lb, ub, strict=True
+                )
             ]
 
         return np.array(startpoints).T

--- a/pypesto/petab/util.py
+++ b/pypesto/petab/util.py
@@ -7,10 +7,8 @@ try:
     from petab import v2
     from petab.v1.C import (
         ESTIMATE,
-        LIN,
         NOISE_PARAMETERS,
         OBSERVABLE_ID,
-        PARAMETER_SCALE_UNIFORM,
     )
 except ImportError:
     petab = None
@@ -103,7 +101,7 @@ class PetabStartpoints(CheckedStartpoints):
     """Startpoint method for PEtab problems.
 
     Samples optimization startpoints from the distributions defined in the
-    provided PEtab problem. The PEtab-problem is copied.
+    provided PEtab problem.
     """
 
     def __init__(self, petab_problem: petab.Problem | v2.Problem, **kwargs):
@@ -147,17 +145,14 @@ class PetabStartpoints(CheckedStartpoints):
                 )
             )
         else:
+            # PEtab v2: keep the prior distribution object (None -> uniform
+            #  over the bounds); sampled directly in `sample`, since the v1
+            #  `sample_from_prior` uses different distribution names
             id_to_prior = {
                 parameter.id: (
-                    # prior_type, prior_pars, par_scale, par_bounds
-                    PARAMETER_SCALE_UNIFORM
-                    if parameter.prior_distribution is None
-                    else parameter.prior_distribution,
-                    (parameter.lb, parameter.ub)
-                    if parameter.prior_distribution is None
-                    else parameter.prior_parameters,
-                    LIN,
-                    (parameter.lb, parameter.ub),
+                    parameter.prior_dist,
+                    parameter.lb,
+                    parameter.ub,
                 )
                 for parameter in self._petab_problem.parameters
                 if parameter.estimate
@@ -187,7 +182,18 @@ class PetabStartpoints(CheckedStartpoints):
         Must only be called through `self.__call__` to ensure that the list of priors
         matches the currently free parameters in the :class:`pypesto.Problem`.
         """
-        sampler = partial(petab.sample_from_prior, n_starts=n_starts)
-        startpoints = list(map(sampler, self._priors))
+        if isinstance(self._petab_problem, petab.Problem):
+            # PEtab v1
+            sampler = partial(petab.sample_from_prior, n_starts=n_starts)
+            startpoints = list(map(sampler, self._priors))
+        else:
+            # PEtab v2 -- sample from the parameter prior distributions,
+            #  falling back to a uniform distribution over the bounds
+            startpoints = [
+                prior_dist.sample(n_starts)
+                if prior_dist is not None
+                else np.random.uniform(par_lb, par_ub, n_starts)
+                for prior_dist, par_lb, par_ub in self._priors
+            ]
 
         return np.array(startpoints).T

--- a/test/petab/test_petab_import.py
+++ b/test/petab/test_petab_import.py
@@ -10,7 +10,7 @@ from itertools import chain
 import amici.sim.sundials as asd
 import benchmark_models_petab as models
 import numpy as np
-import petab.v1 as petab
+import petab
 import petabtests
 import pytest
 
@@ -266,6 +266,7 @@ def test_max_sensi_order():
 
 
 def test_petab_pysb_optimization():
+    """Test optimization for a PySB-based PEtab 2.0 problem."""
     test_case = "0001"
     test_case_dir = petabtests.get_case_dir(
         test_case, version="v2.0.0", format_="pysb"
@@ -276,7 +277,7 @@ def test_petab_pysb_optimization():
         test_case, format="pysb", version="v2.0.0"
     )
 
-    petab_problem = petab.Problem.from_yaml(petab_yaml)
+    petab_problem = petab.v2.Problem.from_yaml(petab_yaml)
     importer = PetabImporter(petab_problem)
     problem = importer.create_problem()
 
@@ -296,6 +297,120 @@ def test_petab_pysb_optimization():
 
     # ensure objective after optimization is not worse than for true parameters
     assert np.all(fvals <= -solution[petabtests.LLH])
+
+
+def test_petab_v2_boehm():
+    import copy
+    import pickle
+
+    from pypesto.optimize.optimizer import ScipyOptimizer
+
+    # load test problem
+    problem_id = "Boehm_JProteomeRes2014"
+    petab_problem = petab.v2.Problem.from_yaml(
+        models.get_problem_yaml_path(problem_id)
+    )
+    expected_fval_nominal = 138.22199693517703
+
+    # create model
+    importer = PetabImporter(petab_problem)
+    problem = importer.create_problem()
+    assert problem.x_names == petab_problem.x_ids
+    assert problem.dim == petab_problem.n_estimated == 9
+    assert problem.dim_full == len(petab_problem.parameters) == 11
+    # petab-non-estimated parameters are fixed in the pypesto problem
+    assert problem.x_fixed_indices == [
+        i for i, p in enumerate(petab_problem.parameters) if not p.estimate
+    ]
+    assert isinstance(
+        problem.objective, pypesto.objective.amici.amici.AmiciPetabV2Objective
+    )
+
+    # evaluate objective at nominal parameters
+    fval = problem.objective(np.asarray(petab_problem.x_nominal_free))
+    assert np.isclose(fval, expected_fval_nominal)
+
+    # deepcopy works?
+    problem_deepcopy = copy.deepcopy(problem)
+    fval = problem_deepcopy.objective(np.asarray(petab_problem.x_nominal_free))
+    assert np.isclose(fval, expected_fval_nominal)
+
+    # pickling works?
+    problem_pickled = pickle.loads(pickle.dumps(problem))  # noqa: S301
+    fval = problem_pickled.objective(np.asarray(petab_problem.x_nominal_free))
+    assert np.isclose(fval, expected_fval_nominal)
+
+    # gradient works?
+    fval, grad = problem.objective(
+        np.asarray(petab_problem.x_nominal_free), sensi_orders=(0, 1)
+    )
+    assert np.isclose(fval, expected_fval_nominal)
+    assert len(grad) == petab_problem.n_estimated
+
+    # fixing parameters, ...
+    problem.unfix_parameters(petab_problem.x_fixed_indices)
+    assert problem.dim == len(petab_problem.parameters)
+    with pytest.raises(ValueError, match="Cannot compute gradient"):
+        # cannot compute sensitivities for fixed parameters
+        problem.objective(
+            np.asarray(petab_problem.x_nominal), sensi_orders=(0, 1)
+        )
+    fval = problem.objective(np.asarray(petab_problem.x_nominal))
+    assert np.isclose(fval, expected_fval_nominal)
+    # re-fixing parameters
+    problem.fix_parameters(
+        petab_problem.x_fixed_indices, petab_problem.x_nominal_fixed
+    )
+    assert problem.dim == petab_problem.n_estimated
+    fval, grad = problem.objective(
+        np.asarray(petab_problem.x_nominal_free), sensi_orders=(0, 1)
+    )
+    assert np.isclose(fval, expected_fval_nominal)
+    assert len(grad) == petab_problem.n_estimated
+
+    # TODO mode=res/fun,
+    # TODO hess/fim...
+
+    # single optimization works?
+    optimizer = ScipyOptimizer()
+    result = optimizer.minimize(
+        id="1",
+        problem=problem,
+        x0=np.asarray(petab_problem.x_nominal_free) + 0.1,
+    )
+    print(result)
+    assert result.fval0 is not None, result.message
+    assert result.fval < result.fval0
+
+    # multi-processing optimization works?
+    result = pypesto.optimize.minimize(
+        problem=problem,
+        optimizer=optimizer,
+        n_starts=4,
+        engine=pypesto.engine.MultiProcessEngine(),
+        progress_bar=False,
+    )
+    assert len(result.optimize_result.list) == 4
+    for local_result in result.optimize_result.list:
+        assert local_result.fval0 is not None, local_result.message
+        assert local_result.fval < local_result.fval0
+
+
+@pytest.mark.filterwarnings(
+    "ignore:.*distribution.*is not supported in PEtab v2.*:UserWarning"
+)
+def test_petab_v2_schwen():
+    problem_id = "Schwen_PONE2014"
+    petab_problem = petab.v2.Problem.from_yaml(
+        models.get_problem_yaml_path(problem_id)
+    )
+    assert petab_problem.n_priors
+    importer = PetabImporter(petab_problem)
+    problem = importer.create_problem()
+    assert problem.x_names == petab_problem.x_ids
+    assert isinstance(problem.objective, pypesto.objective.AggregatedObjective)
+    fval = problem.objective(np.asarray(petab_problem.x_nominal_free))
+    assert np.isfinite(fval)
 
 
 if __name__ == "__main__":

--- a/test/petab/test_petab_import.py
+++ b/test/petab/test_petab_import.py
@@ -461,7 +461,7 @@ def test_petab_v2_residuals():
     with pytest.raises(RuntimeError, match="parameter-dependent sigma"):
         objective(x, sensi_orders=(0, 1), mode=MODE_RES, return_dict=True)
 
-    objective._petab_simulator._model.set_add_sigma_residuals(True)
+    objective.amici_model.set_add_sigma_residuals(True)
     ret = objective(x, sensi_orders=(0, 1), mode=MODE_RES, return_dict=True)
     res, sres = np.asarray(ret["res"]), np.asarray(ret["sres"])
     assert sres.shape == (len(res), petab_problem.n_estimated)

--- a/test/petab/test_petab_import.py
+++ b/test/petab/test_petab_import.py
@@ -519,7 +519,7 @@ def test_petab_v2_prior_indexing():
     from pypesto.petab.importer import PetabImporter
 
     # p0: estimated, no prior; p1: estimated with prior; p2: not estimated;
-    #  p3: estimated with prior; p4: estimated with a uniform prior (skipped)
+    #  p3: estimated with prior
     parameters = [
         SimpleNamespace(
             id="p0",
@@ -542,58 +542,20 @@ def test_petab_v2_prior_indexing():
         SimpleNamespace(
             id="p3",
             estimate=True,
-            prior_distribution="laplace",
-            prior_parameters=[0.0, 1.0],
-        ),
-        SimpleNamespace(
-            id="p4",
-            estimate=True,
             prior_distribution="uniform",
             prior_parameters=[0.0, 10.0],
         ),
     ]
     fake_problem = SimpleNamespace(
-        parameters=parameters, x_ids=["p0", "p1", "p2", "p3", "p4"]
+        parameters=parameters, x_ids=["p0", "p1", "p2", "p3"]
     )
     importer = PetabImporter.__new__(PetabImporter)
     importer.petab_problem = fake_problem
 
     prior = importer._create_prior_v2()
     # priors only for the estimated parameters p1 and p3, at their positions
-    #  in x_ids (1 and 3) -- not at the running prior count (0 and 1).
-    #  p4 is uniform and contributes only a constant, so it is skipped -- as
-    #  the v1 path does for `parameterScaleUniform`.
+    #  in x_ids (1 and 3) -- not at the running prior count (0 and 1)
     assert [entry["index"] for entry in prior.prior_list] == [1, 3]
-
-
-def test_petab_v2_uniform_priors_skipped():
-    """Uniform priors must not contribute to the objective.
-
-    Upgraded PEtab v1 problems can carry a uniform prior for every parameter.
-    Those only add ``sum(log(ub - lb))`` inside the bounds, which the pyPESTO
-    problem enforces anyway, and would otherwise offset the objective against
-    the v1 path.
-    """
-    from types import SimpleNamespace
-
-    from pypesto.petab.importer import PetabImporter
-
-    parameters = [
-        SimpleNamespace(
-            id=f"p{i}",
-            estimate=True,
-            prior_distribution="uniform",
-            prior_parameters=[0.0, 10.0],
-        )
-        for i in range(3)
-    ]
-    importer = PetabImporter.__new__(PetabImporter)
-    importer.petab_problem = SimpleNamespace(
-        parameters=parameters, x_ids=["p0", "p1", "p2"]
-    )
-
-    # only uniform priors -> no prior objective at all
-    assert importer._create_prior_v2() is None
 
 
 def test_petab_v2_startpoint_sampling():

--- a/test/petab/test_petab_import.py
+++ b/test/petab/test_petab_import.py
@@ -368,8 +368,49 @@ def test_petab_v2_boehm():
     assert np.isclose(fval, expected_fval_nominal)
     assert len(grad) == petab_problem.n_estimated
 
-    # TODO mode=res/fun,
-    # TODO hess/fim...
+    # Hessian (FIM-based) works and has the correct sign and shape?
+    hess = problem.objective(
+        np.asarray(petab_problem.x_nominal_free), sensi_orders=(2,)
+    )
+    assert hess.shape == (
+        petab_problem.n_estimated,
+        petab_problem.n_estimated,
+    )
+    # the FIM is a positive semi-definite approximation of the Hessian of the
+    #  negative log-likelihood
+    eigvals = np.linalg.eigvalsh(hess)
+    assert np.min(eigvals) >= -1e-6 * np.max(np.abs(eigvals))
+    # combined value/gradient/Hessian call
+    fval, grad, hess = problem.objective(
+        np.asarray(petab_problem.x_nominal_free), sensi_orders=(0, 1, 2)
+    )
+    assert np.isclose(fval, expected_fval_nominal)
+    assert len(grad) == petab_problem.n_estimated
+    assert hess.shape == (
+        petab_problem.n_estimated,
+        petab_problem.n_estimated,
+    )
+
+    # a parameter fixed to a NON-nominal value must be simulated at that value
+    #  (regression: previously the PEtab nominal value was used instead), and
+    #  the Hessian must shrink accordingly
+    x_nominal_free = np.asarray(petab_problem.x_nominal_free)
+    perturbed = x_nominal_free.copy()
+    perturbed[0] += 0.5
+    ref_fval = problem.objective(perturbed)
+    assert not np.isclose(ref_fval, expected_fval_nominal)
+    full_idx = problem.x_free_indices[0]
+    problem.fix_parameters(full_idx, perturbed[0])
+    fval_fixed, _, hess_fixed = problem.objective(
+        x_nominal_free[1:], sensi_orders=(0, 1, 2)
+    )
+    assert np.isclose(fval_fixed, ref_fval)
+    assert hess_fixed.shape == (
+        petab_problem.n_estimated - 1,
+        petab_problem.n_estimated - 1,
+    )
+    problem.unfix_parameters(full_idx)
+    assert problem.dim == petab_problem.n_estimated
 
     # single optimization works?
     optimizer = ScipyOptimizer()
@@ -396,6 +437,53 @@ def test_petab_v2_boehm():
         assert local_result.fval < local_result.fval0
 
 
+def test_petab_v2_residuals():
+    """Residual mode (MODE_RES) for a PEtab v2 problem: residuals and their
+    sensitivities, plus the least-squares-safe guard for parameter-dependent
+    sigma."""
+    from pypesto.C import MODE_RES
+
+    petab_problem = petab.v2.Problem.from_yaml(
+        models.get_problem_yaml_path("Boehm_JProteomeRes2014")
+    )
+    problem = PetabImporter(petab_problem).create_problem()
+    objective = problem.objective
+    x = np.asarray(petab_problem.x_nominal_free)
+
+    # residual values
+    res = objective(x, sensi_orders=(0,), mode=MODE_RES, return_dict=True)[
+        "res"
+    ]
+    assert res.ndim == 1 and np.all(np.isfinite(res))
+
+    # Boehm has estimated (parameter-dependent) sigma, so residual
+    #  sensitivities are only valid once sigma residuals are added
+    with pytest.raises(RuntimeError, match="parameter-dependent sigma"):
+        objective(x, sensi_orders=(0, 1), mode=MODE_RES, return_dict=True)
+
+    objective._petab_simulator._model.set_add_sigma_residuals(True)
+    ret = objective(x, sensi_orders=(0, 1), mode=MODE_RES, return_dict=True)
+    res, sres = np.asarray(ret["res"]), np.asarray(ret["sres"])
+    assert sres.shape == (len(res), petab_problem.n_estimated)
+
+    # residual sensitivities match finite differences of the residuals
+    def res_of(x_):
+        return np.asarray(
+            objective(x_, sensi_orders=(0,), mode=MODE_RES, return_dict=True)[
+                "res"
+            ]
+        )
+
+    eps = 1e-6
+    fd = np.column_stack(
+        [
+            (res_of(x + d) - res_of(x - d)) / (2 * eps)
+            for d in np.eye(len(x)) * eps
+        ]
+    )
+    assert np.max(np.abs(fd - sres)) < 1e-3 * np.max(np.abs(sres)) + 1e-6
+
+
 @pytest.mark.filterwarnings(
     "ignore:.*distribution.*is not supported in PEtab v2.*:UserWarning"
 )
@@ -411,6 +499,116 @@ def test_petab_v2_schwen():
     assert isinstance(problem.objective, pypesto.objective.AggregatedObjective)
     fval = problem.objective(np.asarray(petab_problem.x_nominal_free))
     assert np.isfinite(fval)
+
+    # startpoint sampling must work with the problem's priors (which include
+    #  log-normal distributions)
+    startpoints = problem.startpoint_method(n_starts=5, problem=problem)
+    assert startpoints.shape == (5, problem.dim)
+    assert np.all(np.isfinite(startpoints))
+
+
+def test_petab_v2_prior_indexing():
+    """Priors must be assigned to the correct parameter index in ``x_full``.
+
+    Regression test: a prior defined on a non-leading estimated parameter has
+    to use that parameter's position in ``x_ids`` as its index, not the running
+    count of priors created so far.
+    """
+    from types import SimpleNamespace
+
+    from pypesto.petab.importer import PetabImporter
+
+    # p0: estimated, no prior; p1: estimated with prior; p2: not estimated;
+    #  p3: estimated with prior
+    parameters = [
+        SimpleNamespace(
+            id="p0",
+            estimate=True,
+            prior_distribution=None,
+            prior_parameters=[],
+        ),
+        SimpleNamespace(
+            id="p1",
+            estimate=True,
+            prior_distribution="normal",
+            prior_parameters=[0.0, 1.0],
+        ),
+        SimpleNamespace(
+            id="p2",
+            estimate=False,
+            prior_distribution="normal",
+            prior_parameters=[0.0, 1.0],
+        ),
+        SimpleNamespace(
+            id="p3",
+            estimate=True,
+            prior_distribution="uniform",
+            prior_parameters=[0.0, 10.0],
+        ),
+    ]
+    fake_problem = SimpleNamespace(
+        parameters=parameters, x_ids=["p0", "p1", "p2", "p3"]
+    )
+    importer = PetabImporter.__new__(PetabImporter)
+    importer.petab_problem = fake_problem
+
+    prior = importer._create_prior_v2()
+    # priors only for the estimated parameters p1 and p3, at their positions
+    #  in x_ids (1 and 3) -- not at the running prior count (0 and 1)
+    assert [entry["index"] for entry in prior.prior_list] == [1, 3]
+
+
+def test_petab_v2_startpoint_sampling():
+    """Startpoint sampling must handle v2 prior distributions, incl. log-*.
+
+    Regression: PEtab v2 uses distribution names (e.g. ``log-normal``) that the
+    v1 ``petab.sample_from_prior`` does not understand, so sampling has to go
+    through the parameter's own prior distribution object instead.
+    """
+    from types import SimpleNamespace
+
+    from petab.v2 import Parameter
+
+    from pypesto.petab.util import PetabStartpoints
+
+    parameters = [
+        Parameter(
+            id="p_lognormal",
+            lb=1e-3,
+            ub=1e3,
+            estimate=True,
+            nominal_value=1.0,
+            prior_distribution="log-normal",
+            prior_parameters=[0.0, 1.0],
+        ),
+        # no explicit prior -> uniform over the bounds
+        Parameter(
+            id="p_uniform",
+            lb=0.0,
+            ub=10.0,
+            estimate=True,
+            nominal_value=1.0,
+        ),
+    ]
+    petab_problem = SimpleNamespace(parameters=parameters)
+    startpoint_method = PetabStartpoints(petab_problem=petab_problem)
+    pypesto_problem = SimpleNamespace(
+        x_names=["p_lognormal", "p_uniform"], x_free_indices=[0, 1]
+    )
+    startpoint_method._setup(pypesto_problem)
+
+    startpoints = startpoint_method.sample(
+        n_starts=20,
+        lb=np.array([1e-3, 0.0]),
+        ub=np.array([1e3, 10.0]),
+    )
+    assert startpoints.shape == (20, 2)
+    assert np.all(np.isfinite(startpoints))
+    # sampled startpoints respect the parameter bounds
+    assert np.all(startpoints[:, 0] >= 1e-3)
+    assert np.all(startpoints[:, 0] <= 1e3)
+    assert np.all(startpoints[:, 1] >= 0.0)
+    assert np.all(startpoints[:, 1] <= 10.0)
 
 
 if __name__ == "__main__":

--- a/test/petab/test_petab_import.py
+++ b/test/petab/test_petab_import.py
@@ -519,7 +519,7 @@ def test_petab_v2_prior_indexing():
     from pypesto.petab.importer import PetabImporter
 
     # p0: estimated, no prior; p1: estimated with prior; p2: not estimated;
-    #  p3: estimated with prior
+    #  p3: estimated with prior; p4: estimated with a uniform prior (skipped)
     parameters = [
         SimpleNamespace(
             id="p0",
@@ -542,20 +542,58 @@ def test_petab_v2_prior_indexing():
         SimpleNamespace(
             id="p3",
             estimate=True,
+            prior_distribution="laplace",
+            prior_parameters=[0.0, 1.0],
+        ),
+        SimpleNamespace(
+            id="p4",
+            estimate=True,
             prior_distribution="uniform",
             prior_parameters=[0.0, 10.0],
         ),
     ]
     fake_problem = SimpleNamespace(
-        parameters=parameters, x_ids=["p0", "p1", "p2", "p3"]
+        parameters=parameters, x_ids=["p0", "p1", "p2", "p3", "p4"]
     )
     importer = PetabImporter.__new__(PetabImporter)
     importer.petab_problem = fake_problem
 
     prior = importer._create_prior_v2()
     # priors only for the estimated parameters p1 and p3, at their positions
-    #  in x_ids (1 and 3) -- not at the running prior count (0 and 1)
+    #  in x_ids (1 and 3) -- not at the running prior count (0 and 1).
+    #  p4 is uniform and contributes only a constant, so it is skipped -- as
+    #  the v1 path does for `parameterScaleUniform`.
     assert [entry["index"] for entry in prior.prior_list] == [1, 3]
+
+
+def test_petab_v2_uniform_priors_skipped():
+    """Uniform priors must not contribute to the objective.
+
+    Upgraded PEtab v1 problems can carry a uniform prior for every parameter.
+    Those only add ``sum(log(ub - lb))`` inside the bounds, which the pyPESTO
+    problem enforces anyway, and would otherwise offset the objective against
+    the v1 path.
+    """
+    from types import SimpleNamespace
+
+    from pypesto.petab.importer import PetabImporter
+
+    parameters = [
+        SimpleNamespace(
+            id=f"p{i}",
+            estimate=True,
+            prior_distribution="uniform",
+            prior_parameters=[0.0, 10.0],
+        )
+        for i in range(3)
+    ]
+    importer = PetabImporter.__new__(PetabImporter)
+    importer.petab_problem = SimpleNamespace(
+        parameters=parameters, x_ids=["p0", "p1", "p2"]
+    )
+
+    # only uniform priors -> no prior objective at all
+    assert importer._create_prior_v2() is None
 
 
 def test_petab_v2_startpoint_sampling():

--- a/test/petab/test_petab_suite.py
+++ b/test/petab/test_petab_suite.py
@@ -5,7 +5,6 @@ import logging
 import petab.v1 as petab
 import petabtests
 import pytest
-from amici.sim.sundials.petab.v1 import rdatas_to_measurement_df
 
 import pypesto
 import pypesto.petab
@@ -20,8 +19,8 @@ logger = logging.getLogger(__name__)
         (case, model_type, version)
         for (model_type, version) in (
             ("sbml", "v1.0.0"),
-            # FIXME: disabled until there is proper PEtab v2 support https://github.com/ICB-DCM/pyPESTO/pull/1634
-            # ("pysb", "v2.0.0")
+            ("sbml", "v2.0.0"),
+            ("pysb", "v2.0.0"),
         )
         for case in petabtests.get_cases(format_=model_type, version=version)
     ],
@@ -69,29 +68,33 @@ def _execute_case(case, model_type, version):
     model_name = (
         f"petab_test_case_{case}_{model_type}_{version.replace('.', '_')}"
     )
-    output_folder = f"amici_models/{model_name}"
 
     # import and create objective function
     if case.startswith("0006"):
+        if version == "v2.0.0":
+            pytest.skip("TODO")
         petab_problem = petab.Problem.from_yaml(yaml_file)
         petab.flatten_timepoint_specific_output_overrides(petab_problem)
         importer = pypesto.petab.PetabImporter(
             petab_problem=petab_problem,
-            output_folder=output_folder,
             model_name=model_name,
         )
         petab_problem = petab.Problem.from_yaml(yaml_file)
     else:
         importer = pypesto.petab.PetabImporter.from_yaml(
-            yaml_file, output_folder=output_folder
+            yaml_file, model_name=model_name
         )
         petab_problem = importer.petab_problem
+
     factory = importer.create_objective_creator()
     model = factory.create_model(generate_sensitivity_code=False)
     obj = factory.create_objective(model=model)
 
-    # the scaled parameters
-    problem_parameters = factory.petab_problem.x_nominal_scaled
+    if version == "v1.0.0":
+        # the scaled parameters
+        problem_parameters = factory.petab_problem.x_nominal_scaled
+    else:
+        problem_parameters = importer.petab_problem.x_nominal
 
     # simulate
     ret = obj(problem_parameters, sensi_orders=(0,), return_dict=True)
@@ -100,20 +103,24 @@ def _execute_case(case, model_type, version):
     rdatas = ret["rdatas"]
     chi2 = sum(rdata["chi2"] for rdata in rdatas)
     llh = -ret["fval"]
-    simulation_df = rdatas_to_measurement_df(
-        rdatas, model, importer.petab_problem.measurement_df
-    )
+    if version == "v1.0.0":
+        from amici.sim.sundials.petab.v1 import rdatas_to_measurement_df
 
-    if case.startswith("0006"):
-        simulation_df = petab.unflatten_simulation_df(
-            simulation_df, petab_problem
+        simulation_df = rdatas_to_measurement_df(
+            rdatas, model, importer.petab_problem.measurement_df
         )
+        if case.startswith("0006"):
+            simulation_df = petab.unflatten_simulation_df(
+                simulation_df, petab_problem
+            )
 
-    petab.check_measurement_df(simulation_df, petab_problem.observable_df)
-    simulation_df = simulation_df.rename(
-        columns={petab.MEASUREMENT: petab.SIMULATION}
-    )
-    simulation_df[petab.TIME] = simulation_df[petab.TIME].astype(int)
+        petab.check_measurement_df(simulation_df, petab_problem.observable_df)
+        simulation_df = simulation_df.rename(
+            columns={petab.MEASUREMENT: petab.SIMULATION}
+        )
+        simulation_df[petab.TIME] = simulation_df[petab.TIME].astype(int)
+    else:
+        simulation_df = obj.rdatas_to_simulation_df(rdatas)
 
     # check if matches
     chi2s_match = petabtests.evaluate_chi2(chi2, gt_chi2, tol_chi2)

--- a/test/petab/test_petab_suite.py
+++ b/test/petab/test_petab_suite.py
@@ -3,6 +3,7 @@
 import logging
 
 import petab.v1 as petab
+import petab.v2 as petab_v2
 import petabtests
 import pytest
 
@@ -71,15 +72,27 @@ def _execute_case(case, model_type, version):
 
     # import and create objective function
     if case.startswith("0006"):
+        # timepoint-specific overrides are not supported by AMICI -- flatten
+        #  the problem, i.e. replicate the affected observables
         if version == "v2.0.0":
-            pytest.skip("TODO")
-        petab_problem = petab.Problem.from_yaml(yaml_file)
-        petab.flatten_timepoint_specific_output_overrides(petab_problem)
+            from amici.importers.petab._petab_importer import (
+                flatten_timepoint_specific_output_overrides,
+            )
+
+            petab_problem = petab_v2.Problem.from_yaml(yaml_file)
+            flatten_timepoint_specific_output_overrides(petab_problem)
+        else:
+            petab_problem = petab.Problem.from_yaml(yaml_file)
+            petab.flatten_timepoint_specific_output_overrides(petab_problem)
         importer = pypesto.petab.PetabImporter(
             petab_problem=petab_problem,
             model_name=model_name,
         )
-        petab_problem = petab.Problem.from_yaml(yaml_file)
+        petab_problem = (
+            petab_v2.Problem.from_yaml(yaml_file)
+            if version == "v2.0.0"
+            else petab.Problem.from_yaml(yaml_file)
+        )
     else:
         importer = pypesto.petab.PetabImporter.from_yaml(
             yaml_file, model_name=model_name
@@ -87,13 +100,17 @@ def _execute_case(case, model_type, version):
         petab_problem = importer.petab_problem
 
     factory = importer.create_objective_creator()
-    model = factory.create_model(generate_sensitivity_code=False)
-    obj = factory.create_objective(model=model)
-
     if version == "v1.0.0":
+        model = factory.create_model(generate_sensitivity_code=False)
+        obj = factory.create_objective(model=model)
         # the scaled parameters
         problem_parameters = factory.petab_problem.x_nominal_scaled
     else:
+        # for PEtab v2, the objective creates model and solver itself, via the
+        #  AMICI PEtab importer -- which does not expose the model import
+        #  options either
+        model = None
+        obj = factory.create_objective()
         problem_parameters = importer.petab_problem.x_nominal
 
     # simulate
@@ -121,6 +138,15 @@ def _execute_case(case, model_type, version):
         simulation_df[petab.TIME] = simulation_df[petab.TIME].astype(int)
     else:
         simulation_df = obj.rdatas_to_simulation_df(rdatas)
+        if case.startswith("0006"):
+            # map the replicated observables back to the original ones
+            from amici.importers.petab._petab_importer import (
+                unflatten_simulation_df,
+            )
+
+            simulation_df = unflatten_simulation_df(
+                simulation_df, petab_problem
+            )
 
     # check if matches
     chi2s_match = petabtests.evaluate_chi2(chi2, gt_chi2, tol_chi2)

--- a/tox.ini
+++ b/tox.ini
@@ -54,11 +54,7 @@ description =
 extras = test,amici,petab,emcee,dynesty,mltools,pymc,jax,fides,roadrunner
 deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
-# FIXME: Until we have proper PEtab v2 import
-#  we need `10ffb050380933b60ac192962bf9550a9df65a9c`
-#  with the pseudo-v2 format for pysb tests instead of `main`
-#    git+https://github.com/PEtab-dev/petab_test_suite@main
-    git+https://github.com/PEtab-dev/petab_test_suite@10ffb050380933b60ac192962bf9550a9df65a9c
+    git+https://github.com/PEtab-dev/petab_test_suite@a80dd936766d347a86b991d140d3e4a2eeda26bf
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/base --durations=0 \
@@ -85,17 +81,15 @@ deps =
 # always install amici from main branch, avoid caching
 #  to skip re-installation, run `tox -e petab --override testenv:petab.commands_pre=`
 commands_pre =
-   python3 -m pip uninstall -y amici
+   python3 -m pip uninstall -y amici petabtests
    python3 -m pip install git+https://github.com/AMICI-dev/amici.git@main\#egg=amici&subdirectory=python/sdist
+   python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@a80dd936766d347a86b991d140d3e4a2eeda26bf
    python -m pip list
 commands =
-# FIXME: Until we have proper PEtab v2 import
-#  we need `10ffb050380933b60ac192962bf9550a9df65a9c`
-#  with the pseudo-v2 format for pysb tests instead of `main`
-#    python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@main
-    python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@10ffb050380933b60ac192962bf9550a9df65a9c
     python3 -m pip install git+https://github.com/pysb/pysb@master
     python3 -m pip install -U copasi-basico[petab]
+    python3 -m pip uninstall -y petab
+    python3 -m pip install git+https://github.com/petab-dev/libpetab-python@main\#egg=petab
     # upgrade after installing pysb which requires an older sympy
     python3 -m pip install -U sympy
     pytest --cov=pypesto --cov-report=xml --cov-append \

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ description =
 extras = test,amici,petab,emcee,dynesty,mltools,pymc,jax,fides,roadrunner
 deps =
     git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
-    git+https://github.com/PEtab-dev/petab_test_suite@a80dd936766d347a86b991d140d3e4a2eeda26bf
+    git+https://github.com/PEtab-dev/petab_test_suite@main
 commands =
     pytest --cov=pypesto --cov-report=xml --cov-append \
         test/base --durations=0 \
@@ -83,7 +83,7 @@ deps =
 commands_pre =
    python3 -m pip uninstall -y amici petabtests
    python3 -m pip install git+https://github.com/AMICI-dev/amici.git@main\#egg=amici&subdirectory=python/sdist
-   python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@a80dd936766d347a86b991d140d3e4a2eeda26bf
+   python3 -m pip install git+https://github.com/PEtab-dev/petab_test_suite@main
    python -m pip list
 commands =
     python3 -m pip install git+https://github.com/pysb/pysb@master


### PR DESCRIPTION
This picks up @dweindl's WIP "PEtab v2 import via AMICI" (#1634) and completes it against the current AMICI 1.0 PEtab importer API (`amici.importers.petab` / `amici.sim.sundials.petab`), so PEtab v2 problems can be imported and optimized end-to-end.

### Commits

1. **Import PEtab v2 via AMICI support from #1634** — the WIP work, rebased onto `develop`.
2. **Complete PEtab v2 via AMICI support** — finishes the remaining pieces and fixes several correctness bugs.
3. **Simplify the PEtab v2 calculator and share model/solver with the simulator** — removes the accidental complexity introduced along the way.
4. **Derive `AmiciPetabV2ObjectiveCreator` from `AmiciObjectiveCreator`** — deduplication.

### Objective / calculator (`pypesto/objective/amici/`)

`AmiciCalculatorPetabV2` translates an `amici.sim.sundials.petab.PetabSimulator` result into pyPESTO's return dict:

- use `result.llh` (was an invalid `result["llh"]` subscript);
- fix the Hessian — `result.s2llh` is the (positive semi-definite) FIM, i.e. the Hessian of the *negative* log-likelihood, so it must not be negated;
- implement residual mode (`MODE_RES`): residuals from `result.res`, residual sensitivities from `result.sres`, with the least-squares-safe check for parameter-dependent sigma. Requires an AMICI build with residual-sensitivity aggregation (currently `main`);
- return full-dimension gradients / Hessians / `sres`, as `calculate_function_values` does, rather than pre-reduced arrays that happened to pass through `FixedParametersProcessor.postprocess`;
- log the individual simulations and return the error output for non-finite objective values, matching the v1 path;
- raise a clear error when a parameter is free in the pyPESTO problem but not estimated in the PEtab problem (it is a constant in the AMICI model, so no sensitivities exist — only `sensi_orders=(0,)` works).

`AmiciPetabV2Objective` now hands its own model and solver to the PEtab simulator instead of operating on clones the simulation never sees. Consequences:

- the reporting mode chosen by `AmiciObjective.call_unprocessed` takes effect, so the calculator no longer has to request `RDataReporting.full` on every call — residuals and the FIM are computed only when requested;
- `objective.amici_model` / `objective.amici_solver` are the instances actually simulated with (e.g. `set_add_sigma_residuals`);
- `n_threads` reaches the simulator (it was silently 1);
- `guess_steadystate` is disabled — the simulator builds fresh `ExpData` objects per call, so guesses stored on `self.edatas` could never be applied.

Fixed parameters no longer need separate plumbing. The vector reaching `call_unprocessed` already carries the pyPESTO-fixed values; they were only stripped again by the v1-specific bookkeeping in `AmiciObjective.update_from_problem`, which is now bypassed (there is no parameter mapping to update for v2). This affects profile likelihoods and any non-nominal `fix_parameters`.

Also: `check_gradients_match_finite_differences` no longer uses `x_nominal_scaled`, which does not exist for PEtab v2.

### Objective creator (`pypesto/petab/objective_creator.py`)

`AmiciPetabV2ObjectiveCreator` now derives from `AmiciObjectiveCreator` (−147 lines). Model import and compilation do not depend on the PEtab version; only `compile_model`, `_create_amici_importer`, `create_edatas`, `create_objective` and the `rdatas_to_*` conversions are version-specific. `create_edatas` builds the `ExperimentManager` on the PEtab problem preprocessed by the AMICI importer — only that one matches the compiled model. Stale `amici.Model` / `amici.Solver` annotations updated to `amici.sim.sundials`.

### Importer / startpoints (`pypesto/petab/`)

- `_create_prior_v2`: index priors by the parameter's position in `x_ids` (was the running prior count, which mis-assigned priors unless they were on the leading estimated parameters).
- `PetabStartpoints` for v2: sample from the parameter's own prior distribution (`Parameter.prior_dist`), falling back to a uniform over the bounds — the v1 `sample_from_prior` uses different distribution names (e.g. `logNormal` vs. `log-normal`) and crashed for `log-normal` / `log-laplace` / `log-uniform` initialization priors.

### Why a separate calculator

`AmiciCalculator` is built around PEtab v1's `fill_in_parameters` and `calculate_function_values(parameter_mapping=…)`. PEtab v2 has no equivalent `ParameterMapping`: parameter application (`ExperimentManager.apply_parameters`) and the aggregation of sensitivities across experiments (`PetabSimulator._aggregate_sllh` / `_s2llh` / `_sres`, including placeholder summation) live in AMICI. Reusing the v1 calculator would mean reimplementing that mapping in pyPESTO. `AmiciCalculatorPetabV2` is the fifth `AmiciCalculator` subclass to override `__call__` wholesale, alongside `InnerCalculatorCollector`, `RelativeAmiciCalculator`, `OrdinalCalculator` and `SemiquantCalculator`.

### Not yet supported

Hierarchical optimization, non-quantitative data types, predictors and the prediction-to-PEtab-dataframe conversions raise `NotImplementedError` for v2 problems.

Known limitation: sensitivities are computed for every parameter estimated in the PEtab problem, including those fixed in the pyPESTO problem. Unlike for v1, `plist` cannot be narrowed from pyPESTO — it is set inside `ExperimentManager.apply_parameters`. This costs performance for profile likelihoods.

### Validation

Against AMICI `main` and libpetab 0.8.2:

- the PEtab v2 import tests (Boehm, Schwen) and the SBML and PySB PEtab test-suite v2 cases pass, unsupported cases skipped;
- no regression in the v1 path;
- Boehm checked in detail — nominal function value `138.2219980`, gradient against relative-step finite differences at tight solver tolerances (max rel. err. 3.3e-4), FIM Hessian positive semi-definite with the correct shape, residuals and residual sensitivities against finite differences (rel. 5e-5), fixing a parameter to a non-nominal value, and `deepcopy` / `pickle` preserving the model↔simulator sharing.

Co-authored with @dweindl (see commit trailers). Supersedes the WIP in #1634.
