### PR TITLE
Fix `x_free` handling in `check_gradients_match_finite_differences`

### DIFF
--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -667,9 +667,23 @@ class AmiciObjective(ObjectiveBase):
             Indicates whether gradients match (True) FDs or not (False)
         """
         if x is None and "petab_problem" in dir(self.amici_object_builder):
-            x = self.amici_object_builder.petab_problem.x_nominal_scaled
-            kwargs["x_free"] = (
-                self.amici_object_builder.petab_problem.x_free_indices
+            petab_problem = self.amici_object_builder.petab_problem
+            # parameters fixed in the `Problem` are not part of this
+            #  objective's parameter vector, so drop them from the nominal
+            #  values and map the free-parameter indices accordingly
+            x_full = np.asarray(petab_problem.x_nominal_scaled)
+            x = self.pre_post_processor.reduce(x_full)
+            input_to_full = self.pre_post_processor.reduce(
+                np.arange(len(x_full))
+            )
+            free = set(petab_problem.x_free_indices)
+            kwargs.setdefault(
+                "x_free",
+                [
+                    ix
+                    for ix, ix_full in enumerate(input_to_full)
+                    if ix_full in free
+                ],
             )
         return super().check_gradients_match_finite_differences(
             *args, x=x, **kwargs
@@ -846,14 +860,22 @@ class AmiciPetabV2Objective(AmiciObjective):
         if x is None:
             # PEtab v2 does not have parameter scales
             x_nominal = self.petab_problem.get_x_nominal_dict()
-            x = np.array([x_nominal[x_id] for x_id in self.x_ids])
+            x_full = np.array([x_nominal[x_id] for x_id in self.x_ids])
             x_free_ids = set(self.petab_problem.x_free_ids)
+            free = {
+                ix for ix, x_id in enumerate(self.x_ids) if x_id in x_free_ids
+            }
+            # see `AmiciObjective.check_gradients_match_finite_differences`
+            x = self.pre_post_processor.reduce(x_full)
+            input_to_full = self.pre_post_processor.reduce(
+                np.arange(len(x_full))
+            )
             kwargs.setdefault(
                 "x_free",
                 [
                     ix
-                    for ix, x_id in enumerate(self.x_ids)
-                    if x_id in x_free_ids
+                    for ix, ix_full in enumerate(input_to_full)
+                    if ix_full in free
                 ],
             )
         return ObjectiveBase.check_gradients_match_finite_differences(

--- a/pypesto/objective/base.py
+++ b/pypesto/objective/base.py
@@ -668,9 +668,11 @@ class ObjectiveBase(ABC):
 
         Parameters
         ----------
-        rtol: relative error tolerance
-        x: The parameters for which to evaluate the gradient
-        x_free: Indices for which to compute gradients
+        x: The parameters for which to evaluate the gradient. Has to be given
+            in this objective's parameter space, i.e. without the parameters
+            that are fixed in the :class:`pypesto.Problem`.
+        x_free: Indices of ``x`` for which to compute gradients.
+            Default: all.
         rtol: relative error tolerance
         atol: absolute error tolerance
         mode: function values or residuals
@@ -683,10 +685,10 @@ class ObjectiveBase(ABC):
             Indicates whether gradients match (True) FDs or not (False)
         """
         par = np.asarray(x)
-        if x_free is None:
-            free_indices = par
-        else:
-            free_indices = par[x_free]
+        if x_free is not None:
+            # the objective is evaluated at the full vector `x`; finite
+            #  differences are only computed for the `x_free` indices
+            kwargs["x_indices"] = x_free
         dfs = []
 
         if mode is None:
@@ -701,7 +703,7 @@ class ObjectiveBase(ABC):
             try:
                 dfs.append(
                     self.check_grad_multi_eps(
-                        free_indices,
+                        par,
                         *args,
                         **kwargs,
                         mode=mode,

--- a/test/base/test_objective.py
+++ b/test/base/test_objective.py
@@ -178,6 +178,44 @@ def test_finite_difference_checks():
     )
 
 
+def test_check_gradients_match_finite_differences_x_free():
+    """Test the FD gradient check with a subset of free parameter indices.
+
+    Regression test: ``x_free`` used to be applied to the parameter vector
+    itself before calling the objective, so objectives that require the
+    full-length parameter vector raised -- and the check reported a gradient
+    mismatch -- whenever ``x_free`` was a strict subset of the parameters.
+    """
+    n = 5
+    c = np.arange(1.0, n + 1.0)
+    x = np.linspace(0.5, 1.5, n)
+    x_free = [1, 3]
+
+    # `fun` and `grad` require the full-length parameter vector
+    #  (like, e.g., AmiciObjective)
+    objective = pypesto.Objective(
+        fun=lambda x: c @ x**2,
+        grad=lambda x: 2 * c * x,
+    )
+    assert objective.check_gradients_match_finite_differences(
+        x=x, x_free=x_free, mode=pypesto.C.MODE_FUN, verbosity=0
+    )
+
+    # gradient errors in components that are not checked are not detected ...
+    e_0 = np.eye(n)[0]
+    objective_wrong_grad = pypesto.Objective(
+        fun=lambda x: c @ x**2,
+        grad=lambda x: 2 * c * x + e_0,
+    )
+    assert objective_wrong_grad.check_gradients_match_finite_differences(
+        x=x, x_free=x_free, mode=pypesto.C.MODE_FUN, verbosity=0
+    )
+    # ... while errors in the checked components are
+    assert not objective_wrong_grad.check_gradients_match_finite_differences(
+        x=x, x_free=[0, 1], mode=pypesto.C.MODE_FUN, verbosity=0
+    )
+
+
 @pytest.mark.parametrize("enable_x64", [True, False])
 @pytest.mark.parametrize("fix_parameters", [True, False])
 @pytest.mark.flaky(reruns=2)


### PR DESCRIPTION
## Problem

`ObjectiveBase.check_gradients_match_finite_differences` used `x_free` to slice the parameter vector and passed the result on as the full `x`:

```python
free_indices = par[x_free]
...
self.check_grad_multi_eps(free_indices, ...)
```

So whenever `x_free` was a strict subset of the parameters, the objective was called with a wrong-length vector. For `AmiciObjective` the strict `zip` in `par_arr_to_dct` raises `ValueError`, which is swallowed by

```python
except (RuntimeError, ValueError):
    return False
```

and the check silently reported a **gradient mismatch** instead of failing. Reproducible with the Boehm PEtab v2 problem (2 PEtab-fixed parameters), where `objective.check_gradients_match_finite_differences(mode="mode_fun")` returned `False` while `objective.check_grad(x, x_indices=free_indices)` showed matching gradients.

The defect dates back to c0df8d6 (#690).

## Change

- `x_free` is forwarded as `check_grad`'s `x_indices`: the objective is evaluated at the full `x`, and finite differences are computed only for the selected indices.
- The `AmiciObjective` / `AmiciPetabV2Objective` defaults are mapped into the objective's parameter space, so parameters fixed in the `Problem` are part of neither the nominal vector nor the indices. Without this the problem-normalized objectives would break — they happened to work before, because slicing produced exactly their reduced input.
- Regression test with a cheap non-AMICI objective whose `fun`/`grad` require the full-length vector.

## Verification

- `test/base/test_objective.py`, `test/base/test_prior.py`: 153 passed, 8 skipped.
- `test/petab/test_petab_import.py::PetabImportTest::test_check_gradients` and `::test_plist_mapping`: passed.
- Boehm PEtab v2, default eps sweep: raw objective and problem-normalized objective both `True` (was `False` for the raw one).

## Not addressed here

Found while working on this, each a separate silent-wrong-answer bug in the same method:

- `order` is documented as selecting the derivative order but is never forwarded, so `order=1` checks the gradient and reports it as a Hessian check (`test_prior.py::test_derivatives` asserts this). Forwarding it makes 23 parametrizations fail, so it needs its own investigation.
- An integer-valued `x` truncates the finite-difference step, giving a false mismatch.
- The default `mode=None` returns `False` for any objective without residuals.
- `multi_eps=[]` raises `AttributeError` on a `None` result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)