### PR TITLE
Make the relative calculator's evaluator a collaborator

### DIFF
--- a/pypesto/hierarchical/relative/calculator.py
+++ b/pypesto/hierarchical/relative/calculator.py
@@ -46,6 +46,7 @@ class RelativeAmiciCalculator(AmiciCalculator):
         self,
         inner_problem: AmiciInnerProblem,
         inner_solver: InnerSolver | None = None,
+        evaluator: AmiciCalculator | None = None,
     ):
         """Initialize the calculator from the given problem.
 
@@ -56,10 +57,19 @@ class RelativeAmiciCalculator(AmiciCalculator):
         inner_solver:
             A solver to solve ``inner_problem``.
             Defaults to ``pypesto.hierarchical.solver.AnalyticalInnerSolver``.
+        evaluator:
+            Performs a plain, non-hierarchical evaluation of the problem;
+            used to obtain simulations at given parameters. Defaults to this
+            calculator's own PEtab v1 machinery. PEtab v2 problems are
+            simulated through :class:`AmiciCalculatorPetabV2` instead, since
+            their parameter mapping lives in the PEtab simulator rather than
+            in a v1 ``ParameterMapping``.
         """
         super().__init__()
 
         self.inner_problem = inner_problem
+        #: See the ``evaluator`` argument.
+        self.evaluator = evaluator
 
         if inner_solver is None:
             inner_solver = AnalyticalInnerSolver()
@@ -77,6 +87,16 @@ class RelativeAmiciCalculator(AmiciCalculator):
         """Initialize."""
         super().initialize()
         self.inner_solver.initialize()
+
+    def _evaluate(self, **kwargs):
+        """Evaluate the problem without hierarchical optimization.
+
+        Routes through the injected evaluator if there is one, and otherwise
+        through this calculator's own PEtab v1 simulation.
+        """
+        if self.evaluator is not None:
+            return self.evaluator(**kwargs)
+        return super().__call__(**kwargs)
 
     def __call__(
         self,
@@ -208,7 +228,7 @@ class RelativeAmiciCalculator(AmiciCalculator):
         x_dct = copy.deepcopy(x_dct)
         x_dct.update(self.inner_problem.get_dummy_values(scaled=True))
 
-        inner_result = super().__call__(
+        inner_result = self._evaluate(
             x_dct=x_dct,
             sensi_orders=(0,),
             mode=mode,
@@ -250,7 +270,7 @@ class RelativeAmiciCalculator(AmiciCalculator):
 
         # TODO use plist to compute only required derivatives, in
         #  `super.__call__`, `amici.parameter_mapping.fill_in_parameters`
-        inner_result = super().__call__(
+        inner_result = self._evaluate(
             x_dct=x_dct,
             sensi_orders=sensi_orders,
             mode=mode,
@@ -299,6 +319,14 @@ class RelativeAmiciCalculator(AmiciCalculator):
             sensi_order = max(sensi_orders)
 
         # if AMICI ReturnData is not provided, we need to simulate the model
+        if rdatas is None and self.evaluator is not None:
+            # this path fills the `ExpData` from a PEtab v1 parameter mapping,
+            #  which for PEtab v2 resolves no placeholders and would silently
+            #  produce a wrong objective
+            raise NotImplementedError(
+                "Cannot simulate from within the relative calculator when an "
+                "evaluator is set; pass the simulation results as `rdatas`."
+            )
         if rdatas is None:
             amici_solver.set_sensitivity_order(sensi_order)
             x_dct.update(self.inner_problem.get_dummy_values(scaled=True))


### PR DESCRIPTION
`RelativeAmiciCalculator` conflates two jobs. Solving the inner problem from simulations is version-independent and is its real work. *Producing* those simulations is version-specific, and it is inherited from `AmiciCalculator`, whose path is PEtab v1 only: fill the `ExpData` objects from a `ParameterMapping`, then run AMICI.

This makes the evaluator a collaborator instead. `call_amici_twice` evaluates through `self._evaluate`, which uses an injected `evaluator` when one is given and falls back to `super().__call__` otherwise. **PEtab v1 behaviour is unchanged**; its hierarchical tests pass untouched (44 passed, plus the `test_hierarchical_optimization_pipeline` failure already on `develop`).

## The latent hazard this closes

Two routes on the class would simulate via the v1 parameter mapping. For a PEtab v2 problem that mapping is an identity mapping that never resolves observable and noise placeholders to the inner parameters, so they would return a wrong objective **with no error**:

* `call_amici_twice`, through `super().__call__` — now goes through the seam.
* `calculate_directly`, when `rdatas is None` — now raises when an evaluator is set.

Neither is reachable from the PEtab v2 collector today, since it always supplies `rdatas` and never calls `call_amici_twice` on the calculator. This is about not leaving a silently wrong path in a class that serves both versions. The same failure mode is why `visualize.observable_mapping` carries an explicit v1-only guard.

## What it unlocks

Without this seam the v2 collector had to reimplement the simulate, solve, simulate-again scheme itself, which put the decision and the implementation one layer above where v1 keeps them. With it, the v2 collector delegates to the calculator exactly as the v1 collector does, and ~60 duplicated lines go away. That follow-up lands in #1740.

## Review notes

* The guard in `calculate_directly` is deliberately a raise rather than a silent fallback: there is no correct way for that branch to simulate a v2 problem.
* `_evaluate` is the only new indirection; both call sites in `call_amici_twice` were previously `super().__call__` with identical arguments.

## Stack

Merge bottom-up. Each PR's diff shows only its own files.

1. #1746 — NumPy 2 `row_stack` fix, and the base-env import fixes from the merged #1738
2. #1742 — pre-existing bug fixes
3. #1743 — index slices: PEtab v2 support, and v1 refactors
4. #1749 — extract the inner-result combination
5. **this PR** — evaluator as a collaborator
6. #1751 — `__call__` as a template with two hooks
7. #1744 — PEtab v2 detection and validation
8. #1740 — the PEtab v2 hierarchical calculator

#1738 was stacked on #1746 and merged **into it**, so merging #1746 lands both base-environment fixes on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

