### PR TITLE
Time specific noise value overrides

### DIFF
--- a/pypesto/objective/roadrunner/roadrunner_calculator.py
+++ b/pypesto/objective/roadrunner/roadrunner_calculator.py
@@ -415,29 +415,84 @@ def calculate_llh(
         """Fill in the noise formula."""
         if isinstance(noise_formula, numbers.Number):
             return float(noise_formula)
+        # Try to convert string to number
+        try:
+            return float(noise_formula)
+        except (ValueError, TypeError):
+            pass
         # if it is not a number, it is assumed to be a string
         if noise_formula in parameter_mapping.keys():
             return parameter_mapping[noise_formula]
         # if the string starts with "noiseFormula_" it is saved in the model
-        if noise_formula.startswith("noiseFormula_"):
+        if isinstance(noise_formula, str) and noise_formula.startswith(
+            "noiseFormula_"
+        ):
             return roadrunner_instance.getValue(noise_formula)
+        # If we couldn't resolve it, return None (will cause error downstream)
+        return None
 
     # replace noise formula with actual value from mapping
-    noise_formulae = np.array(
-        [_fill_in_noise_formula(formula) for formula in edata.noise_formulae]
-    )
-    # check that the rows of noise are the columns of the simulation
-    if noise_formulae.shape[0] != simulations.shape[1]:
-        raise ValueError("Noise and Simulation have different dimensions.")
-    # per observable, decide on the llh function based on the noise dist
-    llhs = np.array(
-        [
-            LLH_TYPES[noise_dist](
-                measurements[:, i], simulations[:, i], noise_formulae[i]
+    # Handle both 1D (n_observables,) and 2D (n_timepoints, n_observables) arrays
+    if edata.noise_formulae.ndim == 1:
+        # 1D case: one noise parameter per observable (broadcast to all timepoints)
+        noise_formulae = np.array(
+            [
+                _fill_in_noise_formula(formula)
+                for formula in edata.noise_formulae
+            ]
+        )
+    elif edata.noise_formulae.ndim == 2:
+        # 2D case: timepoint-specific noise parameters
+        noise_formulae = np.array(
+            [
+                [_fill_in_noise_formula(formula) for formula in row]
+                for row in edata.noise_formulae
+            ]
+        )
+    else:
+        raise ValueError(
+            f"noise_formulae must be 1D or 2D, got {edata.noise_formulae.ndim}D"
+        )
+
+    # Handle noise_distributions similarly
+    if edata.noise_distributions.ndim == 1:
+        # 1D case: broadcast to all timepoints
+        noise_distributions = edata.noise_distributions
+    elif edata.noise_distributions.ndim == 2:
+        # 2D case: use first row (distributions should be constant across timepoints)
+        noise_distributions = edata.noise_distributions[0, :]
+    else:
+        raise ValueError(
+            f"noise_distributions must be 1D or 2D, got {edata.noise_distributions.ndim}D"
+        )
+
+    # Calculate likelihood
+    if noise_formulae.ndim == 1:
+        # 1D noise: one value per observable, broadcast to all timepoints
+        if noise_formulae.shape[0] != simulations.shape[1]:
+            raise ValueError("Noise and Simulation have different dimensions.")
+        llhs = np.array(
+            [
+                LLH_TYPES[noise_dist](
+                    measurements[:, i], simulations[:, i], noise_formulae[i]
+                )
+                for i, noise_dist in enumerate(noise_distributions)
+            ]
+        ).transpose()
+    else:
+        # 2D noise: timepoint-specific values
+        if noise_formulae.shape != simulations.shape:
+            raise ValueError(
+                f"Noise shape {noise_formulae.shape} and Simulation shape {simulations.shape} must match."
             )
-            for i, noise_dist in enumerate(edata.noise_distributions)
-        ]
-    ).transpose()
+        llhs = np.array(
+            [
+                LLH_TYPES[noise_dist](
+                    measurements[:, i], simulations[:, i], noise_formulae[:, i]
+                )
+                for i, noise_dist in enumerate(noise_distributions)
+            ]
+        ).transpose()
     # check whether all nan values in llhs coincide with nan measurements
     if not np.all(np.isnan(llhs) == np.isnan(measurements)):
         return np.nan

--- a/pypesto/objective/roadrunner/roadrunner_calculator.py
+++ b/pypesto/objective/roadrunner/roadrunner_calculator.py
@@ -411,19 +411,25 @@ def calculate_llh(
     simulations = simulations[:, 1:]
     measurements = edata.measurements[:, 1:]
 
+    def _try_convert_to_float(value):
+        """Convert value to float if possible, returns None if not numeric."""
+        if isinstance(value, numbers.Number):
+            return float(value)
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
+
     def _fill_in_noise_formula(noise_formula):
         """Fill in the noise formula."""
-        if isinstance(noise_formula, numbers.Number):
-            return float(noise_formula)
-        # Try to convert string to number
-        try:
-            return float(noise_formula)
-        except (ValueError, TypeError):
-            pass
-        # if it is not a number, it is assumed to be a string
+        # Try numeric conversion first
+        numeric_value = _try_convert_to_float(noise_formula)
+        if numeric_value is not None:
+            return numeric_value
+        # Check if it's a parameter in the mapping
         if noise_formula in parameter_mapping.keys():
             return parameter_mapping[noise_formula]
-        # if the string starts with "noiseFormula_" it is saved in the model
+        # Check if it's a noiseFormula_ parameter in the model
         if isinstance(noise_formula, str) and noise_formula.startswith(
             "noiseFormula_"
         ):

--- a/pypesto/objective/roadrunner/roadrunner_calculator.py
+++ b/pypesto/objective/roadrunner/roadrunner_calculator.py
@@ -421,7 +421,14 @@ def calculate_llh(
             return None
 
     def _fill_in_noise_formula(noise_formula):
-        """Fill in the noise formula."""
+        """Resolve a noise formula to its numeric value.
+
+        Raises
+        ------
+        ValueError:
+            If the formula is neither numeric, a mapped parameter, nor a
+            ``noiseFormula_``-prefixed model parameter.
+        """
         # Try numeric conversion first
         numeric_value = _try_convert_to_float(noise_formula)
         if numeric_value is not None:
@@ -434,8 +441,11 @@ def calculate_llh(
             "noiseFormula_"
         ):
             return roadrunner_instance.getValue(noise_formula)
-        # If we couldn't resolve it, return None (will cause error downstream)
-        return None
+        raise ValueError(
+            f"Could not resolve noise formula {noise_formula!r}: it is "
+            "neither numeric, a mapped parameter, nor a "
+            "'noiseFormula_'-prefixed model parameter."
+        )
 
     # replace noise formula with actual value from mapping
     # Handle both 1D (n_observables,) and 2D (n_timepoints, n_observables) arrays

--- a/pypesto/objective/roadrunner/utils.py
+++ b/pypesto/objective/roadrunner/utils.py
@@ -100,6 +100,42 @@ class ExpData:
         """
         return self.observable_ids
 
+    def _validate_array_shape(
+        self,
+        array: np.ndarray,
+        name: str,
+        n_observables: int,
+        n_timepoints: int,
+    ):
+        """Validate that array has correct shape (1D or 2D).
+
+        Parameters
+        ----------
+        array:
+            Array to validate
+        name:
+            Name of the array for error messages
+        n_observables:
+            Expected number of observables (for 1D: array length, for 2D: second dimension)
+        n_timepoints:
+            Expected number of timepoints (for 2D: first dimension)
+        """
+        if array.ndim == 1:
+            if len(array) != n_observables:
+                raise ValueError(
+                    f"{name} length ({len(array)}) doesn't match "
+                    f"number of observable ids ({n_observables})."
+                )
+        elif array.ndim == 2:
+            expected_shape = (n_timepoints, n_observables)
+            if array.shape != expected_shape:
+                raise ValueError(
+                    f"{name} shape {array.shape} doesn't match "
+                    f"expected (n_timepoints, n_observables) = {expected_shape}."
+                )
+        else:
+            raise ValueError(f"{name} must be 1D or 2D, got {array.ndim}D")
+
     def sanity_check(self):
         """Perform a sanity check of the data."""
         if self.measurements.shape[1] != len(self.observable_ids) + 1:
@@ -112,23 +148,16 @@ class ExpData:
         n_timepoints = self.measurements.shape[0]
         n_observables = len(self.observable_ids)
 
-        # noise_distributions can be 1D or 2D
-        if self.noise_distributions.ndim == 1:
-            if len(self.noise_distributions) != n_observables:
-                raise ValueError(
-                    f"Number of noise distributions ({len(self.noise_distributions)}) "
-                    f"does not match number of observable ids ({n_observables})."
-                )
-        elif self.noise_distributions.ndim == 2:
-            if self.noise_distributions.shape != (n_timepoints, n_observables):
-                raise ValueError(
-                    f"Shape of noise distributions {self.noise_distributions.shape} "
-                    f"does not match (n_timepoints, n_observables) = ({n_timepoints}, {n_observables})."
-                )
-        else:
-            raise ValueError(
-                f"noise_distributions must be 1D or 2D, got {self.noise_distributions.ndim}D"
-            )
+        # Validate both arrays using helper method
+        self._validate_array_shape(
+            self.noise_distributions,
+            "noise_distributions",
+            n_observables,
+            n_timepoints,
+        )
+        self._validate_array_shape(
+            self.noise_formulae, "noise_formulae", n_observables, n_timepoints
+        )
 
     @staticmethod
     def from_petab_problem(petab_problem: petab.Problem) -> list[ExpData]:

--- a/pypesto/objective/roadrunner/utils.py
+++ b/pypesto/objective/roadrunner/utils.py
@@ -20,6 +20,7 @@ try:
         MEASUREMENT,
         NOISE_DISTRIBUTION,
         NOISE_FORMULA,
+        NOISE_PARAMETERS,
         NORMAL,
         OBSERVABLE_ID,
         OBSERVABLE_TRANSFORMATION,
@@ -107,16 +108,26 @@ class ExpData:
                 "observable ids + time."
             )
         # check that the noise distributions and noise formulae have the
-        # same length as the number of observables
-        if len(self.noise_distributions) != len(self.observable_ids):
+        # correct shape: either (n_observables,) or (n_timepoints, n_observables)
+        n_timepoints = self.measurements.shape[0]
+        n_observables = len(self.observable_ids)
+
+        # noise_distributions can be 1D or 2D
+        if self.noise_distributions.ndim == 1:
+            if len(self.noise_distributions) != n_observables:
+                raise ValueError(
+                    f"Number of noise distributions ({len(self.noise_distributions)}) "
+                    f"does not match number of observable ids ({n_observables})."
+                )
+        elif self.noise_distributions.ndim == 2:
+            if self.noise_distributions.shape != (n_timepoints, n_observables):
+                raise ValueError(
+                    f"Shape of noise distributions {self.noise_distributions.shape} "
+                    f"does not match (n_timepoints, n_observables) = ({n_timepoints}, {n_observables})."
+                )
+        else:
             raise ValueError(
-                "Number of noise distributions does not match number of "
-                "observable ids."
-            )
-        if len(self.noise_formulae) != len(self.observable_ids):
-            raise ValueError(
-                "Number of noise formulae does not match number of "
-                "observable ids."
+                f"noise_distributions must be 1D or 2D, got {self.noise_distributions.ndim}D"
             )
 
     @staticmethod
@@ -165,6 +176,14 @@ class ExpData:
         # construct noise distributions and noise formulae
         noise_distributions, noise_formulae = construct_noise_matrices(
             petab_problem, observale_ids
+        )
+        # inject timepoint-specific noise parameter overrides if present
+        noise_distributions, noise_formulae = inject_timepoint_specific_noise(
+            noise_distributions,
+            noise_formulae,
+            measurement_df,
+            observale_ids,
+            measurements,
         )
         return ExpData(
             condition_id=condition_id,
@@ -399,6 +418,106 @@ def construct_noise_matrices(
 
     noise_distributions, noise_formulae = zip(*noise, strict=True)
     return np.array(noise_distributions), np.array(noise_formulae)
+
+
+def inject_timepoint_specific_noise(
+    noise_distributions: np.ndarray,
+    noise_formulae: np.ndarray,
+    measurement_df: pd.DataFrame,
+    observable_ids: Sequence[str],
+    measurements: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Inject timepoint-specific noise parameter overrides from measurement table.
+
+    Takes the default noise distributions and formulae (one per observable) and
+    expands them to timepoint-specific arrays if the measurement table contains
+    timepoint-specific noise parameter overrides.
+
+    Parameters
+    ----------
+    noise_distributions:
+        Default noise distributions from observable table. Shape: (n_observables,)
+    noise_formulae:
+        Default noise formulae from observable table. Shape: (n_observables,)
+    measurement_df:
+        PEtab measurement DataFrame filtered for a single condition.
+    observable_ids:
+        Observable IDs in the order they appear in the measurement matrix.
+    measurements:
+        Measurement matrix with shape (n_timepoints, n_observables + 1).
+        First column is time.
+
+    Returns
+    -------
+    noise_distributions:
+        Noise distributions array. Shape: (n_timepoints, n_observables)
+    noise_formulae:
+        Noise formulae array with timepoint-specific overrides applied.
+        Shape: (n_timepoints, n_observables)
+    """
+    # Get timepoints from measurements
+    timepoints = measurements[:, 0]
+    n_timepoints = len(timepoints)
+
+    # Initialize arrays with default values repeated for each timepoint
+    noise_distributions_expanded = np.tile(
+        noise_distributions, (n_timepoints, 1)
+    )
+    noise_formulae_expanded = np.tile(noise_formulae, (n_timepoints, 1))
+
+    # If no noise parameters column, return the 1D defaults
+    if NOISE_PARAMETERS not in measurement_df.columns:
+        return noise_distributions, noise_formulae
+
+    # Check if there are actually timepoint-specific numeric overrides
+    # Build a lookup dictionary: (time, observable_id) -> noise_parameter_value
+    noise_override_map = {}
+    has_timepoint_specific = False
+
+    for _, row in measurement_df.iterrows():
+        time = row[TIME]
+        obs_id = row[OBSERVABLE_ID]
+        noise_param = row[NOISE_PARAMETERS]
+        # Only process non-NaN values
+        if pd.notna(noise_param):
+            noise_param_str = str(noise_param)
+            # Check if it's a simple numeric value (not a formula like "0.5;2")
+            try:
+                float(noise_param_str)
+                # It's numeric - add to map
+                noise_override_map[(time, obs_id)] = noise_param_str
+            except ValueError:
+                # Not a simple number (could be "0.5;2", "noise", etc.)
+                # Don't treat as timepoint-specific override
+                pass
+
+    # Check if noise values actually vary by timepoint for any observable
+    if noise_override_map:
+        for obs_id in observable_ids:
+            obs_noise_values = [
+                v for (t, o), v in noise_override_map.items() if o == obs_id
+            ]
+            if len(set(obs_noise_values)) > 1:
+                # This observable has different noise values at different timepoints
+                has_timepoint_specific = True
+                break
+
+    # If no timepoint-specific overrides, return 1D defaults
+    if not has_timepoint_specific:
+        return noise_distributions, noise_formulae
+
+    # Apply timepoint-specific overrides
+    for i_time, time in enumerate(timepoints):
+        for i_obs, obs_id in enumerate(observable_ids):
+            key = (time, obs_id)
+            if key in noise_override_map:
+                # Override the noise formula with the value from measurement table
+                noise_formulae_expanded[i_time, i_obs] = noise_override_map[
+                    key
+                ]
+
+    return noise_distributions_expanded, noise_formulae_expanded
 
 
 def simulation_to_measurement_df(

--- a/pypesto/objective/roadrunner/utils.py
+++ b/pypesto/objective/roadrunner/utils.py
@@ -480,71 +480,79 @@ def inject_timepoint_specific_noise(
     Returns
     -------
     noise_distributions:
-        Noise distributions array. Shape: (n_timepoints, n_observables)
+        Noise distributions array. Shape: (n_timepoints, n_observables) if
+        timepoint-specific overrides were found, else unchanged
+        (n_observables,).
     noise_formulae:
         Noise formulae array with timepoint-specific overrides applied.
-        Shape: (n_timepoints, n_observables)
+        Shape: (n_timepoints, n_observables) if timepoint-specific overrides
+        were found, else unchanged (n_observables,).
     """
-    # Get timepoints from measurements
-    timepoints = measurements[:, 0]
-    n_timepoints = len(timepoints)
-
-    # Initialize arrays with default values repeated for each timepoint
-    noise_distributions_expanded = np.tile(
-        noise_distributions, (n_timepoints, 1)
-    )
-    noise_formulae_expanded = np.tile(noise_formulae, (n_timepoints, 1))
-
     # If no noise parameters column, return the 1D defaults
     if NOISE_PARAMETERS not in measurement_df.columns:
         return noise_distributions, noise_formulae
 
-    # Check if there are actually timepoint-specific numeric overrides
-    # Build a lookup dictionary: (time, observable_id) -> noise_parameter_value
-    noise_override_map = {}
-    has_timepoint_specific = False
+    def _to_numeric(value):
+        """Convert to float, or NaN if not a plain number."""
+        if pd.isna(value):
+            return np.nan
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            # not a plain number, e.g. "0.5;2" or a parameter id -- left to
+            # the existing single-parameter-per-observable mechanism
+            return np.nan
 
-    for _, row in measurement_df.iterrows():
-        time = row[TIME]
-        obs_id = row[OBSERVABLE_ID]
-        noise_param = row[NOISE_PARAMETERS]
-        # Only process non-NaN values
-        if pd.notna(noise_param):
-            noise_param_str = str(noise_param)
-            # Check if it's a simple numeric value (not a formula like "0.5;2")
-            try:
-                float(noise_param_str)
-                # It's numeric - add to map
-                noise_override_map[(time, obs_id)] = noise_param_str
-            except ValueError:
-                # Not a simple number (could be "0.5;2", "noise", etc.)
-                # Don't treat as timepoint-specific override
-                pass
+    noise_df = measurement_df.loc[
+        :, [OBSERVABLE_ID, TIME, NOISE_PARAMETERS]
+    ].copy()
+    noise_df["noise_value"] = noise_df[NOISE_PARAMETERS].map(_to_numeric)
 
-    # Check if noise values actually vary by timepoint for any observable
-    if noise_override_map:
-        for obs_id in observable_ids:
-            obs_noise_values = [
-                v for (t, o), v in noise_override_map.items() if o == obs_id
-            ]
-            if len(set(obs_noise_values)) > 1:
-                # This observable has different noise values at different timepoints
-                has_timepoint_specific = True
-                break
-
-    # If no timepoint-specific overrides, return 1D defaults
-    if not has_timepoint_specific:
+    # only observables whose numeric override actually differs across rows
+    # (timepoints or replicates) need to be expanded; a constant numeric
+    # override is equivalent to the existing per-observable default.
+    numeric_rows = noise_df.dropna(subset=["noise_value"])
+    n_unique = numeric_rows.groupby(OBSERVABLE_ID)["noise_value"].nunique()
+    variable_observables = set(n_unique[n_unique > 1].index)
+    if not variable_observables:
         return noise_distributions, noise_formulae
 
-    # Apply timepoint-specific overrides
-    for i_time, time in enumerate(timepoints):
-        for i_obs, obs_id in enumerate(observable_ids):
-            key = (time, obs_id)
-            if key in noise_override_map:
-                # Override the noise formula with the value from measurement table
-                noise_formulae_expanded[i_time, i_obs] = noise_override_map[
-                    key
-                ]
+    # Recreate the exact (time, count) row order used to build `measurements`
+    # (see `measurement_df_to_matrix`) so the noise grid lines up row-for-row
+    # with it, including replicate measurements sharing the same timepoint.
+    noise_df["count"] = noise_df.groupby([OBSERVABLE_ID, TIME]).cumcount()
+    pivot = noise_df.pivot(
+        index=[TIME, "count"], columns=OBSERVABLE_ID, values="noise_value"
+    )
+    pivot = pivot.reindex(columns=observable_ids)
+
+    n_timepoints = measurements.shape[0]
+    if pivot.shape[0] != n_timepoints:
+        raise ValueError(
+            f"Could not align timepoint-specific noise overrides "
+            f"({pivot.shape[0]} rows) with measurements ({n_timepoints} "
+            "rows)."
+        )
+
+    # Use dtype=object explicitly: a fixed-width numpy string dtype inferred
+    # from the (possibly short, e.g. "1") default formulae would silently
+    # truncate longer override values written into it later.
+    noise_formulae_expanded = np.empty(
+        (n_timepoints, len(observable_ids)), dtype=object
+    )
+    noise_distributions_expanded = np.empty(
+        (n_timepoints, len(observable_ids)), dtype=object
+    )
+    for i_obs, obs_id in enumerate(observable_ids):
+        noise_distributions_expanded[:, i_obs] = noise_distributions[i_obs]
+        if obs_id not in variable_observables:
+            noise_formulae_expanded[:, i_obs] = noise_formulae[i_obs]
+            continue
+        overrides = pivot[obs_id].to_numpy()
+        noise_formulae_expanded[:, i_obs] = [
+            noise_formulae[i_obs] if pd.isna(value) else value
+            for value in overrides
+        ]
 
     return noise_distributions_expanded, noise_formulae_expanded
 

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -662,25 +662,79 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
         for i_edata, (edata, par_map) in enumerate(
             zip(edatas, parameter_mapping, strict=True)
         ):
-            for j_formula, noise_formula in enumerate(edata.noise_formulae):
-                # constant values are allowed
-                if isinstance(noise_formula, numbers.Number):
-                    continue
-                # single parameters are allowed
-                if noise_formula in par_map[1].keys():
-                    continue
-                # extract the observable name via regex pattern
-                pattern = r"noiseParameter1_(.*?)($|\s)"
-                observable_name = re.search(pattern, noise_formula).group(1)
-                to_change.append((i_edata, j_formula, observable_name))
+            # Handle both 1D and 2D noise_formulae arrays
+            noise_formulae_array = edata.noise_formulae
+
+            # For 2D arrays, we need to handle each unique formula
+            if noise_formulae_array.ndim == 2:
+                # Get unique non-numeric formulae
+                unique_formulae = set()
+                for formula in noise_formulae_array.flatten():
+                    # Skip numbers
+                    try:
+                        float(formula)
+                        continue
+                    except (ValueError, TypeError):
+                        pass
+                    # Skip if already a simple parameter
+                    if formula not in par_map[1].keys():
+                        unique_formulae.add(formula)
+
+                # Process unique complex formulae
+                for noise_formula in unique_formulae:
+                    pattern = r"noiseParameter1_(.*?)($|\s)"
+                    match = re.search(pattern, noise_formula)
+                    if match:
+                        observable_name = match.group(1)
+                        to_change.append(
+                            (i_edata, noise_formula, observable_name)
+                        )
+            else:
+                # 1D case: process as before
+                for _j_formula, noise_formula in enumerate(
+                    noise_formulae_array
+                ):
+                    # constant values are allowed
+                    if isinstance(noise_formula, numbers.Number):
+                        continue
+                    # Try to convert string to number
+                    try:
+                        float(noise_formula)
+                        continue
+                    except (ValueError, TypeError):
+                        pass
+                    # single parameters are allowed
+                    if noise_formula in par_map[1].keys():
+                        continue
+                    # extract the observable name via regex pattern
+                    pattern = r"noiseParameter1_(.*?)($|\s)"
+                    match = re.search(pattern, noise_formula)
+                    if match:
+                        observable_name = match.group(1)
+                        to_change.append(
+                            (i_edata, noise_formula, observable_name)
+                        )
+
         # change formulae
         formulae_changed = []
-        for i_edata, j_formula, obs_name in to_change:
-            # assign new parameter, formula in RR and parameter into mapping
-            original_formula = edatas[i_edata].noise_formulae[j_formula]
-            edatas[i_edata].noise_formulae[j_formula] = (
-                f"noiseFormula_{obs_name}"
-            )
+        for i_edata, formula_to_replace, obs_name in to_change:
+            # For 2D arrays, replace all occurrences; for 1D, replace the specific one
+            if edatas[i_edata].noise_formulae.ndim == 2:
+                # Replace all occurrences of this formula in the 2D array
+                mask = edatas[i_edata].noise_formulae == formula_to_replace
+                edatas[i_edata].noise_formulae[mask] = (
+                    f"noiseFormula_{obs_name}"
+                )
+                original_formula = formula_to_replace
+            else:
+                # 1D case: use j_formula index (but we stored formula instead)
+                # Find the formula and replace it
+                mask = edatas[i_edata].noise_formulae == formula_to_replace
+                edatas[i_edata].noise_formulae[mask] = (
+                    f"noiseFormula_{obs_name}"
+                )
+                original_formula = formula_to_replace
+
             # different conditions will have the same noise formula
             if (obs_name, original_formula) not in formulae_changed:
                 self.rr.addParameter(f"noiseFormula_{obs_name}", 0.0, False)
@@ -760,6 +814,7 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
             parameter_df=self.petab_problem.parameter_df,
             observable_df=self.petab_problem.observable_df,
             model=self.petab_problem.model,
+            allow_timepoint_specific_numeric_noise_parameters=True,
         )
         # check whether any species in the condition table are assigned
         species = self.rr.model.getFloatingSpeciesIds()

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -658,6 +658,28 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
             edatas = self.create_edatas()
         # save formulae that need to be changed
         to_change = []
+
+        def _is_simple_value(formula, par_map):
+            """Check if formula is a simple numeric or parameter value."""
+            if isinstance(formula, numbers.Number):
+                return True
+            try:
+                float(formula)
+                return True
+            except (ValueError, TypeError):
+                return formula in par_map[1].keys()
+
+        def _extract_complex_formulae(formulae_iter, par_map):
+            """Extract formulae that need noiseFormula_ conversion."""
+            complex = []
+            for formula in formulae_iter:
+                if _is_simple_value(formula, par_map):
+                    continue
+                match = re.search(r"noiseParameter1_(.*?)($|\s)", formula)
+                if match:
+                    complex.append((formula, match.group(1)))
+            return complex
+
         # check that noise formulae are valid
         for i_edata, (edata, par_map) in enumerate(
             zip(edatas, parameter_mapping, strict=True)
@@ -665,55 +687,19 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
             # Handle both 1D and 2D noise_formulae arrays
             noise_formulae_array = edata.noise_formulae
 
-            # For 2D arrays, we need to handle each unique formula
-            if noise_formulae_array.ndim == 2:
-                # Get unique non-numeric formulae
-                unique_formulae = set()
-                for formula in noise_formulae_array.flatten():
-                    # Skip numbers
-                    try:
-                        float(formula)
-                        continue
-                    except (ValueError, TypeError):
-                        pass
-                    # Skip if already a simple parameter
-                    if formula not in par_map[1].keys():
-                        unique_formulae.add(formula)
+            # Flatten to iterate over all unique formulae
+            formulae_to_check = (
+                set(noise_formulae_array.flatten())
+                if noise_formulae_array.ndim == 2
+                else noise_formulae_array
+            )
 
-                # Process unique complex formulae
-                for noise_formula in unique_formulae:
-                    pattern = r"noiseParameter1_(.*?)($|\s)"
-                    match = re.search(pattern, noise_formula)
-                    if match:
-                        observable_name = match.group(1)
-                        to_change.append(
-                            (i_edata, noise_formula, observable_name)
-                        )
-            else:
-                # 1D case: process as before
-                for _j_formula, noise_formula in enumerate(
-                    noise_formulae_array
-                ):
-                    # constant values are allowed
-                    if isinstance(noise_formula, numbers.Number):
-                        continue
-                    # Try to convert string to number
-                    try:
-                        float(noise_formula)
-                        continue
-                    except (ValueError, TypeError):
-                        pass
-                    # single parameters are allowed
-                    if noise_formula in par_map[1].keys():
-                        continue
-                    # extract the observable name via regex pattern
-                    pattern = r"noiseParameter1_(.*?)($|\s)"
-                    match = re.search(pattern, noise_formula)
-                    if match:
-                        observable_name = match.group(1)
-                        to_change.append(
-                            (i_edata, noise_formula, observable_name)
-                        )
+            # Extract complex formulae that need conversion
+            complex_formulae = _extract_complex_formulae(
+                formulae_to_check, par_map
+            )
+            for formula, obs_name in complex_formulae:
+                to_change.append((i_edata, formula, obs_name))
 
         # change formulae
         formulae_changed = []

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -929,25 +929,79 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
         for i_edata, (edata, par_map) in enumerate(
             zip(edatas, parameter_mapping, strict=True)
         ):
-            for j_formula, noise_formula in enumerate(edata.noise_formulae):
-                # constant values are allowed
-                if isinstance(noise_formula, numbers.Number):
-                    continue
-                # single parameters are allowed
-                if noise_formula in par_map[1].keys():
-                    continue
-                # extract the observable name via regex pattern
-                pattern = r"noiseParameter1_(.*?)($|\s)"
-                observable_name = re.search(pattern, noise_formula).group(1)
-                to_change.append((i_edata, j_formula, observable_name))
+            # Handle both 1D and 2D noise_formulae arrays
+            noise_formulae_array = edata.noise_formulae
+
+            # For 2D arrays, we need to handle each unique formula
+            if noise_formulae_array.ndim == 2:
+                # Get unique non-numeric formulae
+                unique_formulae = set()
+                for formula in noise_formulae_array.flatten():
+                    # Skip numbers
+                    try:
+                        float(formula)
+                        continue
+                    except (ValueError, TypeError):
+                        pass
+                    # Skip if already a simple parameter
+                    if formula not in par_map[1].keys():
+                        unique_formulae.add(formula)
+
+                # Process unique complex formulae
+                for noise_formula in unique_formulae:
+                    pattern = r"noiseParameter1_(.*?)($|\s)"
+                    match = re.search(pattern, noise_formula)
+                    if match:
+                        observable_name = match.group(1)
+                        to_change.append(
+                            (i_edata, noise_formula, observable_name)
+                        )
+            else:
+                # 1D case: process as before
+                for _j_formula, noise_formula in enumerate(
+                    noise_formulae_array
+                ):
+                    # constant values are allowed
+                    if isinstance(noise_formula, numbers.Number):
+                        continue
+                    # Try to convert string to number
+                    try:
+                        float(noise_formula)
+                        continue
+                    except (ValueError, TypeError):
+                        pass
+                    # single parameters are allowed
+                    if noise_formula in par_map[1].keys():
+                        continue
+                    # extract the observable name via regex pattern
+                    pattern = r"noiseParameter1_(.*?)($|\s)"
+                    match = re.search(pattern, noise_formula)
+                    if match:
+                        observable_name = match.group(1)
+                        to_change.append(
+                            (i_edata, noise_formula, observable_name)
+                        )
+
         # change formulae
         formulae_changed = []
-        for i_edata, j_formula, obs_name in to_change:
-            # assign new parameter, formula in RR and parameter into mapping
-            original_formula = edatas[i_edata].noise_formulae[j_formula]
-            edatas[i_edata].noise_formulae[j_formula] = (
-                f"noiseFormula_{obs_name}"
-            )
+        for i_edata, formula_to_replace, obs_name in to_change:
+            # For 2D arrays, replace all occurrences; for 1D, replace the specific one
+            if edatas[i_edata].noise_formulae.ndim == 2:
+                # Replace all occurrences of this formula in the 2D array
+                mask = edatas[i_edata].noise_formulae == formula_to_replace
+                edatas[i_edata].noise_formulae[mask] = (
+                    f"noiseFormula_{obs_name}"
+                )
+                original_formula = formula_to_replace
+            else:
+                # 1D case: use j_formula index (but we stored formula instead)
+                # Find the formula and replace it
+                mask = edatas[i_edata].noise_formulae == formula_to_replace
+                edatas[i_edata].noise_formulae[mask] = (
+                    f"noiseFormula_{obs_name}"
+                )
+                original_formula = formula_to_replace
+
             # different conditions will have the same noise formula
             if (obs_name, original_formula) not in formulae_changed:
                 self.rr.addParameter(f"noiseFormula_{obs_name}", 0.0, False)
@@ -1027,6 +1081,7 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
             parameter_df=self.petab_problem.parameter_df,
             observable_df=self.petab_problem.observable_df,
             model=self.petab_problem.model,
+            allow_timepoint_specific_numeric_noise_parameters=True,
         )
         # check whether any species in the condition table are assigned
         species = self.rr.model.getFloatingSpeciesIds()

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -926,8 +926,24 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
         # save formulae that need to be changed
         to_change = []
 
-        def _is_simple_value(formula, par_map):
-            """Check if formula is a simple numeric or parameter value."""
+        def _is_simple_value(
+            formula: str | float, par_map: ParMappingDictQuadruple
+        ) -> bool:
+            """Check if a noise formula is a simple numeric or parameter value.
+
+            Parameters
+            ----------
+            formula:
+                Noise formula to check.
+            par_map:
+                Parameter mapping of the condition the formula belongs to.
+
+            Returns
+            -------
+            bool:
+                Whether the formula is a plain number or a known parameter
+                id, as opposed to a complex expression.
+            """
             if isinstance(formula, numbers.Number):
                 return True
             try:
@@ -936,16 +952,33 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
             except (ValueError, TypeError):
                 return formula in par_map[1].keys()
 
-        def _extract_complex_formulae(formulae_iter, par_map):
-            """Extract formulae that need noiseFormula_ conversion."""
-            complex = []
+        def _extract_complex_formulae(
+            formulae_iter: Iterable[str],
+            par_map: ParMappingDictQuadruple,
+        ) -> list[tuple[str, str]]:
+            """Extract noise formulae that require noiseFormula_ conversion.
+
+            Parameters
+            ----------
+            formulae_iter:
+                Noise formulae to check.
+            par_map:
+                Parameter mapping of the condition the formulae belong to.
+
+            Returns
+            -------
+            list:
+                ``(formula, observable_id)`` tuples for formulae that are not
+                simple values and reference an observable's noise parameter.
+            """
+            complex_formulae = []
             for formula in formulae_iter:
                 if _is_simple_value(formula, par_map):
                     continue
                 match = re.search(r"noiseParameter1_(.*?)($|\s)", formula)
                 if match:
-                    complex.append((formula, match.group(1)))
-            return complex
+                    complex_formulae.append((formula, match.group(1)))
+            return complex_formulae
 
         # check that noise formulae are valid
         for i_edata, (edata, par_map) in enumerate(
@@ -971,33 +1004,21 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
         # change formulae
         formulae_changed = []
         for i_edata, formula_to_replace, obs_name in to_change:
-            # For 2D arrays, replace all occurrences; for 1D, replace the specific one
-            if edatas[i_edata].noise_formulae.ndim == 2:
-                # Replace all occurrences of this formula in the 2D array
-                mask = edatas[i_edata].noise_formulae == formula_to_replace
-                edatas[i_edata].noise_formulae[mask] = (
-                    f"noiseFormula_{obs_name}"
-                )
-                original_formula = formula_to_replace
-            else:
-                # 1D case: use j_formula index (but we stored formula instead)
-                # Find the formula and replace it
-                mask = edatas[i_edata].noise_formulae == formula_to_replace
-                edatas[i_edata].noise_formulae[mask] = (
-                    f"noiseFormula_{obs_name}"
-                )
-                original_formula = formula_to_replace
+            # replace all occurrences of this formula; works for both 1D and
+            # 2D noise_formulae arrays
+            mask = edatas[i_edata].noise_formulae == formula_to_replace
+            edatas[i_edata].noise_formulae[mask] = f"noiseFormula_{obs_name}"
 
             # different conditions will have the same noise formula
-            if (obs_name, original_formula) not in formulae_changed:
+            if (obs_name, formula_to_replace) not in formulae_changed:
                 self.rr.addParameter(f"noiseFormula_{obs_name}", 0.0, False)
                 self.rr.addAssignmentRule(
                     f"noiseFormula_{obs_name}",
-                    original_formula,
+                    formula_to_replace,
                     forceRegenerate=False,
                 )
                 self.rr.regenerateModel()
-                formulae_changed.append((obs_name, original_formula))
+                formulae_changed.append((obs_name, formula_to_replace))
 
     def _write_observables_to_model(self):
         """Write observables of petab problem to the model."""

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -925,6 +925,28 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
             edatas = self.create_edatas()
         # save formulae that need to be changed
         to_change = []
+
+        def _is_simple_value(formula, par_map):
+            """Check if formula is a simple numeric or parameter value."""
+            if isinstance(formula, numbers.Number):
+                return True
+            try:
+                float(formula)
+                return True
+            except (ValueError, TypeError):
+                return formula in par_map[1].keys()
+
+        def _extract_complex_formulae(formulae_iter, par_map):
+            """Extract formulae that need noiseFormula_ conversion."""
+            complex = []
+            for formula in formulae_iter:
+                if _is_simple_value(formula, par_map):
+                    continue
+                match = re.search(r"noiseParameter1_(.*?)($|\s)", formula)
+                if match:
+                    complex.append((formula, match.group(1)))
+            return complex
+
         # check that noise formulae are valid
         for i_edata, (edata, par_map) in enumerate(
             zip(edatas, parameter_mapping, strict=True)
@@ -932,55 +954,19 @@ class RoadRunnerObjectiveCreator(ObjectiveCreator):
             # Handle both 1D and 2D noise_formulae arrays
             noise_formulae_array = edata.noise_formulae
 
-            # For 2D arrays, we need to handle each unique formula
-            if noise_formulae_array.ndim == 2:
-                # Get unique non-numeric formulae
-                unique_formulae = set()
-                for formula in noise_formulae_array.flatten():
-                    # Skip numbers
-                    try:
-                        float(formula)
-                        continue
-                    except (ValueError, TypeError):
-                        pass
-                    # Skip if already a simple parameter
-                    if formula not in par_map[1].keys():
-                        unique_formulae.add(formula)
+            # Flatten to iterate over all unique formulae
+            formulae_to_check = (
+                set(noise_formulae_array.flatten())
+                if noise_formulae_array.ndim == 2
+                else noise_formulae_array
+            )
 
-                # Process unique complex formulae
-                for noise_formula in unique_formulae:
-                    pattern = r"noiseParameter1_(.*?)($|\s)"
-                    match = re.search(pattern, noise_formula)
-                    if match:
-                        observable_name = match.group(1)
-                        to_change.append(
-                            (i_edata, noise_formula, observable_name)
-                        )
-            else:
-                # 1D case: process as before
-                for _j_formula, noise_formula in enumerate(
-                    noise_formulae_array
-                ):
-                    # constant values are allowed
-                    if isinstance(noise_formula, numbers.Number):
-                        continue
-                    # Try to convert string to number
-                    try:
-                        float(noise_formula)
-                        continue
-                    except (ValueError, TypeError):
-                        pass
-                    # single parameters are allowed
-                    if noise_formula in par_map[1].keys():
-                        continue
-                    # extract the observable name via regex pattern
-                    pattern = r"noiseParameter1_(.*?)($|\s)"
-                    match = re.search(pattern, noise_formula)
-                    if match:
-                        observable_name = match.group(1)
-                        to_change.append(
-                            (i_edata, noise_formula, observable_name)
-                        )
+            # Extract complex formulae that need conversion
+            complex_formulae = _extract_complex_formulae(
+                formulae_to_check, par_map
+            )
+            for formula, obs_name in complex_formulae:
+                to_change.append((i_edata, formula, obs_name))
 
         # change formulae
         formulae_changed = []

--- a/test/base/test_roadrunner.py
+++ b/test/base/test_roadrunner.py
@@ -30,9 +30,7 @@ def test_petab_case(case, model_type, version):
     try:
         _execute_case_rr(case, model_type, version)
     except Exception as e:
-        if isinstance(
-            e, NotImplementedError
-        ) or "Timepoint-specific parameter overrides" in str(e):
+        if isinstance(e, NotImplementedError):
             logger.info(
                 f"Case {case} expectedly failed. Required functionality is "
                 f"not implemented: {e}"
@@ -47,6 +45,10 @@ def _execute_case_rr(case, model_type, version):
     case = petabtests.test_id_str(case)
     if case == "0018" and model_type == "sbml" and version == "v1.0.0":
         pytest.skip("https://github.com/ICB-DCM/pyPESTO/issues/1597")
+    if case == "0006" and model_type == "sbml" and version == "v1.0.0":
+        pytest.skip(
+            "Case 0006: Timepoint-specific observable parameters not yet supported for roadrunner"
+        )
     logger.info(f"Case {case}")
 
     # case folder

--- a/test/base/test_roadrunner.py
+++ b/test/base/test_roadrunner.py
@@ -6,6 +6,7 @@ import os
 
 import benchmark_models_petab as models
 import numpy as np
+import pandas as pd
 import petab.v1 as petab
 import petabtests
 import pytest
@@ -13,6 +14,7 @@ import pytest
 import pypesto
 import pypesto.petab
 from pypesto.objective.roadrunner import simulation_to_measurement_df
+from pypesto.objective.roadrunner.utils import inject_timepoint_specific_noise
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -188,3 +190,156 @@ def test_multiprocessing():
             for fval in result.optimize_result.fval
         ]
     )
+
+
+def test_inject_timepoint_specific_noise_no_truncation():
+    """Timepoint-specific numeric noise overrides must not be silently
+    truncated by a fixed-width numpy string dtype inferred from the
+    (possibly short) default noise formula, e.g. "1"."""
+    noise_distributions = np.array(["lin_normal"])
+    noise_formulae = np.array(["1"])
+    observable_ids = ["obs_a"]
+    measurement_df = pd.DataFrame(
+        {
+            "observableId": ["obs_a", "obs_a"],
+            "time": [0, 10],
+            "measurement": [0.7, 0.1],
+            "noiseParameters": [5.0, 25.0],
+        }
+    )
+    measurements = np.array([[0, 0.7], [10, 0.1]])
+
+    _, noise_formulae_out = inject_timepoint_specific_noise(
+        noise_distributions,
+        noise_formulae,
+        measurement_df,
+        observable_ids,
+        measurements,
+    )
+
+    assert [float(v) for v in noise_formulae_out.ravel()] == [5.0, 25.0]
+
+
+def test_inject_timepoint_specific_noise_replicates():
+    """Replicate measurements at the same timepoint with different noise
+    overrides must keep their individual values, not collapse to a single
+    value shared by all replicates at that timepoint."""
+    noise_distributions = np.array(["lin_normal"])
+    noise_formulae = np.array(["1.0"])
+    observable_ids = ["obs_a"]
+    measurement_df = pd.DataFrame(
+        {
+            "observableId": ["obs_a", "obs_a", "obs_a"],
+            "time": [0, 0, 10],
+            "measurement": [0.7, 0.75, 0.1],
+            "noiseParameters": [3.0, 9.0, 3.0],
+        }
+    )
+    measurements = np.array([[0, 0.7], [0, 0.75], [10, 0.1]])
+
+    _, noise_formulae_out = inject_timepoint_specific_noise(
+        noise_distributions,
+        noise_formulae,
+        measurement_df,
+        observable_ids,
+        measurements,
+    )
+
+    assert [float(v) for v in noise_formulae_out.ravel()] == [3.0, 9.0, 3.0]
+
+
+def test_timepoint_specific_noise_end_to_end():
+    """A genuinely timepoint-varying numeric noise override, run through the
+    full roadrunner PEtab import pipeline, must match the log-likelihood
+    computed by petab's own (model-agnostic) reference implementation.
+
+    Regression test for the roadrunner-specific bugs in
+    ``inject_timepoint_specific_noise`` (silent string truncation, and
+    collapsing of replicate noise overrides): either would corrupt the
+    noise values used to simulate here and change the likelihood.
+    """
+    from petab.v1.C import (
+        CONDITION_ID,
+        ESTIMATE,
+        LIN,
+        LOWER_BOUND,
+        MEASUREMENT,
+        NOISE_FORMULA,
+        NOISE_PARAMETERS,
+        NOMINAL_VALUE,
+        OBSERVABLE_FORMULA,
+        OBSERVABLE_ID,
+        PARAMETER_ID,
+        PARAMETER_SCALE,
+        SIMULATION,
+        SIMULATION_CONDITION_ID,
+        TIME,
+        UPPER_BOUND,
+    )
+    from petab.v1.calculate import calculate_llh
+    from petab.v1.models.sbml_model import SbmlModel
+    from petabtests.C import DEFAULT_SBML_FILE
+    from petabtests.model import analytical_a
+
+    a0, b0, k1, k2 = 1, 0, 0.8, 0.6
+    times = [0, 5, 10]
+    # deliberately varying magnitude/digit-width noise values, and not a
+    # single shared value, to exercise both the truncation and the
+    # replicate-alignment paths.
+    noise_values = [0.2, 1.0, 3.0]
+
+    condition_df = pd.DataFrame({CONDITION_ID: ["c0"]}).set_index(CONDITION_ID)
+    measurement_df = pd.DataFrame(
+        {
+            OBSERVABLE_ID: ["obs_a"] * len(times),
+            SIMULATION_CONDITION_ID: ["c0"] * len(times),
+            TIME: times,
+            MEASUREMENT: [
+                analytical_a(t, a0, b0, k1, k2) + 0.01 for t in times
+            ],
+            NOISE_PARAMETERS: noise_values,
+        }
+    )
+    observable_df = pd.DataFrame(
+        {
+            OBSERVABLE_ID: ["obs_a"],
+            OBSERVABLE_FORMULA: ["A"],
+            NOISE_FORMULA: ["noiseParameter1_obs_a"],
+        }
+    ).set_index(OBSERVABLE_ID)
+    parameter_df = pd.DataFrame(
+        {
+            PARAMETER_ID: ["a0", "b0", "k1", "k2"],
+            PARAMETER_SCALE: [LIN] * 4,
+            LOWER_BOUND: [0] * 4,
+            UPPER_BOUND: [10] * 4,
+            NOMINAL_VALUE: [a0, b0, k1, k2],
+            ESTIMATE: [1] * 4,
+        }
+    ).set_index(PARAMETER_ID)
+
+    petab_problem = petab.Problem(
+        model=SbmlModel.from_file(DEFAULT_SBML_FILE),
+        condition_df=condition_df,
+        measurement_df=measurement_df,
+        observable_df=observable_df,
+        parameter_df=parameter_df,
+    )
+
+    simulation_df = measurement_df.rename(columns={MEASUREMENT: SIMULATION})
+    simulation_df[SIMULATION] = [
+        analytical_a(t, a0, b0, k1, k2) for t in times
+    ]
+    expected_llh = calculate_llh(
+        [measurement_df], [simulation_df], [observable_df], parameter_df
+    )
+
+    importer = pypesto.petab.PetabImporter(
+        petab_problem, simulator_type="roadrunner"
+    )
+    obj = importer.create_problem().objective
+    problem_parameters = petab_problem.x_nominal_free_scaled
+    ret = obj(problem_parameters, sensi_orders=(0,), return_dict=True)
+    llh = -ret["fval"]
+
+    assert llh == pytest.approx(expected_llh, rel=1e-6)

--- a/test/base/test_roadrunner.py
+++ b/test/base/test_roadrunner.py
@@ -248,15 +248,19 @@ def test_inject_timepoint_specific_noise_replicates():
     assert [float(v) for v in noise_formulae_out.ravel()] == [3.0, 9.0, 3.0]
 
 
-def test_timepoint_specific_noise_end_to_end():
-    """A genuinely timepoint-varying numeric noise override, run through the
-    full roadrunner PEtab import pipeline, must match the log-likelihood
-    computed by petab's own (model-agnostic) reference implementation.
+def test_timepoint_specific_noise_2d_with_symbolic_placeholder():
+    """When one observable's noise varies by timepoint (forcing the
+    per-condition noise array to 2D), another observable in the same
+    condition that still uses a *compound* noise formula referencing
+    ``noiseParameter1_x``/``noiseParameter2_x`` placeholders (constant
+    across timepoints, PEtab test case 0014 style) must still get that
+    formula registered as a ``noiseFormula_x`` roadrunner parameter -- a
+    bare placeholder name would instead resolve directly via the standard
+    PEtab parameter mapping, without ever reaching this registration code.
 
-    Regression test for the roadrunner-specific bugs in
-    ``inject_timepoint_specific_noise`` (silent string truncation, and
-    collapsing of replicate noise overrides): either would corrupt the
-    noise values used to simulate here and change the likelihood.
+    This exercises the ``noise_formulae_array.ndim == 2`` branch of
+    ``RoadRunnerObjectiveCreator._check_noise_formulae``, which the
+    purely-numeric test above never reaches.
     """
     from petab.v1.C import (
         CONDITION_ID,
@@ -279,32 +283,36 @@ def test_timepoint_specific_noise_end_to_end():
     from petab.v1.calculate import calculate_llh
     from petab.v1.models.sbml_model import SbmlModel
     from petabtests.C import DEFAULT_SBML_FILE
-    from petabtests.model import analytical_a
+    from petabtests.model import analytical_a, analytical_b
 
     a0, b0, k1, k2 = 1, 0, 0.8, 0.6
-    times = [0, 5, 10]
-    # deliberately varying magnitude/digit-width noise values, and not a
-    # single shared value, to exercise both the truncation and the
-    # replicate-alignment paths.
-    noise_values = [0.2, 1.0, 3.0]
+    times = [0, 10]
 
     condition_df = pd.DataFrame({CONDITION_ID: ["c0"]}).set_index(CONDITION_ID)
     measurement_df = pd.DataFrame(
         {
-            OBSERVABLE_ID: ["obs_a"] * len(times),
-            SIMULATION_CONDITION_ID: ["c0"] * len(times),
-            TIME: times,
+            OBSERVABLE_ID: ["obs_a", "obs_a", "obs_b", "obs_b"],
+            SIMULATION_CONDITION_ID: ["c0"] * 4,
+            TIME: times * 2,
             MEASUREMENT: [
                 analytical_a(t, a0, b0, k1, k2) + 0.01 for t in times
-            ],
-            NOISE_PARAMETERS: noise_values,
+            ]
+            + [analytical_b(t, a0, b0, k1, k2) + 0.01 for t in times],
+            # obs_a varies numerically by timepoint -> forces the array 2D.
+            # obs_b uses the same compound override at both timepoints ->
+            # stays an unresolved formula in that 2D array (matches PEtab
+            # test case 0014's "0.5;2" pattern).
+            NOISE_PARAMETERS: [0.2, 2.0, "0.1;0.2", "0.1;0.2"],
         }
     )
     observable_df = pd.DataFrame(
         {
-            OBSERVABLE_ID: ["obs_a"],
-            OBSERVABLE_FORMULA: ["A"],
-            NOISE_FORMULA: ["noiseParameter1_obs_a"],
+            OBSERVABLE_ID: ["obs_a", "obs_b"],
+            OBSERVABLE_FORMULA: ["A", "B"],
+            NOISE_FORMULA: [
+                "noiseParameter1_obs_a",
+                "noiseParameter1_obs_b + noiseParameter2_obs_b",
+            ],
         }
     ).set_index(OBSERVABLE_ID)
     parameter_df = pd.DataFrame(
@@ -329,7 +337,7 @@ def test_timepoint_specific_noise_end_to_end():
     simulation_df = measurement_df.rename(columns={MEASUREMENT: SIMULATION})
     simulation_df[SIMULATION] = [
         analytical_a(t, a0, b0, k1, k2) for t in times
-    ]
+    ] + [analytical_b(t, a0, b0, k1, k2) for t in times]
     expected_llh = calculate_llh(
         [measurement_df], [simulation_df], [observable_df], parameter_df
     )
@@ -338,6 +346,10 @@ def test_timepoint_specific_noise_end_to_end():
         petab_problem, simulator_type="roadrunner"
     )
     obj = importer.create_problem().objective
+
+    # the placeholder must have been registered as a roadrunner parameter
+    assert obj.roadrunner_instance.getValue("noiseFormula_obs_b") is not None
+
     problem_parameters = petab_problem.x_nominal_free_scaled
     ret = obj(problem_parameters, sensi_orders=(0,), return_dict=True)
     llh = -ret["fval"]


### PR DESCRIPTION
Previously we did not support timepoint specific noise voerrides for roadrunner. This was problematic for the Crauste Model. Should work now