### PR TITLE
Hierarchical optimization for the PEtab v2 importer

### DIFF
--- a/pypesto/hierarchical/__init__.py
+++ b/pypesto/hierarchical/__init__.py
@@ -24,4 +24,7 @@ finding optimal values more efficiently and reliably.
 from .base_parameter import InnerParameter
 from .base_problem import InnerProblem
 from .base_solver import InnerSolver
-from .inner_calculator_collector import InnerCalculatorCollector
+from .inner_calculator_collector import (
+    InnerCalculatorCollector,
+    InnerCalculatorCollectorPetabV2,
+)

--- a/pypesto/hierarchical/inner_calculator_collector.py
+++ b/pypesto/hierarchical/inner_calculator_collector.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 import copy
 import warnings
 from collections.abc import Sequence
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
+
+if TYPE_CHECKING:
+    import amici.sim.sundials.petab
+    from petab import v2
 
 from ..C import (
     AMICI_SIGMAY,
@@ -43,6 +47,7 @@ from ..objective.amici.amici_util import (
     filter_return_dict,
     init_return_values,
     par_index_slices,
+    petab_v2_index_slices,
 )
 
 try:
@@ -664,6 +669,204 @@ class InnerCalculatorCollector(AmiciCalculator):
             fim_for_hess=fim_for_hess,
             index_slices=self._index_slices,
         )
+
+
+class InnerCalculatorCollectorPetabV2(InnerCalculatorCollector):
+    """Class to collect inner calculators for PEtab v2 problems.
+
+    PEtab v2 counterpart of :class:`InnerCalculatorCollector`, for use with
+    :class:`pypesto.objective.amici.amici.AmiciPetabV2Objective`. Simulations
+    are delegated to the :class:`amici.sim.sundials.petab.PetabSimulator`,
+    which maps the PEtab problem parameters to the model parameters. Only
+    relative (and quantitative) data are supported.
+
+    Parameters
+    ----------
+    data_types:
+        List of non-quantitative data types in the problem.
+    petab_simulator:
+        The PEtab simulator of the :class:`AmiciPetabV2Objective` this
+        calculator belongs to.
+    inner_options:
+        Options for the inner problems and solvers.
+    """
+
+    def __init__(
+        self,
+        data_types: set[str],
+        petab_simulator: amici.sim.sundials.petab.PetabSimulator,
+        inner_options: dict,
+    ):
+        from ..objective.amici.amici_calculator import AmiciCalculatorPetabV2
+
+        self.petab_simulator = petab_simulator
+        #: plain (non-hierarchical) evaluation of the PEtab v2 problem
+        self._evaluator = AmiciCalculatorPetabV2(petab_simulator)
+
+        edatas = petab_simulator.exp_man.create_edatas()
+        super().__init__(
+            data_types=data_types,
+            petab_problem=petab_simulator.exp_man.petab_problem,
+            model=petab_simulator.model,
+            edatas=edatas,
+            inner_options=inner_options,
+        )
+        #: the ``ExpData`` objects the index slices are built against
+        self._edatas = edatas
+
+    @property
+    def free_parameter_ids(self) -> set[str] | None:
+        """IDs of the parameters that are free in the pyPESTO problem.
+
+        See :class:`AmiciCalculatorPetabV2`.
+        """
+        return self._evaluator.free_parameter_ids
+
+    @free_parameter_ids.setter
+    def free_parameter_ids(self, value: set[str] | None) -> None:
+        self._evaluator.free_parameter_ids = value
+
+    def construct_inner_calculators(
+        self,
+        petab_problem: v2.Problem,
+        model: AmiciModel,
+        edatas: list[asd.ExpData],
+        inner_options: dict,
+    ):
+        """Construct inner calculators for each data type."""
+        self.necessary_par_dummy_values = {}
+
+        if unsupported_data_types := self.data_types - {RELATIVE}:
+            raise NotImplementedError(
+                f"Data types {unsupported_data_types} are not yet supported "
+                "for PEtab v2 problems."
+            )
+
+        if RELATIVE in self.data_types:
+            relative_inner_problem = RelativeInnerProblem.from_petab_v2_amici(
+                petab_problem, model, edatas
+            )
+            self.necessary_par_dummy_values.update(
+                relative_inner_problem.get_dummy_values(scaled=True)
+            )
+            self.inner_calculators.append(
+                RelativeAmiciCalculator(
+                    inner_problem=relative_inner_problem,
+                    # PEtab v2 is simulated through the PEtab simulator, not
+                    #  the v1 parameter-mapping machinery of the base class
+                    evaluator=self._evaluator,
+                )
+            )
+            self.relative_observable_ids = (
+                relative_inner_problem.get_relative_observable_ids()
+            )
+
+    def _inner_only_result(
+        self,
+        x_dct: dict,
+        sensi_orders: tuple[int],
+        mode: ModeType,
+        amici_model: AmiciModel,
+        amici_solver: AmiciSolver,
+        edatas: list[asd.ExpData],
+        n_threads: int,
+        x_ids: Sequence[str],
+        parameter_mapping: ParameterMapping,
+        fim_for_hess: bool,
+    ) -> dict | None:
+        """See :meth:`InnerCalculatorCollector._inner_only_result`.
+
+        Unlike the PEtab v1 dispatch, this one also requires a gradient
+        before it takes the adjoint route.
+        """
+        if not (
+            (
+                1 in sensi_orders
+                and amici_solver.get_sensitivity_method()
+                == asd.SensitivityMethod.adjoint
+            )
+            or 2 in sensi_orders
+            or mode == MODE_RES
+        ):
+            return None
+
+        # `PetabSimulator.simulate` fills missing parameters from the
+        #  nominal values, so the inner parameters need dummy values
+        x_dct = x_dct | self.necessary_par_dummy_values
+        # the relative calculator owns the simulate-solve-simulate scheme
+        #  and evaluates through the injected evaluator. It is called
+        #  directly rather than through `__call__`, whose own dispatch
+        #  does not route residual mode here.
+        relative_calculator = self.inner_calculators[0]
+        inner_result, inner_parameters = relative_calculator.call_amici_twice(
+            x_dct=x_dct,
+            sensi_orders=sensi_orders,
+            mode=mode,
+            amici_model=amici_model,
+            amici_solver=amici_solver,
+            edatas=edatas,
+            n_threads=n_threads,
+            x_ids=x_ids,
+            parameter_mapping=parameter_mapping,
+            fim_for_hess=fim_for_hess,
+        )
+        inner_result[INNER_PARAMETERS] = (
+            np.array(
+                [
+                    inner_parameters[x_id]
+                    for x_id in relative_calculator.inner_problem.get_x_ids()
+                ]
+            )
+            if inner_parameters is not None
+            else None
+        )
+        return inner_result
+
+    def _simulate(
+        self,
+        x_dct: dict,
+        sensi_orders: tuple[int],
+        mode: ModeType,
+        amici_model: AmiciModel,
+        amici_solver: AmiciSolver,
+        edatas: list[asd.ExpData],
+        n_threads: int,
+        x_ids: Sequence[str],
+        parameter_mapping: ParameterMapping,
+        fim_for_hess: bool,
+    ) -> tuple[list[asd.ReturnDataView], dict | None]:
+        """See :meth:`InnerCalculatorCollector._simulate`.
+
+        The PEtab simulator handles the parameter mapping, so
+        ``parameter_mapping`` is unused.
+        """
+        if self._index_slices is None:
+            self._index_slices = petab_v2_index_slices(
+                petab_problem=self.petab_simulator.exp_man.petab_problem,
+                par_sim_ids=self.petab_simulator.model.get_free_parameter_ids(),
+                edatas=self._edatas,
+                par_opt_ids=x_ids,
+            )
+            for calculator in self.inner_calculators:
+                calculator.index_slices = self._index_slices
+
+        ret = self._evaluator(
+            x_dct=x_dct,
+            sensi_orders=sensi_orders,
+            mode=mode,
+            amici_model=amici_model,
+            amici_solver=amici_solver,
+            edatas=edatas,
+            n_threads=n_threads,
+            x_ids=x_ids,
+            parameter_mapping=parameter_mapping,
+            fim_for_hess=fim_for_hess,
+        )
+        rdatas = ret[RDATAS]
+        # if any simulation failed, meaningful inner parameters are unlikely
+        if any(rdata.status != asd.AMICI_SUCCESS for rdata in rdatas):
+            return rdatas, ret
+        return rdatas, None
 
 
 def calculate_quantitative_result(

--- a/pypesto/hierarchical/relative/calculator.py
+++ b/pypesto/hierarchical/relative/calculator.py
@@ -294,30 +294,40 @@ class RelativeAmiciCalculator(AmiciCalculator):
             scaled=True,
         )
 
-        # Fill the optimal values into the parameter mapping rather than
-        #  into `x_dct`. Mapping a simulation parameter to a value instead of
-        #  to an id keeps it out of AMICI's plist, so the second simulation
-        #  differentiates with respect to the outer parameters only. Without
-        #  this, sigmas solved for hierarchically look parameter-dependent to
-        #  the least-squares check in `AmiciCalculator.__call__`.
-        inner_values = scale_back_value_dict(
-            inner_parameters, self.inner_problem
-        )
-        parameter_mapping = copy.deepcopy(parameter_mapping)
-        for condition_mapping in parameter_mapping:
-            for sim_par, mapped in list(condition_mapping.map_sim_var.items()):
-                if isinstance(mapped, str) and mapped in inner_values:
-                    condition_mapping.map_sim_var[sim_par] = inner_values[
-                        mapped
-                    ]
-                    condition_mapping.scale_map_sim_var[sim_par] = LIN
-        # the inner parameters are no longer referenced by the mapping, so
-        #  leaving them in `x_dct` would make them unused problem parameters
-        x_dct = {
-            par_id: value
-            for par_id, value in x_dct.items()
-            if par_id not in inner_values
-        }
+        if self.evaluator is not None:
+            # The evaluator simulates from `x_dct` and ignores the PEtab v1
+            #  parameter mapping, so the optimal values have to go there. Its
+            #  plist comes from the problem's free parameters, which exclude
+            #  the inner ones, so the mapping rewrite below is unnecessary.
+            x_dct = copy.deepcopy(x_dct)
+            x_dct.update(inner_parameters)
+        else:
+            # Fill the optimal values into the parameter mapping rather than
+            #  into `x_dct`. Mapping a simulation parameter to a value instead of
+            #  to an id keeps it out of AMICI's plist, so the second simulation
+            #  differentiates with respect to the outer parameters only. Without
+            #  this, sigmas solved for hierarchically look parameter-dependent to
+            #  the least-squares check in `AmiciCalculator.__call__`.
+            inner_values = scale_back_value_dict(
+                inner_parameters, self.inner_problem
+            )
+            parameter_mapping = copy.deepcopy(parameter_mapping)
+            for condition_mapping in parameter_mapping:
+                for sim_par, mapped in list(
+                    condition_mapping.map_sim_var.items()
+                ):
+                    if isinstance(mapped, str) and mapped in inner_values:
+                        condition_mapping.map_sim_var[sim_par] = inner_values[
+                            mapped
+                        ]
+                        condition_mapping.scale_map_sim_var[sim_par] = LIN
+            # the inner parameters are no longer referenced by the mapping, so
+            #  leaving them in `x_dct` would make them unused problem parameters
+            x_dct = {
+                par_id: value
+                for par_id, value in x_dct.items()
+                if par_id not in inner_values
+            }
 
         # TODO use plist to compute only required derivatives, in
         #  `super.__call__`, `amici.parameter_mapping.fill_in_parameters`

--- a/pypesto/hierarchical/relative/problem.py
+++ b/pypesto/hierarchical/relative/problem.py
@@ -5,6 +5,7 @@ import logging
 import pandas as pd
 
 from ...C import (
+    LIN,
     MEASUREMENT_TYPE,
     PARAMETER_TYPE,
     SEMIQUANTITATIVE,
@@ -20,8 +21,10 @@ from .parameter import RelativeInnerParameter
 try:
     import amici.sim.sundials as asd
     import petab.v1 as petab
+    from petab import v2
     from petab.v1.C import (
         ESTIMATE,
+        LIN,
         LOWER_BOUND,
         NOISE_PARAMETERS,
         OBSERVABLE_ID,
@@ -31,6 +34,7 @@ try:
         TIME,
         UPPER_BOUND,
     )
+    from petab.v2.C import EXPERIMENT_ID
 except ImportError:
     pass
 
@@ -62,6 +66,31 @@ class RelativeInnerProblem(AmiciInnerProblem):
     ) -> "RelativeInnerProblem":
         """Create an InnerProblem from a PEtab problem and AMICI objects."""
         return inner_problem_from_petab_problem(
+            petab_problem, amici_model, edatas
+        )
+
+    @staticmethod
+    def from_petab_v2_amici(
+        petab_problem: "v2.Problem",
+        amici_model: "asd.Model",
+        edatas: list["asd.ExpData"],
+    ) -> "RelativeInnerProblem":
+        """Create an InnerProblem from a PEtab v2 problem and AMICI objects.
+
+        Parameters
+        ----------
+        petab_problem:
+            The PEtab v2 problem, as used by the
+            :class:`amici.sim.sundials.petab.ExperimentManager` that created
+            ``edatas`` (i.e., the problem preprocessed by the AMICI PEtab
+            importer).
+        amici_model:
+            The AMICI model.
+        edatas:
+            The experimental data, one per PEtab experiment, in the order of
+            ``petab_problem.experiments``.
+        """
+        return inner_problem_from_petab_v2_problem(
             petab_problem, amici_model, edatas
         )
 
@@ -158,7 +187,30 @@ def inner_problem_from_petab_problem(
         )
     }
 
-    # Check each group is of length 2
+    assign_coupled_pairs(inner_parameters, coupled_pars)
+
+    return RelativeInnerProblem(xs=inner_parameters, data=data, edatas=edatas)
+
+
+def assign_coupled_pairs(
+    inner_parameters: list[RelativeInnerParameter],
+    coupled_pars: set[tuple[str, ...]],
+    strict: bool = False,
+) -> None:
+    """Link each scaling to the offset it shares a measurement with.
+
+    Parameters
+    ----------
+    inner_parameters:
+        The inner parameters, modified in place.
+    coupled_pars:
+        Groups of observable-parameter overrides that contain both a scaling
+        and an offset.
+    strict:
+        Raise if a group's partner is not among ``inner_parameters``. For
+        PEtab v1 the partner is always present; for PEtab v2 a pair may be
+        only partially estimated, which cannot be solved for analytically.
+    """
     for group in coupled_pars:
         if len(group) != 2:
             raise ValueError(
@@ -168,7 +220,6 @@ def inner_problem_from_petab_problem(
 
     id_to_par = {par.inner_parameter_id: par for par in inner_parameters}
 
-    # assign coupling
     for par in inner_parameters:
         if par.inner_parameter_type not in [
             InnerParameterType.SCALING,
@@ -180,10 +231,14 @@ def inner_problem_from_petab_problem(
                 coupled_parameter_id = group[
                     group.index(par.inner_parameter_id) - 1
                 ]
+                if strict and coupled_parameter_id not in id_to_par:
+                    raise NotImplementedError(
+                        "Coupled scaling/offset parameters must all be "
+                        f"estimated, but `{coupled_parameter_id}` (coupled to "
+                        f"`{par.inner_parameter_id}`) is not estimated."
+                    )
                 par.coupled = id_to_par[coupled_parameter_id]
                 break
-
-    return RelativeInnerProblem(xs=inner_parameters, data=data, edatas=edatas)
 
 
 def inner_parameters_from_parameter_df(
@@ -326,3 +381,121 @@ def _ixs_for_condition(
                     ixs_for_par.setdefault(override, []).append(
                         (condition_ix, time_w_reps_ix, observable_ix)
                     )
+
+
+def inner_problem_from_petab_v2_problem(
+    petab_problem: "v2.Problem",
+    amici_model: "asd.Model",
+    edatas: list["asd.ExpData"],
+) -> RelativeInnerProblem:
+    """
+    Create inner problem from a PEtab v2 problem.
+
+    See :meth:`RelativeInnerProblem.from_petab_v2_amici`.
+    """
+    from ..petab import get_inner_parameters_v2
+
+    # inner parameters
+    inner_parameters = inner_parameters_from_petab_v2_problem(petab_problem)
+
+    x_ids = [x.inner_parameter_id for x in inner_parameters]
+
+    # used indices for all measurement specific parameters
+    ixs = ixs_for_measurement_specific_parameters_v2(
+        petab_problem, amici_model, x_ids
+    )
+
+    # transform experimental data
+    data = [asd.ExpDataView(edata)["measurements"] for edata in edatas]
+
+    # matrixify
+    ix_matrices = ix_matrices_from_arrays(ixs, data)
+
+    # assign matrices, observable indices and ids to inner parameters
+    for par in inner_parameters:
+        par.ixs = ix_matrices[par.inner_parameter_id]
+        par.observable_indices = [
+            meas_indices[2] for meas_indices in ixs[par.inner_parameter_id]
+        ]
+        par.observable_ids = [
+            amici_model.get_observable_ids()[obs_idx]
+            for obs_idx in par.observable_indices
+        ]
+
+    # detect coupled scaling and offset parameters, i.e., pairs of scaling
+    #  and offset parameters that override the placeholders of the same
+    #  measurement (numeric and unrelated overrides do not count)
+    annotated = get_inner_parameters_v2(petab_problem)
+    coupled_pars = set()
+    for measurement in petab_problem.measurements:
+        group = tuple(
+            override
+            for override in map(str, measurement.observable_parameters)
+            if override in annotated
+        )
+        if len(group) >= 2 and {
+            InnerParameterType.SCALING,
+            InnerParameterType.OFFSET,
+        } <= {annotated[override] for override in group}:
+            coupled_pars.add(group)
+
+    assign_coupled_pairs(inner_parameters, coupled_pars, strict=True)
+
+    return RelativeInnerProblem(xs=inner_parameters, data=data, edatas=edatas)
+
+
+def inner_parameters_from_petab_v2_problem(
+    petab_problem: "v2.Problem",
+) -> list[RelativeInnerParameter]:
+    """
+    Create list of inner free parameters from a PEtab v2 problem.
+
+    Inner parameters are those that have a non-empty `parameterType` extra
+    field (column) in the PEtab parameter table.
+
+    A PEtab v2 problem exposes v1-shaped tables, so this only adapts them and
+    reuses the v1 reader: v2 has no parameter scales (everything is linear),
+    and the bounds of all inner parameter types except scaling and offset are
+    replaced by the fixed ones hierarchical optimization requires.
+    """
+    from ..petab import correct_parameter_df_bounds
+
+    parameter_df = petab_problem.parameter_df.copy()
+    parameter_df[PARAMETER_SCALE] = LIN
+    # the v2 table stores `estimate` as the string "true"/"false", which is
+    #  always truthy; take it from the parameters themselves instead
+    parameter_df[ESTIMATE] = parameter_df.index.map(
+        {par.id: bool(par.estimate) for par in petab_problem.parameters}
+    )
+    return inner_parameters_from_parameter_df(
+        correct_parameter_df_bounds(parameter_df),
+        petab_problem.measurement_df,
+    )
+
+
+def ixs_for_measurement_specific_parameters_v2(
+    petab_problem: "v2.Problem",
+    amici_model: "asd.Model",
+    x_ids: list[str],
+) -> dict[str, list[tuple[int, int, int]]]:
+    """
+    Create mapping of parameters to measurements for a PEtab v2 problem.
+
+    See :func:`ixs_for_measurement_specific_parameters`. The condition index
+    is the position of the experiment in ``petab_problem.experiments``, which
+    is the order of the ``ExpData`` objects created by
+    :class:`amici.sim.sundials.petab.ExperimentManager`.
+    """
+    ixs_for_par = {}
+    observable_ids = amici_model.get_observable_ids()
+    measurement_df = petab_problem.measurement_df
+
+    for condition_ix, experiment in enumerate(petab_problem.experiments):
+        _ixs_for_condition(
+            measurement_df[measurement_df[EXPERIMENT_ID] == experiment.id],
+            condition_ix,
+            observable_ids,
+            x_ids,
+            ixs_for_par,
+        )
+    return ixs_for_par

--- a/pypesto/objective/amici/amici.py
+++ b/pypesto/objective/amici/amici.py
@@ -759,8 +759,9 @@ class AmiciPetabV2Objective(AmiciObjective):
         * Steady-state guessing (``guess_steadystate``) is not available: the
           PEtab simulator creates its own :class:`amici.ExpData` objects for
           every simulation, so guesses cannot be passed on to it.
-        * Hierarchical optimization and non-quantitative data types (ordinal,
-          censored, semiquantitative) are not supported.
+        * Of the non-quantitative data types, only relative data
+          (hierarchically optimized scaling/offset/sigma parameters) are
+          supported; ordinal, censored and semiquantitative data are not.
         * Predictors (:class:`pypesto.predict.AmiciPredictor`) and the
           conversion of predictions to PEtab dataframes are not supported.
         * Custom timepoints (:meth:`AmiciObjective.set_custom_timepoints`)
@@ -771,6 +772,8 @@ class AmiciPetabV2Objective(AmiciObjective):
         self,
         petab_importer: amici.importers.petab.PetabImporter,
         force_compile: bool = False,
+        non_quantitative_data_types: set[str] | None = None,
+        inner_options: dict | None = None,
         **kwargs,
     ) -> None:
         """Initialize the objective.
@@ -782,6 +785,15 @@ class AmiciPetabV2Objective(AmiciObjective):
         force_compile:
             If ``True``, force (re-)import/compilation of the AMICI model even
             if a compiled model already exists.
+        non_quantitative_data_types:
+            The non-quantitative data types in the problem, to be handled by
+            hierarchical optimization
+            (see :class:`pypesto.hierarchical.InnerCalculatorCollectorPetabV2`).
+            If given, the parameters estimated in the inner problems are
+            removed from the objective's ``x_ids``.
+        inner_options:
+            Options for the inner problems and solvers of hierarchical
+            optimization.
         kwargs:
             Additional arguments passed on to :class:`AmiciObjective`.
         """
@@ -796,11 +808,34 @@ class AmiciPetabV2Objective(AmiciObjective):
         #  so steady-state guesses cannot be passed on to it
         kwargs.setdefault("guess_steadystate", False)
 
+        if non_quantitative_data_types:
+            from ...hierarchical.inner_calculator_collector import (
+                InnerCalculatorCollectorPetabV2,
+            )
+
+            calculator = InnerCalculatorCollectorPetabV2(
+                data_types=non_quantitative_data_types,
+                petab_simulator=self._petab_simulator,
+                inner_options=inner_options or {},
+            )
+            # the inner problems are solved from the observables, sigmas and
+            #  their sensitivities
+            kwargs["amici_reporting"] = asd.RDataReporting.full
+            # parameters estimated in the inner subproblems are removed from
+            #  the objective parameters
+            inner_parameter_ids = set(calculator.get_inner_par_ids())
+            x_ids = kwargs.get("x_ids") or self.petab_problem.x_ids
+            kwargs["x_ids"] = [
+                x_id for x_id in x_ids if x_id not in inner_parameter_ids
+            ]
+        else:
+            calculator = AmiciCalculatorPetabV2(self._petab_simulator)
+
         super().__init__(
             amici_model=self._petab_simulator.model,
             amici_solver=self._petab_simulator.solver,
             edatas=self._petab_simulator.exp_man.create_edatas(),
-            calculator=AmiciCalculatorPetabV2(self._petab_simulator),
+            calculator=calculator,
             **kwargs,
         )
         # `AmiciObjective` works on clones of the model and the solver, but the

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -105,6 +105,8 @@ class PetabImporter:
             underlying PEtab problem has parameters marked for hierarchical
             optimization (non-empty `parameterType` column in the PEtab
             parameter table). Required for ordinal, censored and semiquantitative data.
+            For PEtab v2 problems, only relative data (scaling/offset/sigma
+            parameters) are supported so far.
         inner_options:
             Options for the inner problems and solvers.
             If not provided, default options will be used.
@@ -118,12 +120,6 @@ class PetabImporter:
         """
         self.petab_problem = petab_problem
         self._hierarchical = hierarchical
-
-        if self._hierarchical and isinstance(self.petab_problem, v2.Problem):
-            raise NotImplementedError(
-                "Hierarchical optimization is not yet supported "
-                "for PEtab v2 problems."
-            )
 
         self._non_quantitative_data_types = (
             get_petab_non_quantitative_data_types(petab_problem)

--- a/pypesto/petab/objective_creator.py
+++ b/pypesto/petab/objective_creator.py
@@ -628,15 +628,9 @@ class AmiciPetabV2ObjectiveCreator(AmiciObjectiveCreator):
         """
         Initialize the creator.
 
-        See :class:`AmiciObjectiveCreator`. Hierarchical optimization and
-        non-quantitative data types are not supported for PEtab v2 yet.
+        See :class:`AmiciObjectiveCreator`. Of the non-quantitative data
+        types, only relative data are supported for PEtab v2 so far.
         """
-        if hierarchical or non_quantitative_data_types or inner_options:
-            raise NotImplementedError(
-                "Hierarchical optimization and non-quantitative data types "
-                "are not supported for PEtab v2 problems yet."
-            )
-
         super().__init__(
             petab_problem=petab_problem,
             hierarchical=hierarchical,
@@ -752,7 +746,10 @@ class AmiciPetabV2ObjectiveCreator(AmiciObjectiveCreator):
             Passed to AMICI's model compilation. If True, the compilation
             progress is printed.
         **kwargs:
-            Additional arguments passed on to the objective.
+            Additional arguments passed on to the objective. In case of
+            relative measurements, ``inner_options`` can optionally
+            be passed here. If none are given, ``inner_options`` given to the
+            importer constructor (or inner defaults) will be chosen.
 
         Returns
         -------
@@ -769,6 +766,14 @@ class AmiciPetabV2ObjectiveCreator(AmiciObjectiveCreator):
                 stacklevel=2,
             )
         petab_importer = self._create_amici_importer()
+
+        if self._hierarchical and self._non_quantitative_data_types:
+            kwargs["inner_options"] = (
+                kwargs.get("inner_options") or self.inner_options
+            )
+            kwargs["non_quantitative_data_types"] = (
+                self._non_quantitative_data_types
+            )
 
         return AmiciPetabV2Objective(
             petab_importer=petab_importer,

--- a/pypesto/visualize/observable_mapping.py
+++ b/pypesto/visualize/observable_mapping.py
@@ -27,7 +27,10 @@ try:
     import amici.sim.sundials as asd
     from amici.sim.sundials.petab.v1 import fill_in_parameters
 
-    from ..hierarchical import InnerCalculatorCollector
+    from ..hierarchical import (
+        InnerCalculatorCollector,
+        InnerCalculatorCollectorPetabV2,
+    )
     from ..hierarchical.base_problem import scale_back_value_dict
     from ..hierarchical.relative.calculator import RelativeAmiciCalculator
     from ..hierarchical.relative.problem import RelativeInnerProblem
@@ -92,6 +95,25 @@ def _finalize_observable_mapping_axes(
     ax.legend(frameon=False, loc="best")
 
 
+def _require_v1_inner_calculator(calculator) -> None:
+    """Check that ``calculator`` is a PEtab v1 hierarchical calculator.
+
+    The observable-mapping plots simulate outside the calculator, using the
+    PEtab v1 style ``objective.parameter_mapping``. For PEtab v2 that mapping
+    is an identity mapping in which the observable/noise placeholders are not
+    resolved to the inner parameters, so the plot would be silently wrong.
+    """
+    if not isinstance(calculator, InnerCalculatorCollector):
+        raise ValueError(
+            "The calculator must be an instance of the InnerCalculatorCollector."
+        )
+    if isinstance(calculator, InnerCalculatorCollectorPetabV2):
+        raise NotImplementedError(
+            "Visualizing the observable mapping is not yet supported for "
+            "PEtab v2 problems."
+        )
+
+
 def visualize_estimated_observable_mapping(
     pypesto_result: Result,
     pypesto_problem: HierarchicalProblem,
@@ -137,13 +159,7 @@ def visualize_estimated_observable_mapping(
             "The problem must contain the corresponding objective that was used for estimation."
         )
 
-    # Check the calculator is the InnerCalculatorCollector.
-    if not isinstance(
-        pypesto_problem.objective.calculator, InnerCalculatorCollector
-    ):
-        raise ValueError(
-            "The calculator must be an instance of the InnerCalculatorCollector."
-        )
+    _require_v1_inner_calculator(pypesto_problem.objective.calculator)
 
     amici_model = pypesto_problem.objective.amici_model
 
@@ -231,13 +247,7 @@ def plot_linear_observable_mappings_from_pypesto_result(
     axes:
         A 2-D NumPy array of matplotlib Axes.
     """
-    # Check the calculator is the InnerCalculatorCollector.
-    if not isinstance(
-        pypesto_problem.objective.calculator, InnerCalculatorCollector
-    ):
-        raise ValueError(
-            "The calculator must be an instance of the InnerCalculatorCollector."
-        )
+    _require_v1_inner_calculator(pypesto_problem.objective.calculator)
 
     # Get the needed objects from the pypesto problem.
     edatas = pypesto_problem.objective.edatas
@@ -466,13 +476,7 @@ def plot_splines_from_pypesto_result(
             "The problem must contain the corresponding objective that was used for estimation."
         )
 
-    # Check the calculator is the InnerCalculatorCollector.
-    if not isinstance(
-        pypesto_result.problem.objective.calculator, InnerCalculatorCollector
-    ):
-        raise ValueError(
-            "The calculator must be an instance of the InnerCalculatorCollector."
-        )
+    _require_v1_inner_calculator(pypesto_result.problem.objective.calculator)
 
     # Check the result for start index contains the spline knots.
     if SPLINE_KNOTS not in pypesto_result.optimize_result.list[start_index]:

--- a/test/hierarchical/test_hierarchical_petab_v2.py
+++ b/test/hierarchical/test_hierarchical_petab_v2.py
@@ -2,18 +2,326 @@
 
 import copy
 
+import numpy as np
 import pytest
+from amici.sim.sundials import SensitivityMethod
+from petab.v1.C import LIN, NOMINAL_VALUE, PARAMETER_SCALE
 
-from pypesto.C import MEASUREMENT_TYPE, ORDINAL, PARAMETER_TYPE
+import pypesto
+from pypesto.C import (
+    INNER_PARAMETERS,
+    MEASUREMENT_TYPE,
+    MODE_FUN,
+    MODE_RES,
+    ORDINAL,
+    PARAMETER_TYPE,
+    InnerParameterType,
+)
+from pypesto.hierarchical import InnerCalculatorCollectorPetabV2
 from pypesto.hierarchical.petab import validate_hierarchical_petab_problem
+from pypesto.petab import PetabImporter
+from pypesto.problem import HierarchicalProblem
 from pypesto.testing.examples import (
+    get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds,
     get_Boehm_JProteomeRes2014_hierarchical_petab_v2,
 )
+
+# tolerances for comparing v1 and v2 objective values and gradients,
+# which use different simulator implementations
+RTOL_FVAL = 1e-6
+RTOL_GRAD = 1e-3
+
+
+@pytest.fixture(scope="module")
+def petab_problem_v1():
+    return get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds()
 
 
 @pytest.fixture(scope="module")
 def petab_problem_v2():
     return get_Boehm_JProteomeRes2014_hierarchical_petab_v2()
+
+
+@pytest.fixture(scope="module")
+def importer_v1(petab_problem_v1):
+    return PetabImporter(petab_problem_v1, hierarchical=True)
+
+
+@pytest.fixture(scope="module")
+def importer_v2(petab_problem_v2):
+    return PetabImporter(
+        petab_problem_v2,
+        hierarchical=True,
+        model_name="Boehm_hierarchical_petab_v2",
+    )
+
+
+@pytest.fixture(scope="module")
+def problem_v1(importer_v1):
+    return importer_v1.create_problem()
+
+
+@pytest.fixture(scope="module")
+def problem_v2(importer_v2):
+    return importer_v2.create_problem()
+
+
+@pytest.fixture(scope="module")
+def objective_v2(importer_v2):
+    """A v2 hierarchical objective that is not part of a problem.
+
+    Takes the full vector of outer parameters, including the ones fixed in
+    the pypesto problem.
+    """
+    return importer_v2.create_objective_creator().create_objective()
+
+
+def _to_linear(x_scaled, scales):
+    return np.asarray(
+        [
+            x if scale == LIN else 10.0**x
+            for x, scale in zip(x_scaled, scales, strict=True)
+        ]
+    )
+
+
+def _grad_to_scaled(grad_linear, x_linear, scales):
+    """Convert a gradient w.r.t. linear parameters to parameter scale."""
+    return np.asarray(
+        [
+            g if scale == LIN else g * x * np.log(10)
+            for g, x, scale in zip(grad_linear, x_linear, scales, strict=True)
+        ]
+    )
+
+
+def test_hierarchical_petab_v2_structure(
+    petab_problem_v2, problem_v1, problem_v2
+):
+    """The v2 hierarchical problem has the expected structure."""
+    assert isinstance(problem_v2, HierarchicalProblem)
+    assert isinstance(
+        problem_v2.objective.calculator, InnerCalculatorCollectorPetabV2
+    )
+
+    # same inner and outer parameters as for PEtab v1
+    assert sorted(
+        problem_v2.objective.calculator.get_inner_par_ids()
+    ) == sorted(problem_v1.objective.calculator.get_inner_par_ids())
+    assert problem_v2.x_names == problem_v1.x_names
+    assert problem_v2.x_fixed_indices == problem_v1.x_fixed_indices
+    assert sorted(problem_v2.inner_x_names) == sorted(problem_v1.inner_x_names)
+
+    # inner parameters are the parameters with a parameterType annotation
+    expected_inner_ids = [
+        parameter.id
+        for parameter in petab_problem_v2.parameters
+        if (parameter.model_extra or {}).get("parameterType")
+        in list(InnerParameterType)
+    ]
+    assert sorted(
+        problem_v2.objective.calculator.get_inner_par_ids()
+    ) == sorted(expected_inner_ids)
+
+
+def test_hierarchical_petab_v2_matches_v1(
+    petab_problem_v1, problem_v1, problem_v2
+):
+    """Function values, gradients and inner parameters match between the
+    PEtab v1 and v2 hierarchical objectives."""
+    assert problem_v1.x_free_indices == problem_v2.x_free_indices
+    x_names_free = [problem_v1.x_names[ix] for ix in problem_v1.x_free_indices]
+    scales = [
+        petab_problem_v1.parameter_df.loc[x_id, PARAMETER_SCALE]
+        for x_id in x_names_free
+    ]
+    x_nominal_scaled = np.asarray(
+        [
+            petab_problem_v1.parameter_df.loc[x_id, NOMINAL_VALUE]
+            if scale == LIN
+            else np.log10(
+                petab_problem_v1.parameter_df.loc[x_id, NOMINAL_VALUE]
+            )
+            for x_id, scale in zip(x_names_free, scales, strict=True)
+        ]
+    )
+
+    rng = np.random.default_rng(42)
+    for i_point in range(3):
+        # the v1 objective operates on scaled parameters, the v2 objective on
+        #  linear ones
+        x_scaled = x_nominal_scaled + (
+            rng.uniform(-0.2, 0.2, size=len(x_names_free)) if i_point else 0.0
+        )
+        x_linear = _to_linear(x_scaled, scales)
+
+        fval_v1, grad_v1 = problem_v1.objective(x_scaled, sensi_orders=(0, 1))
+        fval_v2, grad_v2 = problem_v2.objective(x_linear, sensi_orders=(0, 1))
+
+        assert np.isclose(fval_v1, fval_v2, rtol=RTOL_FVAL)
+        assert np.allclose(
+            grad_v1,
+            _grad_to_scaled(grad_v2, x_linear, scales),
+            rtol=RTOL_GRAD,
+            atol=RTOL_GRAD * np.max(np.abs(grad_v1)),
+        )
+
+        # the optimal inner parameters agree
+        ret_v1 = problem_v1.objective(
+            x_scaled, sensi_orders=(0,), return_dict=True
+        )
+        ret_v2 = problem_v2.objective(
+            x_linear, sensi_orders=(0,), return_dict=True
+        )
+        inner_v1 = dict(
+            zip(
+                problem_v1.inner_x_names,
+                ret_v1[INNER_PARAMETERS],
+                strict=True,
+            )
+        )
+        inner_v2 = dict(
+            zip(
+                problem_v2.inner_x_names,
+                ret_v2[INNER_PARAMETERS],
+                strict=True,
+            )
+        )
+        for inner_id, value_v1 in inner_v1.items():
+            assert np.isclose(value_v1, inner_v2[inner_id], rtol=1e-5)
+
+
+def test_hierarchical_petab_v2_gradient_check(petab_problem_v2, objective_v2):
+    """The v2 hierarchical gradient matches finite differences."""
+    objective = copy.deepcopy(objective_v2)
+    # tight tolerances, so that the finite differences are meaningful also
+    #  in flat directions
+    objective.amici_solver.set_relative_tolerance(1e-12)
+    objective.amici_solver.set_absolute_tolerance(1e-14)
+
+    x_nominal = petab_problem_v2.get_x_nominal_dict()
+    x = np.asarray([x_nominal[x_id] for x_id in objective.x_ids])
+    # restrict to the parameters estimated in the PEtab problem -- there are
+    #  no sensitivities for the others
+    x_free_ids = set(petab_problem_v2.x_free_ids)
+    x_indices = [
+        ix for ix, x_id in enumerate(objective.x_ids) if x_id in x_free_ids
+    ]
+
+    check_df = objective.check_grad(
+        x, x_indices=x_indices, eps=1e-5, mode=MODE_FUN
+    )
+    assert np.all(
+        (check_df.rel_err.abs() < 1e-3) | (check_df.abs_err < 1e-3)
+    ), check_df
+
+
+def test_hierarchical_petab_v2_adjoint_hessian_residuals(
+    petab_problem_v2, objective_v2
+):
+    """Adjoint sensitivities, the FIM, and residual mode work with the v2
+    hierarchical objective and are consistent with the forward results."""
+    objective = copy.deepcopy(objective_v2)
+    x_nominal = petab_problem_v2.get_x_nominal_dict()
+    x = np.asarray([x_nominal[x_id] for x_id in objective.x_ids])
+
+    fval_forward, grad_forward = objective(x, sensi_orders=(0, 1))
+
+    # adjoint sensitivities (computes the inner parameters from a first
+    #  simulation, then uses AMICI with fixed inner parameters)
+    objective.amici_solver.set_sensitivity_method(SensitivityMethod.adjoint)
+    fval_adjoint, grad_adjoint = objective(x, sensi_orders=(0, 1))
+    assert np.isclose(fval_forward, fval_adjoint, rtol=1e-6)
+    assert np.allclose(
+        grad_forward,
+        grad_adjoint,
+        rtol=1e-3,
+        atol=1e-3 * np.max(np.abs(grad_forward)),
+    )
+
+    # FIM-based Hessian
+    objective.amici_solver.set_sensitivity_method(SensitivityMethod.forward)
+    hess = objective(x, sensi_orders=(2,))
+    assert hess.shape == (len(x), len(x))
+    # the FIM is a positive semi-definite approximation of the Hessian
+    eigvals = np.linalg.eigvalsh(hess)
+    assert np.min(eigvals) >= -1e-6 * np.max(np.abs(eigvals))
+
+    # residual mode: the residuals of the hierarchical objective are computed
+    #  at the optimal inner parameters and are finite
+    res = objective(x, sensi_orders=(0,), mode=MODE_RES, return_dict=True)[
+        "res"
+    ]
+    assert np.all(np.isfinite(res))
+
+
+def test_hierarchical_petab_v2_vs_non_hierarchical(
+    petab_problem_v2, objective_v2
+):
+    """The hierarchical objective matches the non-hierarchical objective
+    evaluated at the hierarchically computed optimal inner parameters."""
+    importer = PetabImporter(
+        petab_problem_v2,
+        hierarchical=False,
+        model_name="Boehm_hierarchical_petab_v2",
+    )
+    objective_full = importer.create_objective_creator().create_objective()
+
+    x_nominal = petab_problem_v2.get_x_nominal_dict()
+    x_outer = np.asarray([x_nominal[x_id] for x_id in objective_v2.x_ids])
+
+    ret = objective_v2(x_outer, sensi_orders=(0,), return_dict=True)
+    fval_hierarchical = ret["fval"]
+    inner_parameters = dict(
+        zip(
+            objective_v2.calculator.get_inner_par_ids(),
+            ret[INNER_PARAMETERS],
+            strict=True,
+        )
+    )
+
+    # evaluate the full (non-hierarchical) objective with the inner parameters
+    #  set to their hierarchically computed optimal values
+    x_full_dict = x_nominal | inner_parameters
+    x_full = np.asarray([x_full_dict[x_id] for x_id in objective_full.x_ids])
+    fval_full_at_inner_optimum = objective_full(x_full)
+    assert np.isclose(fval_hierarchical, fval_full_at_inner_optimum, rtol=1e-6)
+
+    # ... the hierarchical objective is at least as good as the full
+    #  objective at the nominal inner parameter values
+    x_full_nominal = np.asarray(
+        [x_nominal[x_id] for x_id in objective_full.x_ids]
+    )
+    fval_full_nominal = objective_full(x_full_nominal)
+    assert fval_hierarchical <= fval_full_nominal + 1e-8
+
+
+def test_hierarchical_petab_v2_optimization(petab_problem_v2, problem_v2):
+    """Hierarchical optimization of a PEtab v2 problem runs and improves."""
+    # start close to the nominal parameters to keep the test fast
+    # (some nominal values are on the bounds, so clip the perturbed guesses)
+    x_nominal = petab_problem_v2.get_x_nominal_dict()
+    x_full = np.asarray([x_nominal[x_id] for x_id in problem_v2.x_names])
+    problem_v2.set_x_guesses(
+        np.clip(
+            np.vstack([x_full * 1.1, x_full * 0.8]),
+            problem_v2.lb_full,
+            problem_v2.ub_full,
+        )
+    )
+
+    optimizer = pypesto.optimize.ScipyOptimizer(
+        method="L-BFGS-B", options={"maxiter": 10}
+    )
+    result = pypesto.optimize.minimize(
+        problem=problem_v2,
+        n_starts=2,
+        optimizer=optimizer,
+        progress_bar=False,
+    )
+    for start in result.optimize_result.list:
+        assert start.fval0 is not None
+        assert start.fval <= start.fval0
 
 
 def test_hierarchical_petab_v2_validation(petab_problem_v2):
@@ -57,3 +365,103 @@ def test_hierarchical_petab_v2_validation(petab_problem_v2):
     petab_problem.observables[0].noise_distribution = "laplace"
     with pytest.raises(NotImplementedError, match="oise distribution"):
         validate_hierarchical_petab_problem(petab_problem)
+
+
+def test_hierarchical_petab_v2_sigma_bounds_are_corrected(petab_problem_v2):
+    """Sigma inner parameters get the canonical bounds, whatever the PEtab
+    problem declares (PEtab v2 requires bounds, so they cannot be omitted)."""
+    from pypesto.C import INNER_PARAMETER_BOUNDS, LOWER_BOUND, UPPER_BOUND
+    from pypesto.hierarchical.relative.problem import (
+        inner_parameters_from_petab_v2_problem,
+    )
+
+    petab_problem = copy.deepcopy(petab_problem_v2)
+    for parameter in petab_problem.parameters:
+        if parameter.id.startswith("sd_"):
+            parameter.lb, parameter.ub = 1e-5, 1e5
+
+    expected = INNER_PARAMETER_BOUNDS[InnerParameterType.SIGMA]
+    sigmas = [
+        par
+        for par in inner_parameters_from_petab_v2_problem(petab_problem)
+        if par.inner_parameter_type == InnerParameterType.SIGMA
+    ]
+    assert sigmas
+    for par in sigmas:
+        assert par.lb == expected[LOWER_BOUND]
+        assert par.ub == expected[UPPER_BOUND]
+
+
+def test_hierarchical_petab_v2_coupled_pair_rejections(
+    petab_problem_v2, importer_v2
+):
+    """A scaling/offset pair whose partner is not estimated must be rejected
+    rather than silently treated as uncoupled, and a numeric override must not
+    be counted as a member of the coupled pair."""
+    from pypesto.hierarchical.relative.problem import (
+        inner_problem_from_petab_v2_problem,
+    )
+
+    # the model/edatas of the (already compiled) fixture problem
+    creator = importer_v2.create_objective_creator()
+    amici_importer = creator._create_amici_importer()
+    simulator = amici_importer.create_simulator(force_import=False)
+    model = simulator.model
+    edatas = simulator.exp_man.create_edatas()
+    converted = simulator.exp_man.petab_problem
+
+    # baseline: the unmodified problem couples each scaling with its offset
+    inner_problem = inner_problem_from_petab_v2_problem(
+        copy.deepcopy(converted), model, edatas
+    )
+    assert all(
+        inner_problem.xs[x_id].coupled is not None
+        for x_id in inner_problem.xs
+        if inner_problem.xs[x_id].inner_parameter_type
+        in (InnerParameterType.SCALING, InnerParameterType.OFFSET)
+    )
+
+    # a non-estimated offset partner must raise, not silently uncouple
+    petab_problem = copy.deepcopy(converted)
+    for parameter in petab_problem.parameters:
+        if parameter.id == "offset_pSTAT5A_rel":
+            parameter.estimate = False
+    with pytest.raises(NotImplementedError, match="not.*estimated"):
+        inner_problem_from_petab_v2_problem(petab_problem, model, edatas)
+
+    # ... but if NEITHER is estimated, that observable is simply not
+    # hierarchically optimized and the pair must be accepted, not rejected
+    petab_problem = copy.deepcopy(converted)
+    for parameter in petab_problem.parameters:
+        if parameter.id in ("scaling_pSTAT5A_rel", "offset_pSTAT5A_rel"):
+            parameter.estimate = False
+    inner_problem = inner_problem_from_petab_v2_problem(
+        petab_problem, model, edatas
+    )
+    assert "scaling_pSTAT5A_rel" not in inner_problem.xs
+    assert (
+        inner_problem.xs["scaling_pSTAT5B_rel"].coupled.inner_parameter_id
+        == "offset_pSTAT5B_rel"
+    )
+
+    # a numeric override alongside the pair must not inflate the group
+    petab_problem = copy.deepcopy(converted)
+    for measurement in petab_problem.measurements:
+        if measurement.observable_id == "pSTAT5A_rel":
+            measurement.observable_parameters = [
+                *measurement.observable_parameters,
+                1.0,
+            ]
+    for observable in petab_problem.observables:
+        if observable.id == "pSTAT5A_rel":
+            observable.observable_placeholders = [
+                *map(str, observable.observable_placeholders),
+                "observableParameter3_pSTAT5A_rel",
+            ]
+    inner_problem = inner_problem_from_petab_v2_problem(
+        petab_problem, model, edatas
+    )
+    assert (
+        inner_problem.xs["scaling_pSTAT5A_rel"].coupled.inner_parameter_id
+        == "offset_pSTAT5A_rel"
+    )


### PR DESCRIPTION
## What

Adds hierarchical optimization (analytically solved scaling, offset and sigma inner parameters for relative data) to the PEtab v2 import path, which previously raised `NotImplementedError` for `hierarchical=True`.

* `InnerCalculatorCollectorPetabV2` — v2 counterpart of `InnerCalculatorCollector`. Simulation is delegated to AMICI's `PetabSimulator` through `AmiciCalculatorPetabV2`; the inner problems are solved from the returned observables, sigmas and sensitivities. Simulation sensitivities are mapped onto the optimization parameters via per-experiment index slices derived from `ExpData.plist` (no PEtab-v1-style parameter mapping is constructed for v2). Adjoint sensitivities, the FIM and residual mode go through the same twice-call scheme as v1.
* `RelativeInnerProblem.from_petab_v2_amici` and the v2 inner-problem construction in `hierarchical/relative/problem.py`, reusing the v1 per-condition measurement indexing on the preprocessed problem's `measurement_df`.
* `validate_hierarchical_petab_problem_v2` — formula-form validation for v2 (explicit placeholders, `real=True` symbols), sharing the checks with v1 via extracted helpers.
* The pyPESTO annotations (`parameterType`, `measurementType`) are read from the PEtab v2 `model_extra` fields, which survive `petab1to2` and AMICI's experiment conversion.

Shared v1 code changes are minimal: `RelativeInnerSolver.calculate_gradients` and `calculate_quantitative_result` gain one trailing `index_slices=None` argument; `_get_quantitative_data_mask` uses `any` instead of `all` (with `all`, one condition without quantitative data dropped the quantitative contribution of every condition).

## Scope / limitations

* Only relative (and quantitative) data. Ordinal, censored and semiquantitative data are detected and rejected with `NotImplementedError`.
* Observable-mapping plots (`visualize.observable_mapping`) raise `NotImplementedError` for v2 objectives; they re-simulate via the v1 parameter mapping.
* Measurement-specific placeholder overrides that differ within one experiment are rejected: AMICI applies one value per placeholder and experiment, and its own guard for this never fires.
* Sigma bounds are forced to `INNER_PARAMETER_BOUNDS` (as `correct_parameter_df_bounds` does for v1); a scaling/offset pair that is only partially estimated is rejected rather than silently treated as uncoupled.

## Verification

* `test/hierarchical/test_hierarchical_petab_v2.py`: structure, v1/v2 equivalence of fval, gradient and inner parameters on Boehm, finite-difference gradient check, adjoint/FIM/residual consistency, agreement with the non-hierarchical objective at the inner optimum, a short optimization run, validation and coupled-pair cases.
* Out-of-tree probes (Boehm, and a 2-experiment synthetic problem with replicates and per-condition overrides) agree between v1 and v2 to ~1e-16 relative gradient error.
* `test_hierarchical_optimization_pipeline` fails locally on `develop` as well; unrelated.

## Notes for review

* `PetabSimulationResult.res` is a method in amici ≤ 1.0.1 and a property on AMICI main; `AmiciCalculatorPetabV2` handles both. The `petab` tox env installs AMICI main, the `hierarchical` env the PyPI release.
* History: one feature commit, four review-fix commits, then a slimming commit that removed most of what the review rounds had added. Happy to squash.

## Stack

Merge bottom-up. Each PR's diff shows only its own files.

1. #1746 — NumPy 2 `row_stack` fix, and the base-env import fixes from the merged #1738
2. #1742 — pre-existing bug fixes
3. #1743 — index slices: PEtab v2 support, and v1 refactors
4. #1749 — extract the inner-result combination
5. #1748 — evaluator as a collaborator
6. #1751 — `__call__` as a template with two hooks
7. #1744 — PEtab v2 detection and validation
8. **this PR** — the PEtab v2 hierarchical calculator

#1738 was stacked on #1746 and merged **into it**, so merging #1746 lands both base-environment fixes on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

