### PR TITLE
Fix two pre-existing hierarchical/PEtab v2 bugs

### DIFF
--- a/pypesto/hierarchical/inner_calculator_collector.py
+++ b/pypesto/hierarchical/inner_calculator_collector.py
@@ -246,8 +246,10 @@ class InnerCalculatorCollector(AmiciCalculator):
         ):
             condition_mask[np.isnan(edata)] = False
 
-        # If there is no quantitative data, return None
-        if not all(mask.any() for mask in quantitative_data_mask):
+        # If there is no quantitative data at all, return None. Individual
+        #  conditions without quantitative data are fine -- their (all-False)
+        #  mask simply contributes nothing.
+        if not any(mask.any() for mask in quantitative_data_mask):
             return None
 
         return quantitative_data_mask

--- a/pypesto/hierarchical/inner_calculator_collector.py
+++ b/pypesto/hierarchical/inner_calculator_collector.py
@@ -222,7 +222,12 @@ class InnerCalculatorCollector(AmiciCalculator):
     def _get_quantitative_data_mask(
         self,
         edatas: list[asd.ExpData],
-    ) -> list[np.ndarray]:
+    ) -> list[np.ndarray] | None:
+        """Get the mask of quantitative measurements, one entry per condition.
+
+        Returns ``None`` if the problem has no quantitative data at all, which
+        the callers take to mean "no quantitative contribution to add".
+        """
         # transform experimental data
         edatas = [asd.ExpDataView(edata)["measurements"] for edata in edatas]
 

--- a/pypesto/objective/amici/amici_calculator.py
+++ b/pypesto/objective/amici/amici_calculator.py
@@ -339,7 +339,10 @@ class AmiciCalculatorPetabV2(AmiciCalculator):
                     )
                 self._known_least_squares_safe = True  # don't check this again
             if 0 in sensi_orders:
-                if (res := result.res) is None:
+                # `PetabSimulationResult.res` is a method in amici <= 1.0.1,
+                #  and a property in later versions
+                res = result.res() if callable(result.res) else result.res
+                if res is None:
                     raise ValueError("The residuals were not computed.")
             if 1 in sensi_orders:
                 if result.sres is None:


### PR DESCRIPTION
Two independent bug fixes found while implementing hierarchical optimization for the PEtab v2 importer. Split out of that work so they can be reviewed and merged on their own. **1 of 4 in a stack** (see below).

## 1. Quantitative data silently dropped when one condition has none

`InnerCalculatorCollector._get_quantitative_data_mask` returned `None` unless *every* condition had quantitative data:

```python
if not all(mask.any() for mask in quantitative_data_mask):
    return None
```

`None` means "no quantitative contribution at all", so a single condition without quantitative data — common when one experiment measures only relative observables — removed the quantitative contribution of *all* conditions from the objective. Silently: no error, just a wrong objective value and gradient.

An all-False mask contributes nothing on its own, so `any` is the correct quantifier.

## 2. `AmiciCalculatorPetabV2` returned a bound method as the residuals

```python
if (res := result.res) is None:
```

`PetabSimulationResult.res` is a *method* in amici <= 1.0.1 and only became a property later. With the released amici, `result.res` is therefore a bound method: the `is None` check never fires, and the method object is returned in the result dict as `RES`.

Verified against the amici in the dev environment: `PetabSimulationResult.res` is a `function`.

## Review notes

* Both bugs are on `develop` today; neither is introduced by the PEtab v2 work.
* Bug 1 affects the PEtab v1 hierarchical path, bug 2 the PEtab v2 residual path. They are unrelated to each other and only grouped because both are small and were found together — happy to split further.
* Neither has a regression test here. Bug 1 needs a multi-condition fixture where one condition is purely relative; bug 2 needs `MODE_RES` on a v2 problem, which the stack's last PR exercises.

## Stack

Merge bottom-up. Each PR's diff shows only its own files.

1. #1746 — NumPy 2 `row_stack` fix, and the base-env import fixes from the merged #1738
2. **this PR** — pre-existing bug fixes
3. #1743 — index slices: PEtab v2 support, and v1 refactors
4. #1749 — extract the inner-result combination
5. #1748 — evaluator as a collaborator
6. #1751 — `__call__` as a template with two hooks
7. #1744 — PEtab v2 detection and validation
8. #1740 — the PEtab v2 hierarchical calculator

#1738 was stacked on #1746 and merged **into it**, so merging #1746 lands both base-environment fixes on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

