### PR TITLE
Fix Hessian check in check_gradients_match_finite_differences

### DIFF
--- a/pypesto/objective/base.py
+++ b/pypesto/objective/base.py
@@ -552,12 +552,12 @@ class ObjectiveBase(ABC):
             # forward (plus) point
             x_p = copy.deepcopy(x)
             x_p[ix] += eps
-            fval_p = self(x_p, (0,), mode)
+            fval_p = self(x_p, (0 + order,), mode)
 
             # backward (minus) point
             x_m = copy.deepcopy(x)
             x_m[ix] -= eps
-            fval_m = self(x_m, (0,), mode)
+            fval_m = self(x_m, (0 + order,), mode)
 
             # finite differences
             fd_f_ix = (fval_p - fval) / eps
@@ -690,7 +690,9 @@ class ObjectiveBase(ABC):
         dfs = []
 
         if mode is None:
-            modes = [MODE_FUN, MODE_RES]
+            # second order derivatives (order == 1) are only defined for
+            # MODE_FUN (there are no second order residual sensitivities)
+            modes = [MODE_FUN] if order == 1 else [MODE_FUN, MODE_RES]
         else:
             modes = [mode]
 
@@ -705,6 +707,7 @@ class ObjectiveBase(ABC):
                         *args,
                         **kwargs,
                         mode=mode,
+                        order=order,
                         multi_eps=multi_eps,
                     )
                 )

--- a/pypesto/objective/base.py
+++ b/pypesto/objective/base.py
@@ -493,17 +493,20 @@ class ObjectiveBase(ABC):
         detailed: bool = False,
     ) -> pd.DataFrame:
         """
-        Compare gradient evaluation.
+        Compare an analytic derivative against finite differences.
 
-        Firstly approximate via finite differences, and secondly use the
-        objective gradient.
+        The derivative of order ``order + 1`` reported by the objective is
+        compared against finite differences of the derivative of order
+        ``order``. For ``order=0`` that is the gradient against finite
+        differences of the function value; for ``order=1`` the Hessian
+        against finite differences of the gradient.
 
         Parameters
         ----------
         x:
-            The parameters for which to evaluate the gradient.
+            The parameters for which to evaluate the derivatives.
         x_indices:
-            Indices for which to compute gradients. Default: all.
+            Indices for which to compute derivatives. Default: all.
         eps:
             Finite differences step size.
         verbosity:
@@ -515,25 +518,31 @@ class ObjectiveBase(ABC):
             Residual (MODE_RES) or objective function value (MODE_FUN)
             computation mode.
         order:
-            Derivative order, either gradient (0) or Hessian (1).
+            Derivative order to check, either gradient (0) or Hessian (1).
         detailed:
             Toggle whether additional values are returned. Additional values
-            are function values, and the central difference weighted by the
-            difference in output from all methods (standard deviation and
-            mean).
+            are the differenced quantity, and the central difference weighted
+            by the difference in output from all methods (standard deviation
+            and mean).
 
         Returns
         -------
         result:
-            gradient, finite difference approximations and error estimates.
+            The checked derivative, finite difference approximations and error
+            estimates. For historical reasons the column holding the checked
+            derivative is named ``grad`` and the columns holding the
+            differenced quantity are named ``fval``, ``fval_p`` and ``fval_m``
+            at every order, so at ``order=1`` ``grad`` holds Hessian columns
+            and ``fval`` holds the gradient.
         """
         if x_indices is None:
             x_indices = list(range(len(x)))
 
-        # function value and objective gradient
-        fval, grad = self(x, (0 + order, 1 + order), mode)
+        # derivatives of order `order` (differenced below) and `order + 1`
+        # (compared against those differences)
+        deriv_lo, deriv_hi = self(x, (order, order + 1), mode)
 
-        grad_list = []
+        deriv_hi_list = []
         fd_f_list = []
         fd_b_list = []
         fd_c_list = []
@@ -542,8 +551,8 @@ class ObjectiveBase(ABC):
         rel_err_list = []
 
         if detailed:
-            fval_p_list = []
-            fval_m_list = []
+            deriv_lo_p_list = []
+            deriv_lo_m_list = []
             std_check_list = []
             mean_check_list = []
 
@@ -552,31 +561,33 @@ class ObjectiveBase(ABC):
             # forward (plus) point
             x_p = copy.deepcopy(x)
             x_p[ix] += eps
-            fval_p = self(x_p, (0 + order,), mode)
+            deriv_lo_p = self(x_p, (order,), mode)
 
             # backward (minus) point
             x_m = copy.deepcopy(x)
             x_m[ix] -= eps
-            fval_m = self(x_m, (0 + order,), mode)
+            deriv_lo_m = self(x_m, (order,), mode)
 
             # finite differences
-            fd_f_ix = (fval_p - fval) / eps
-            fd_b_ix = (fval - fval_m) / eps
-            fd_c_ix = (fval_p - fval_m) / (2 * eps)
+            fd_f_ix = (deriv_lo_p - deriv_lo) / eps
+            fd_b_ix = (deriv_lo - deriv_lo_m) / eps
+            fd_c_ix = (deriv_lo_p - deriv_lo_m) / (2 * eps)
 
-            # gradient in direction ix
-            grad_ix = grad[ix] if grad.ndim == 1 else grad[:, ix]
+            # derivative of order `order + 1` in direction ix
+            deriv_hi_ix = (
+                deriv_hi[ix] if deriv_hi.ndim == 1 else deriv_hi[:, ix]
+            )
 
             # errors
             fd_err_ix = abs(fd_f_ix - fd_b_ix)
-            abs_err_ix = abs(grad_ix - fd_c_ix)
+            abs_err_ix = abs(deriv_hi_ix - fd_c_ix)
             rel_err_ix = abs(abs_err_ix / (fd_c_ix + eps))
 
             if detailed:
-                std_check_ix = (grad_ix - fd_c_ix) / np.std(
+                std_check_ix = (deriv_hi_ix - fd_c_ix) / np.std(
                     [fd_f_ix, fd_b_ix, fd_c_ix]
                 )
-                mean_check_ix = abs(grad_ix - fd_c_ix) / np.mean(
+                mean_check_ix = abs(deriv_hi_ix - fd_c_ix) / np.mean(
                     [
                         abs(fd_f_ix - fd_b_ix),
                         abs(fd_f_ix - fd_c_ix),
@@ -588,7 +599,7 @@ class ObjectiveBase(ABC):
             if verbosity > 1:
                 logger.info(
                     f"index:    {ix}\n"
-                    f"grad:     {grad_ix}\n"
+                    f"grad:     {deriv_hi_ix}\n"
                     f"fd_f:     {fd_f_ix}\n"
                     f"fd_b:     {fd_b_ix}\n"
                     f"fd_c:     {fd_c_ix}\n"
@@ -598,7 +609,7 @@ class ObjectiveBase(ABC):
                 )
 
             # append to lists
-            grad_list.append(grad_ix)
+            deriv_hi_list.append(deriv_hi_ix)
             fd_f_list.append(fd_f_ix)
             fd_b_list.append(fd_b_ix)
             fd_c_list.append(fd_c_ix)
@@ -606,14 +617,14 @@ class ObjectiveBase(ABC):
             abs_err_list.append(np.mean(abs_err_ix))
             rel_err_list.append(np.mean(rel_err_ix))
             if detailed:
-                fval_p_list.append(fval_p)
-                fval_m_list.append(fval_m)
+                deriv_lo_p_list.append(deriv_lo_p)
+                deriv_lo_m_list.append(deriv_lo_m)
                 std_check_list.append(std_check_ix)
                 mean_check_list.append(mean_check_ix)
 
         # create data dictionary for dataframe
         data = {
-            "grad": grad_list,
+            "grad": deriv_hi_list,
             "fd_f": fd_f_list,
             "fd_b": fd_b_list,
             "fd_c": fd_c_list,
@@ -625,9 +636,9 @@ class ObjectiveBase(ABC):
         # update data dictionary if detailed output is requested
         if detailed:
             prefix_data = {
-                "fval": [fval] * len(x_indices),
-                "fval_p": fval_p_list,
-                "fval_m": fval_m_list,
+                "fval": [deriv_lo] * len(x_indices),
+                "fval_p": deriv_lo_p_list,
+                "fval_m": deriv_lo_m_list,
             }
             std_str = "(grad-fd_c)/std({fd_f,fd_b,fd_c})"
             mean_str = "|grad-fd_c|/mean(|fd_f-fd_b|,|fd_f-fd_c|,|fd_b-fd_c|)"
@@ -668,13 +679,12 @@ class ObjectiveBase(ABC):
 
         Parameters
         ----------
-        rtol: relative error tolerance
-        x: The parameters for which to evaluate the gradient
-        x_free: Indices for which to compute gradients
+        x: The parameters for which to evaluate the derivatives
+        x_free: Indices for which to compute derivatives
         rtol: relative error tolerance
         atol: absolute error tolerance
         mode: function values or residuals
-        order: gradient order, 0 for gradient, 1 for hessian
+        order: derivative order to check, 0 for gradient, 1 for Hessian
         multi_eps: multiple test step width for FDs
 
         Returns


### PR DESCRIPTION
## What

`ObjectiveBase.check_gradients_match_finite_differences` accepted an `order` argument (documented as "0 for gradient, 1 for hessian") but never forwarded it, so `order=1` silently re-ran the order-0 gradient check. Forwarding it alone was not enough — `check_grad` had the same class of bug underneath.

Three changes in `pypesto/objective/base.py`:

1. **`check_grad`**: the perturbed points now evaluate sensitivity order `(0 + order,)` instead of always `(0,)`. Since 074078e the base point has been evaluated at `(0 + order, 1 + order)` while the perturbed points stayed at `(0,)`, so an `order=1` check compared Hessian columns against finite differences of the *function value* rather than the gradient. For a `normal(1, 1)` prior at x = 0.5 it compared `hess = 1.0` against `fd_c = -0.5`.
2. **`check_gradients_match_finite_differences`**: forwards `order=order` to `check_grad_multi_eps`.
3. Same function: with `mode=None` and `order=1`, only `MODE_FUN` is checked. There are no second-order residual sensitivities, so `MODE_RES` would raise, get swallowed by the existing `try/except`, and be reported as a derivative mismatch.

## Why

`test/base/test_prior.py::test_derivatives` asserts the `order=1` check passes, believing it validates the priors' second derivatives. It did not — it re-ran the gradient check. The Hessian check now genuinely runs.

## The priors were fine

Forwarding `order` initially failed 23 `test_derivatives` parametrizations, which looked like broken prior second derivatives. It wasn't. Probing all 21 prior-type x scale combinations directly — analytic `density_ddx` against central differences of `density_dx`, bypassing `check_grad` entirely — the worst deviation is 4e-5 (logNormal/lin). The chain-rule transforms for log and log10 scales are correct. The failures came entirely from the broken `order=1` comparison.

## Verification

- `test/base/test_prior.py`: 90 passed, with the Hessian check actually running.
- `test/base/test_objective.py` (the direct `check_grad` / `check_grad_multi_eps` consumers, all `order=0`): 62 passed, 8 skipped.
- The check now has teeth: a prior with `density_ddx` corrupted to -5 instead of -1 is rejected at `order=1` while still passing at `order=0`.
- `order=0` — every existing caller in the repo — is byte-identical. No caller passes `order` explicitly.

## For the reviewer

Making `order=1` real changes behavior for two categories of objective that previously got a free pass, and neither is covered by the test suite:

- **Objectives without Hessian support** (adjoint AMICI, JAX, `PetabSimulatorObjective`). `order=1` now requests sensi orders `(1, 2)`, `__call__` raises `ValueError`, and the blanket `except (RuntimeError, ValueError): return False` reports it as "derivatives don't match" rather than "unsupported". Previously such a call silently ran an order-0 check and returned `True`.
- **`AmiciObjective` with the default `fim_for_hess=True`**, where sensi order 2 in `MODE_FUN` returns the Fisher information matrix (`rdata["FIM"]`), not the true Hessian. An `order=1` check compares finite differences of the gradient against the FIM, which agree only at a residual-free fit.

Neither is introduced by this PR — both were latent behind the dropped argument — but `order=1` should not be adopted for those objectives until the swallow at `base.py:714` distinguishes "unsupported" from "mismatched". Happy to address that here if preferred.

Also worth knowing: with `order=1` the per-index errors are whole Hessian columns collapsed with `np.mean` before the tolerance test, so a single wrong entry is diluted by the correct ones. At 400 parameters a Hessian entry that is 200% wrong still passes; at 60 it is caught. Fine for the diagonal prior Hessians here, weaker than it looks for large models.

## Base branch

Targeting `develop`, matching every recent merged PR. `main` is 26 commits behind and would have produced a 27-commit diff.
