### PR TITLE
Detect and validate hierarchical PEtab v2 problems

### DIFF
--- a/pypesto/hierarchical/petab.py
+++ b/pypesto/hierarchical/petab.py
@@ -6,6 +6,7 @@ import pandas as pd
 import petab.v1 as petab
 import sympy as sp
 from more_itertools import one
+from petab import v2
 from petab.v1.C import (
     ESTIMATE,
     LIN,
@@ -67,7 +68,9 @@ def correct_parameter_df_bounds(parameter_df: pd.DataFrame) -> pd.DataFrame:
     return parameter_df.apply(correct_row, axis=1)
 
 
-def validate_hierarchical_petab_problem(petab_problem: petab.Problem) -> None:
+def validate_hierarchical_petab_problem(
+    petab_problem: petab.Problem | v2.Problem,
+) -> None:
     """Validate a PEtab problem for hierarchical optimization.
 
     Parameters
@@ -75,6 +78,10 @@ def validate_hierarchical_petab_problem(petab_problem: petab.Problem) -> None:
     petab_problem:
         The PEtab problem.
     """
+    if isinstance(petab_problem, v2.Problem):
+        validate_hierarchical_petab_problem_v2(petab_problem)
+        return
+
     if PARAMETER_TYPE in petab_problem.parameter_df:
         # ensure we only have linear parameter scale
         inner_parameter_table = petab_problem.parameter_df[
@@ -657,6 +664,171 @@ def _get_formula_inner_parameters(
         )
 
     return symbolic_formula_inner_parameters
+
+
+def validate_hierarchical_petab_problem_v2(petab_problem: v2.Problem) -> None:
+    """Validate a PEtab v2 problem for hierarchical optimization.
+
+    Parameters
+    ----------
+    petab_problem:
+        The PEtab v2 problem.
+    """
+    from ..petab.util import get_petab_non_quantitative_data_types
+
+    if unsupported := (
+        get_petab_non_quantitative_data_types(petab_problem) or set()
+    ) - {RELATIVE}:
+        raise NotImplementedError(
+            f"Data types {sorted(unsupported)} are not yet supported for "
+            "PEtab v2 problems."
+        )
+
+    inner_parameters = get_inner_parameters_v2(petab_problem)
+    if not inner_parameters:
+        return
+
+    inner_parameter_df = validate_measurement_formulae_v2(
+        petab_problem=petab_problem, inner_parameters=inner_parameters
+    )
+    validate_inner_parameter_pairings(inner_parameter_df=inner_parameter_df)
+
+
+def get_inner_parameters_v2(
+    petab_problem: v2.Problem,
+) -> dict[str, InnerParameterType]:
+    """Get information about the inner parameters of a PEtab v2 problem.
+
+    Parameters
+    ----------
+    petab_problem:
+        The PEtab v2 problem.
+
+    Returns
+    -------
+    Parameter IDs and their inner parameter types.
+    """
+    from ..petab.util import get_petab_v2_extra_field
+
+    inner_parameters = {}
+    for parameter in petab_problem.parameters:
+        type_str = get_petab_v2_extra_field(parameter, PARAMETER_TYPE)
+        if type_str is None:
+            continue
+
+        try:
+            inner_parameters[parameter.id] = InnerParameterType(type_str)
+        except ValueError as e:
+            raise ValueError(
+                f"Unknown inner parameter type `{type_str}`."
+            ) from e
+
+    return inner_parameters
+
+
+def validate_measurement_formulae_v2(
+    petab_problem: v2.Problem,
+    inner_parameters: dict[str, InnerParameterType],
+) -> pd.DataFrame:
+    """Check whether formulae associated with a measurement are valid.
+
+    PEtab v2 version of :func:`validate_measurement_formulae`.
+
+    Parameters
+    ----------
+    petab_problem:
+        The PEtab v2 problem.
+    inner_parameters:
+        See :func:`get_inner_parameters_v2`.
+
+    Returns
+    -------
+    A dataframe containing the inner parameters for each measurement.
+    """
+    import petab.v2.C as petab_v2_C
+
+    observables = {
+        observable.id: observable for observable in petab_problem.observables
+    }
+
+    inner_parameter_sets = []
+    for measurement in petab_problem.measurements:
+        observable = observables[measurement.observable_id]
+
+        # substitute both observable and noise placeholders in both formulae
+        #  -- inner parameters must not end up in the "wrong" formula
+        substitutions = dict(
+            zip(
+                observable.observable_placeholders,
+                measurement.observable_parameters,
+                strict=True,
+            )
+        ) | dict(
+            zip(
+                observable.noise_placeholders,
+                measurement.noise_parameters,
+                strict=True,
+            )
+        )
+
+        observable_formula = sp.sympify(observable.formula).subs(substitutions)
+        noise_formula = sp.sympify(observable.noise_formula).subs(
+            substitutions
+        )
+
+        offset, scaling = _validate_observable_formula_form(
+            formula=observable_formula,
+            formula_inner_parameters=_get_formula_inner_parameters(
+                symbolic_formula=observable_formula,
+                formula_type="observable",
+                inner_parameters=inner_parameters,
+            ),
+        )
+        sigma = _validate_noise_formula_form(
+            formula=noise_formula,
+            formula_inner_parameters=_get_formula_inner_parameters(
+                symbolic_formula=noise_formula,
+                formula_type="noise",
+                inner_parameters=inner_parameters,
+            ),
+        )
+
+        # non-Gaussian noise is not supported for measurements associated
+        #  with inner parameters (the analytical inner solver assumes
+        #  additive Gaussian noise)
+        if (
+            any(v is not None for v in (offset, scaling, sigma))
+            # NoiseDistribution is a str enum
+            and observable.noise_distribution != petab_v2_C.NORMAL
+        ):
+            raise NotImplementedError(
+                "Noise distributions other than `normal` are not supported "
+                "if the observable is associated with hierarchically "
+                "optimized inner parameters. "
+                f"Observable: `{observable.id}`. "
+                f"Noise distribution: `{observable.noise_distribution}`."
+            )
+
+        inner_parameter_sets.append(
+            [
+                str(v) if v is not None else None
+                for v in [offset, scaling, sigma]
+            ]
+        )
+
+    return pd.DataFrame(
+        data=inner_parameter_sets,
+        columns=[
+            InnerParameterType.OFFSET,
+            InnerParameterType.SCALING,
+            InnerParameterType.SIGMA,
+        ],
+        # `dtype=object` keeps the `None` sentinels as `None`; pandas would
+        #  otherwise coerce a mixed str/None column to a string dtype whose
+        #  missing value is NaN, and `validate_inner_parameter_pairings`
+        #  compares against `None` (and `nan != nan`).
+        dtype=object,
+    )
 
 
 def validate_observable_data_types(petab_problem: petab.Problem) -> None:

--- a/pypesto/hierarchical/petab.py
+++ b/pypesto/hierarchical/petab.py
@@ -6,7 +6,7 @@ import pandas as pd
 import petab.v1 as petab
 import sympy as sp
 from more_itertools import one
-from petab import v2
+from petab import v1, v2
 from petab.v1.C import (
     ESTIMATE,
     LIN,
@@ -69,7 +69,7 @@ def correct_parameter_df_bounds(parameter_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def validate_hierarchical_petab_problem(
-    petab_problem: petab.Problem | v2.Problem,
+    petab_problem: v1.Problem | v2.Problem,
 ) -> None:
     """Validate a PEtab problem for hierarchical optimization.
 
@@ -222,7 +222,7 @@ def validate_inner_parameter_pairings(
 
 
 def get_inner_parameters(
-    petab_problem: petab.Problem,
+    petab_problem: v1.Problem,
 ) -> dict[str, InnerParameterType]:
     """Get information about the inner parameters.
 
@@ -261,7 +261,7 @@ def get_inner_parameters(
 
 
 def validate_measurement_formulae(
-    petab_problem: petab.Problem,
+    petab_problem: v1.Problem,
 ) -> pd.DataFrame:
     """Check whether formulae associated with a measurement are valid.
 
@@ -311,7 +311,7 @@ def validate_measurement_formulae(
 
 def _validate_measurement_specific_observable_formula(
     measurement: pd.Series,
-    petab_problem: petab.Problem,
+    petab_problem: v1.Problem,
     inner_parameters: dict[str, InnerParameterType],
 ) -> tuple[InnerParameterType, InnerParameterType]:
     """Check whether a measurement observable formula is valid.
@@ -421,7 +421,7 @@ def _validate_observable_formula_form(
 
 def _validate_measurement_specific_noise_formula(
     measurement: pd.Series,
-    petab_problem: petab.Problem,
+    petab_problem: v1.Problem,
     inner_parameters: dict[str, InnerParameterType],
 ) -> tuple[InnerParameterType, InnerParameterType]:
     """Check whether a measurement noise formula is valid.
@@ -497,7 +497,7 @@ def _validate_noise_formula_form(
 def _get_symbolic_formula_from_measurement(
     measurement: pd.Series,
     formula_type: str,
-    petab_problem: petab.Problem,
+    petab_problem: v1.Problem,
     inner_parameters: dict[str, InnerParameterType],
 ) -> tuple[sp.Expr, dict[sp.Symbol, InnerParameterType]]:
     """Get a symbolic representation of a formula, with overrides overridden.
@@ -676,9 +676,9 @@ def validate_hierarchical_petab_problem_v2(petab_problem: v2.Problem) -> None:
     """
     from ..petab.util import get_petab_non_quantitative_data_types
 
-    if unsupported := (
-        get_petab_non_quantitative_data_types(petab_problem) or set()
-    ) - {RELATIVE}:
+    if unsupported := get_petab_non_quantitative_data_types(petab_problem) - {
+        RELATIVE
+    }:
         raise NotImplementedError(
             f"Data types {sorted(unsupported)} are not yet supported for "
             "PEtab v2 problems."
@@ -771,10 +771,9 @@ def validate_measurement_formulae_v2(
             )
         )
 
-        observable_formula = sp.sympify(observable.formula).subs(substitutions)
-        noise_formula = sp.sympify(observable.noise_formula).subs(
-            substitutions
-        )
+        # PEtab v2 parses the formulas into sympy expressions already
+        observable_formula = observable.formula.subs(substitutions)
+        noise_formula = observable.noise_formula.subs(substitutions)
 
         offset, scaling = _validate_observable_formula_form(
             formula=observable_formula,
@@ -831,7 +830,7 @@ def validate_measurement_formulae_v2(
     )
 
 
-def validate_observable_data_types(petab_problem: petab.Problem) -> None:
+def validate_observable_data_types(petab_problem: v1.Problem) -> None:
     """Check whether the data types of observables are valid."""
 
     supported_data_types = [

--- a/pypesto/petab/importer.py
+++ b/pypesto/petab/importer.py
@@ -129,7 +129,7 @@ class PetabImporter:
             get_petab_non_quantitative_data_types(petab_problem)
         )
 
-        if self._non_quantitative_data_types is None and hierarchical:
+        if not self._non_quantitative_data_types and hierarchical:
             raise ValueError(
                 "Hierarchical optimization enabled, but no non-quantitative "
                 "data types specified. Specify non-quantitative data types "

--- a/pypesto/petab/util.py
+++ b/pypesto/petab/util.py
@@ -27,8 +27,19 @@ from ..problem import Problem
 from ..startpoint import CheckedStartpoints
 
 
+def get_petab_v2_extra_field(element, field: str):
+    """Get a pyPESTO-specific extra field from a PEtab v2 table element.
+
+    pyPESTO's hierarchical optimization annotations (e.g. ``parameterType``)
+    are preserved as extra fields of the PEtab v2 table elements. Returns
+    ``None`` if the field is absent or empty.
+    """
+    value = (element.model_extra or {}).get(field)
+    return None if value is None or petab.is_empty(value) else value
+
+
 def get_petab_non_quantitative_data_types(
-    petab_problem: petab.Problem,
+    petab_problem: petab.Problem | v2.Problem,
 ) -> set[str]:
     """
     Get the data types from the PEtab problem.
@@ -43,6 +54,9 @@ def get_petab_non_quantitative_data_types(
     data_types:
         A list of the data types.
     """
+    if isinstance(petab_problem, v2.Problem):
+        return _get_petab_v2_non_quantitative_data_types(petab_problem)
+
     non_quantitative_data_types = set()
     caught_observables = set()
     # For ordinal, censored and semiquantitative data, search
@@ -95,6 +109,45 @@ def get_petab_non_quantitative_data_types(
     if len(non_quantitative_data_types) == 0:
         return None
     return non_quantitative_data_types
+
+
+def _get_petab_v2_non_quantitative_data_types(
+    petab_problem: "v2.Problem",
+) -> set[str] | None:
+    """Get the non-quantitative data types from a PEtab v2 problem.
+
+    See :func:`get_petab_non_quantitative_data_types`.
+    """
+    non_quantitative_data_types = set()
+
+    # Ordinal, censored and semiquantitative data are not supported for PEtab
+    # v2 yet, but they still have to be detected here so that they are
+    # rejected with a clear message rather than silently treated as
+    # quantitative data.
+    for measurement in petab_problem.measurements:
+        data_type = get_petab_v2_extra_field(measurement, MEASUREMENT_TYPE)
+        if data_type in [ORDINAL, SEMIQUANTITATIVE] + CENSORING_TYPES:
+            non_quantitative_data_types.add(
+                CENSORED if data_type in CENSORING_TYPES else data_type
+            )
+
+    # For relative data, search for parameters to estimate with a
+    # scaling/offset/sigma parameter type. Unlike for PEtab v1, sigma
+    # parameters need no special case here: they can only belong to a relative
+    # observable, since semiquantitative data are not supported.
+    if any(
+        get_petab_v2_extra_field(parameter, PARAMETER_TYPE)
+        in (
+            InnerParameterType.SCALING,
+            InnerParameterType.OFFSET,
+            InnerParameterType.SIGMA,
+        )
+        for parameter in petab_problem.parameters
+        if parameter.estimate
+    ):
+        non_quantitative_data_types.add(RELATIVE)
+
+    return non_quantitative_data_types or None
 
 
 class PetabStartpoints(CheckedStartpoints):

--- a/pypesto/petab/util.py
+++ b/pypesto/petab/util.py
@@ -4,7 +4,7 @@ import numpy as np
 
 try:
     import petab.v1 as petab
-    from petab import v2
+    from petab import v1, v2
     from petab.v1.C import (
         ESTIMATE,
         NOISE_PARAMETERS,
@@ -39,7 +39,7 @@ def get_petab_v2_extra_field(element, field: str):
 
 
 def get_petab_non_quantitative_data_types(
-    petab_problem: petab.Problem | v2.Problem,
+    petab_problem: v1.Problem | v2.Problem,
 ) -> set[str]:
     """
     Get the data types from the PEtab problem.
@@ -106,14 +106,12 @@ def get_petab_non_quantitative_data_types(
     # are also specified in the measurement table, but that would require
     # changing the PEtab format of a lot of benchmark models.
 
-    if len(non_quantitative_data_types) == 0:
-        return None
     return non_quantitative_data_types
 
 
 def _get_petab_v2_non_quantitative_data_types(
     petab_problem: "v2.Problem",
-) -> set[str] | None:
+) -> set[str]:
     """Get the non-quantitative data types from a PEtab v2 problem.
 
     See :func:`get_petab_non_quantitative_data_types`.
@@ -126,10 +124,10 @@ def _get_petab_v2_non_quantitative_data_types(
     # quantitative data.
     for measurement in petab_problem.measurements:
         data_type = get_petab_v2_extra_field(measurement, MEASUREMENT_TYPE)
-        if data_type in [ORDINAL, SEMIQUANTITATIVE] + CENSORING_TYPES:
-            non_quantitative_data_types.add(
-                CENSORED if data_type in CENSORING_TYPES else data_type
-            )
+        if data_type in CENSORING_TYPES:
+            non_quantitative_data_types.add(CENSORED)
+        elif data_type in (ORDINAL, SEMIQUANTITATIVE):
+            non_quantitative_data_types.add(data_type)
 
     # For relative data, search for parameters to estimate with a
     # scaling/offset/sigma parameter type. Unlike for PEtab v1, sigma
@@ -147,7 +145,7 @@ def _get_petab_v2_non_quantitative_data_types(
     ):
         non_quantitative_data_types.add(RELATIVE)
 
-    return non_quantitative_data_types or None
+    return non_quantitative_data_types
 
 
 class PetabStartpoints(CheckedStartpoints):

--- a/pypesto/testing/examples.py
+++ b/pypesto/testing/examples.py
@@ -124,3 +124,30 @@ def get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds() -> (
         parameter_df=petab_problem.parameter_df
     )
     return petab_problem
+
+
+def get_Boehm_JProteomeRes2014_hierarchical_petab_v2() -> (
+    "petab.v2.Problem"  # noqa: F821
+):
+    """
+    Get the PEtab v2 version of the hierarchical Boehm_JProteomeRes2014 problem.
+
+    The PEtab v1 problem from
+    `get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds` upgraded
+    to PEtab v2. The pyPESTO-specific hierarchical optimization annotations
+    (`parameterType` column) are preserved as extra fields of the PEtab v2
+    parameter table.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from petab import v2
+
+    petab_problem_v1 = (
+        get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds()
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        petab_problem_v1.to_files_generic(prefix_path=temp_dir)
+        # `from_yaml` upgrades PEtab v1 problems to v2 on the fly;
+        #  the returned problem is fully loaded into memory
+        return v2.Problem.from_yaml(Path(temp_dir) / "problem.yaml")

--- a/pypesto/visualize/model_fit.py
+++ b/pypesto/visualize/model_fit.py
@@ -158,7 +158,7 @@ def visualize_optimized_model_fit(
             petab_problem
         )
 
-        if non_quantitative_data_types is not None:
+        if non_quantitative_data_types:
             if (
                 ORDINAL in non_quantitative_data_types
                 or CENSORED in non_quantitative_data_types

--- a/test/hierarchical/test_hierarchical_petab_v2.py
+++ b/test/hierarchical/test_hierarchical_petab_v2.py
@@ -4,7 +4,7 @@ import copy
 
 import pytest
 
-from pypesto.C import MEASUREMENT_TYPE, ORDINAL
+from pypesto.C import MEASUREMENT_TYPE, ORDINAL, PARAMETER_TYPE
 from pypesto.hierarchical.petab import validate_hierarchical_petab_problem
 from pypesto.testing.examples import (
     get_Boehm_JProteomeRes2014_hierarchical_petab_v2,
@@ -23,7 +23,7 @@ def test_hierarchical_petab_v2_validation(petab_problem_v2):
 
     # unknown parameter type
     petab_problem = copy.deepcopy(petab_problem_v2)
-    petab_problem.parameters[-1].model_extra["parameterType"] = "pink"
+    petab_problem.parameters[-1].model_extra[PARAMETER_TYPE] = "pink"
     with pytest.raises(ValueError, match="Unknown inner parameter type"):
         validate_hierarchical_petab_problem(petab_problem)
 

--- a/test/hierarchical/test_hierarchical_petab_v2.py
+++ b/test/hierarchical/test_hierarchical_petab_v2.py
@@ -1,0 +1,59 @@
+"""Tests for hierarchical optimization with PEtab v2 problems."""
+
+import copy
+
+import pytest
+
+from pypesto.C import MEASUREMENT_TYPE, ORDINAL
+from pypesto.hierarchical.petab import validate_hierarchical_petab_problem
+from pypesto.testing.examples import (
+    get_Boehm_JProteomeRes2014_hierarchical_petab_v2,
+)
+
+
+@pytest.fixture(scope="module")
+def petab_problem_v2():
+    return get_Boehm_JProteomeRes2014_hierarchical_petab_v2()
+
+
+def test_hierarchical_petab_v2_validation(petab_problem_v2):
+    """Invalid hierarchical PEtab v2 problems are rejected."""
+    # the unmodified problem is valid
+    validate_hierarchical_petab_problem(petab_problem_v2)
+
+    # unknown parameter type
+    petab_problem = copy.deepcopy(petab_problem_v2)
+    petab_problem.parameters[-1].model_extra["parameterType"] = "pink"
+    with pytest.raises(ValueError, match="Unknown inner parameter type"):
+        validate_hierarchical_petab_problem(petab_problem)
+
+    # non-quantitative data types other than relative are not supported yet
+    petab_problem = copy.deepcopy(petab_problem_v2)
+    petab_problem.measurements[0].model_extra[MEASUREMENT_TYPE] = ORDINAL
+    with pytest.raises(NotImplementedError, match="not yet supported"):
+        validate_hierarchical_petab_problem(petab_problem)
+
+    # an offset parameter must appear additively in the observable formula
+    petab_problem = copy.deepcopy(petab_problem_v2)
+    observable = petab_problem.observables[0]
+    observable.formula = (
+        f"observableParameter1_{observable.id}"
+        f" * observableParameter2_{observable.id}"
+    )
+    with pytest.raises(
+        ValueError, match="An offset is in the observable formula"
+    ):
+        validate_hierarchical_petab_problem(petab_problem)
+
+    # a sigma parameter must constitute the full noise formula
+    petab_problem = copy.deepcopy(petab_problem_v2)
+    observable = petab_problem.observables[0]
+    observable.noise_formula = f"2 * noiseParameter1_{observable.id}"
+    with pytest.raises(ValueError, match="full noise formula"):
+        validate_hierarchical_petab_problem(petab_problem)
+
+    # non-Gaussian noise distributions are not supported
+    petab_problem = copy.deepcopy(petab_problem_v2)
+    petab_problem.observables[0].noise_distribution = "laplace"
+    with pytest.raises(NotImplementedError, match="oise distribution"):
+        validate_hierarchical_petab_problem(petab_problem)


### PR DESCRIPTION
Adds the PEtab v2 side of problem inspection: reading pyPESTO's hierarchical annotations from a v2 problem, and validating that such a problem can actually be optimized hierarchically.

Nothing consumes this yet — the importer still rejects hierarchical PEtab v2 problems — so this PR only makes the annotations readable and the problems checkable. **3 of 4 in a stack** (see below).

## Reading the annotations

`parameterType` and `measurementType` are pyPESTO extensions, not part of the PEtab format. In PEtab v2 they survive as pydantic **extra fields** on the table elements — through TSV loading, the v1-to-v2 upgrade, and AMICI's experiment conversion. `get_petab_v2_extra_field` reads them, treating absent and empty values alike via `petab.is_empty`.

`get_petab_non_quantitative_data_types` now dispatches to a v2 implementation that reads those extra fields instead of relying on the v1 dataframe columns. Ordinal, censored and semiquantitative data are detected so the importer can reject them, rather than silently treating them as quantitative.

## Validating

`validate_hierarchical_petab_problem` accepts a v2 problem. Placeholders are explicit in v2, so the measurement-specific overrides are substituted directly instead of being inferred from the `observableParameter{n}_{id}` convention, and the resulting formulae go through the validators extracted in #1743.

One check has no v1 counterpart: **non-Gaussian noise is rejected** for observables carrying inner parameters. The analytical inner solver assumes additive Gaussian noise, so hierarchically fitting an observable declared with a Laplace noise distribution silently optimizes the wrong objective. v1 has this hole; this only closes it for v2.

## Review notes

* `get_petab_non_quantitative_data_types` is called for **every** problem the importer builds, v1 and v2, hierarchical or not — this changes which code path v2 problems take through it. The two non-hierarchical v2 import tests still pass.
* The `dtype=object` on the inner-parameter dataframe is load-bearing on pandas 3: without it a mixed str/None column becomes a string dtype whose missing value is NaN, and the pairing check compares against `None` (`nan != nan`). The same one-line issue exists in the v1 function and is worth porting separately.
* Test coverage here is validation only: unknown parameter type, unsupported measurement type, non-additive offset, a sigma that is not the whole noise formula, and non-Gaussian noise.

## Stack

Merge bottom-up. Each PR's diff shows only its own files.

1. #1746 — NumPy 2 `row_stack` fix, and the base-env import fixes from the merged #1738
2. #1742 — pre-existing bug fixes
3. #1743 — index slices: PEtab v2 support, and v1 refactors
4. #1749 — extract the inner-result combination
5. #1748 — evaluator as a collaborator
6. #1751 — `__call__` as a template with two hooks
7. **this PR** — PEtab v2 detection and validation
8. #1740 — the PEtab v2 hierarchical calculator

#1738 was stacked on #1746 and merged **into it**, so merging #1746 lands both base-environment fixes on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

