### PR TITLE
Fix silently empty residuals from hierarchical optimization

### DIFF
--- a/pypesto/hierarchical/relative/calculator.py
+++ b/pypesto/hierarchical/relative/calculator.py
@@ -327,10 +327,18 @@ class RelativeAmiciCalculator(AmiciCalculator):
         Hessian nor residuals are requested. In this case, the objective
         function and gradient are computed directly using the solver methods.
 
-        Only ``FVAL`` and ``GRAD`` are filled in; ``RES`` and ``SRES`` keep
-        the empty arrays from :func:`init_return_values`, so this must not be
-        called in :obj:`MODE_RES`.
+        Only ``FVAL`` and ``GRAD`` are filled in; ``RES`` and ``SRES`` would
+        keep the empty arrays from :func:`init_return_values`, so residual
+        mode raises rather than returning residuals that are silently empty.
         """
+        if mode == MODE_RES:
+            raise ValueError(
+                "`calculate_directly` computes the objective and its "
+                "gradient from the inner solver and produces no residuals. "
+                "Residual mode goes through `call_amici_twice`, where AMICI "
+                "computes them itself."
+            )
+
         dim = len(x_ids)
         # compute optimal inner parameters
         x_dct = copy.deepcopy(x_dct)

--- a/pypesto/hierarchical/relative/calculator.py
+++ b/pypesto/hierarchical/relative/calculator.py
@@ -21,9 +21,12 @@ from ...C import (
     GRAD,
     HESS,
     INNER_PARAMETERS,
+    LIN,
+    MODE_RES,
     RDATAS,
     RES,
     SRES,
+    InnerParameterType,
     ModeType,
 )
 from ...objective.amici.amici_calculator import (
@@ -35,6 +38,7 @@ from ...objective.amici.amici_util import (
     filter_return_dict,
     init_return_values,
 )
+from ..base_problem import scale_back_value_dict
 from .problem import AmiciInnerProblem
 from .solver import AnalyticalInnerSolver, InnerSolver
 
@@ -130,11 +134,19 @@ class RelativeAmiciCalculator(AmiciCalculator):
                 "optimizer."
             )
 
+        # residual mode needs AMICI's own residuals, which only the
+        #  second simulation of the two-call scheme can provide:
+        #  `calculate_directly` computes the objective and its gradient from
+        #  the inner solver and leaves `res`/`sres` at their empty defaults.
         if (
-            1 in sensi_orders
-            and amici_solver.get_sensitivity_method()
-            == asd.SensitivityMethod.adjoint
-        ) or 2 in sensi_orders:
+            (
+                1 in sensi_orders
+                and amici_solver.get_sensitivity_method()
+                == asd.SensitivityMethod.adjoint
+            )
+            or 2 in sensi_orders
+            or mode == MODE_RES
+        ):
             inner_result, inner_parameters = self.call_amici_twice(
                 x_dct=x_dct,
                 sensi_orders=sensi_orders,
@@ -195,6 +207,26 @@ class RelativeAmiciCalculator(AmiciCalculator):
         for the calculation of the inner parameters, and then again to obtain
         the requested objective function and gradient through AMICI.
         """
+        # Same restriction as the parameter-dependent-sigma check in
+        #  `AmiciCalculator.__call__`, and blocking the same thing: the
+        #  residual sensitivities a least-squares solver needs. The residuals
+        #  themselves stay available. Checked here rather than in `__call__`
+        #  so that the PEtab v2 collector, which calls this directly, is
+        #  covered too.
+        if (
+            mode == MODE_RES
+            and 1 in sensi_orders
+            and self.inner_problem.get_xs_for_type(InnerParameterType.SIGMA)
+        ):
+            raise RuntimeError(
+                "Cannot use least squares solver with hierarchically "
+                "estimated sigma! At the analytically optimal sigma the sum "
+                "of squared residuals equals the number of measurements "
+                "whatever the outer parameters are, so the least-squares "
+                "objective the residuals define is constant. Estimate the "
+                "sigmas as ordinary parameters to optimize in residual mode."
+            )
+
         dim = len(x_ids)
         # compute optimal inner parameters
         x_dct = copy.deepcopy(x_dct)
@@ -234,11 +266,30 @@ class RelativeAmiciCalculator(AmiciCalculator):
             scaled=True,
         )
 
-        # fill in optimal values
-        # directly writing to parameter mapping ensures that plists do not
-        # include hierarchically computed parameters
-        x_dct = copy.deepcopy(x_dct)
-        x_dct.update(inner_parameters)
+        # Fill the optimal values into the parameter mapping rather than
+        #  into `x_dct`. Mapping a simulation parameter to a value instead of
+        #  to an id keeps it out of AMICI's plist, so the second simulation
+        #  differentiates with respect to the outer parameters only. Without
+        #  this, sigmas solved for hierarchically look parameter-dependent to
+        #  the least-squares check in `AmiciCalculator.__call__`.
+        inner_values = scale_back_value_dict(
+            inner_parameters, self.inner_problem
+        )
+        parameter_mapping = copy.deepcopy(parameter_mapping)
+        for condition_mapping in parameter_mapping:
+            for sim_par, mapped in list(condition_mapping.map_sim_var.items()):
+                if isinstance(mapped, str) and mapped in inner_values:
+                    condition_mapping.map_sim_var[sim_par] = inner_values[
+                        mapped
+                    ]
+                    condition_mapping.scale_map_sim_var[sim_par] = LIN
+        # the inner parameters are no longer referenced by the mapping, so
+        #  leaving them in `x_dct` would make them unused problem parameters
+        x_dct = {
+            par_id: value
+            for par_id, value in x_dct.items()
+            if par_id not in inner_values
+        }
 
         # TODO use plist to compute only required derivatives, in
         #  `super.__call__`, `amici.parameter_mapping.fill_in_parameters`
@@ -272,9 +323,13 @@ class RelativeAmiciCalculator(AmiciCalculator):
     ):
         """Calculate directly via solver calculate methods.
 
-        This is possible if the forward method is used, and the Hessian is not
-        requested. In this case, the objective function and gradient are computed
-        directly using the solver methods.
+        This is possible if the forward method is used, and neither the
+        Hessian nor residuals are requested. In this case, the objective
+        function and gradient are computed directly using the solver methods.
+
+        Only ``FVAL`` and ``GRAD`` are filled in; ``RES`` and ``SRES`` keep
+        the empty arrays from :func:`init_return_values`, so this must not be
+        called in :obj:`MODE_RES`.
         """
         dim = len(x_ids)
         # compute optimal inner parameters

--- a/test/hierarchical/test_hierarchical.py
+++ b/test/hierarchical/test_hierarchical.py
@@ -6,6 +6,7 @@ import time
 import numpy as np
 import pandas as pd
 import petab.v1 as petab
+import pytest
 from amici.sim.sundials import SensitivityMethod
 
 import pypesto
@@ -14,6 +15,10 @@ from pypesto.C import (
     LIN,
     LOWER_BOUND,
     MODE_FUN,
+    MODE_RES,
+    PARAMETER_TYPE,
+    RES,
+    SRES,
     UPPER_BOUND,
     InnerParameterType,
 )
@@ -234,6 +239,115 @@ def test_hierarchical_calculator_and_objective():
     # the nominal values are very good already, so the test might pass
     # accidentally if the nominal values are used accidentally.
     assert np.isclose(fval_true, fval_false, atol=1e-12, rtol=1e-14)
+
+
+def _boehm_hierarchical_scaling_offset_only():
+    """Boehm with the scalings and offsets inner, and the sigmas fixed.
+
+    Residual mode is only meaningful when the sigmas are not solved
+    analytically, see `test_hierarchical_residuals_with_inner_sigma`.
+    """
+    petab_problem = (
+        get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds()
+    )
+    sd_ids = [
+        par_id
+        for par_id in petab_problem.parameter_df.index
+        if par_id.startswith("sd_")
+    ]
+    petab_problem.parameter_df.loc[sd_ids, PARAMETER_TYPE] = np.nan
+    petab_problem.parameter_df.loc[sd_ids, petab.ESTIMATE] = 0
+    return petab_problem
+
+
+def test_hierarchical_residuals():
+    """Test residual mode with hierarchical scalings and offsets.
+
+    `calculate_directly` fills in only `FVAL` and `GRAD`, so routing residual
+    mode there returned an empty residual array without raising. Residual
+    mode goes through the two-call scheme instead, where AMICI computes the
+    residuals itself, with the inner parameters fixed at their optimum.
+    """
+    petab_problem = _boehm_hierarchical_scaling_offset_only()
+    importer = PetabImporter(petab_problem, hierarchical=True)
+    objective = importer.create_problem(importer.create_objective()).objective
+    objective.amici_solver.set_absolute_tolerance(1e-12)
+    objective.amici_solver.set_relative_tolerance(1e-12)
+
+    x_nominal = dict(
+        zip(petab_problem.x_ids, petab_problem.x_nominal_scaled, strict=True)
+    )
+    x = np.asarray([x_nominal[x_id] for x_id in objective.x_names])
+
+    n_measurements = len(petab_problem.measurement_df)
+    ret = objective(x, sensi_orders=(0, 1), mode=MODE_RES, return_dict=True)
+    res, sres = ret[RES], ret[SRES]
+
+    assert res.shape == (n_measurements,)
+    assert sres.shape == (n_measurements, len(x))
+    assert np.isfinite(res).all()
+    assert np.isfinite(sres).all()
+
+    # the Gauss-Newton gradient of these residuals is the gradient of the
+    # objective, which is what a least-squares optimizer needs of them
+    _, grad = objective(x, sensi_orders=(0, 1), mode=MODE_FUN)
+    assert np.allclose(
+        sres.T @ res, grad, rtol=1e-6, atol=1e-6 * np.max(np.abs(grad))
+    )
+
+    # ... and the least-squares objective they define has to track the
+    # negative log-likelihood, differing from it only by the sigma term,
+    # which is constant here because the sigmas are
+    offsets = []
+    for delta in [0.0, 0.05, -0.1]:
+        x_perturbed = x.copy()
+        x_perturbed[0] += delta
+        fval = objective(x_perturbed, sensi_orders=(0,), mode=MODE_FUN)
+        res_perturbed = objective(
+            x_perturbed, sensi_orders=(0,), mode=MODE_RES, return_dict=True
+        )[RES]
+        offsets.append(fval - 0.5 * res_perturbed @ res_perturbed)
+    assert np.allclose(offsets, offsets[0], rtol=1e-8)
+
+
+def test_hierarchical_residuals_with_inner_sigma():
+    """Test residual mode when the sigmas are solved analytically.
+
+    The residuals themselves are well defined, but at the optimal sigma
+    their sum of squares equals the number of measurements whatever the
+    outer parameters are, so the least-squares objective they define is
+    constant. The residual sensitivities are refused for that reason, as
+    they are for a parameter-dependent sigma in `AmiciCalculator.__call__`.
+    """
+    petab_problem = (
+        get_Boehm_JProteomeRes2014_hierarchical_petab_corrected_bounds()
+    )
+    importer = PetabImporter(petab_problem, hierarchical=True)
+    objective = importer.create_problem(importer.create_objective()).objective
+    objective.amici_solver.set_absolute_tolerance(1e-12)
+    objective.amici_solver.set_relative_tolerance(1e-12)
+
+    x_nominal = dict(
+        zip(petab_problem.x_ids, petab_problem.x_nominal_scaled, strict=True)
+    )
+    x = np.asarray([x_nominal[x_id] for x_id in objective.x_names])
+    n_measurements = len(petab_problem.measurement_df)
+
+    # the residuals are available, and are the standardized residuals at the
+    # optimal sigma, so their sum of squares is the measurement count
+    for delta in [0.0, 0.05, -0.1]:
+        x_perturbed = x.copy()
+        x_perturbed[0] += delta
+        res = objective(
+            x_perturbed, sensi_orders=(0,), mode=MODE_RES, return_dict=True
+        )[RES]
+        assert res.shape == (n_measurements,)
+        assert np.isfinite(res).all()
+        assert np.isclose(res @ res, n_measurements, rtol=1e-8)
+
+    # which is why they must not be handed to a least-squares solver
+    with pytest.raises(RuntimeError, match="hierarchically estimated sigma"):
+        objective(x, sensi_orders=(1,), mode=MODE_RES)
 
 
 def test_analytical_computations():

--- a/test/hierarchical/test_hierarchical.py
+++ b/test/hierarchical/test_hierarchical.py
@@ -309,6 +309,23 @@ def test_hierarchical_residuals():
         offsets.append(fval - 0.5 * res_perturbed @ res_perturbed)
     assert np.allclose(offsets, offsets[0], rtol=1e-8)
 
+    # routing residual mode to `calculate_directly` is what produced the
+    # empty residuals in the first place; it now refuses instead
+    relative_calculator = objective.calculator.inner_calculators[0]
+    with pytest.raises(ValueError, match="no residuals"):
+        relative_calculator.calculate_directly(
+            x_dct=dict(zip(objective.x_names, x, strict=True)),
+            sensi_orders=(0,),
+            mode=MODE_RES,
+            amici_model=objective.amici_model,
+            amici_solver=objective.amici_solver,
+            edatas=objective.edatas,
+            n_threads=1,
+            x_ids=objective.x_names,
+            parameter_mapping=objective.parameter_mapping,
+            fim_for_hess=False,
+        )
+
 
 def test_hierarchical_residuals_with_inner_sigma():
     """Test residual mode when the sigmas are solved analytically.


### PR DESCRIPTION
Hierarchical optimization returned an **empty residual vector** in residual mode, without raising. On hierarchical Boehm, `res` had shape `(0,)` for a problem with 48 measurements.

`RelativeAmiciCalculator.__call__` sends residual mode to `calculate_directly`, which computes `FVAL` and `GRAD` from the inner solver and leaves `RES`/`SRES` at the empty arrays `init_return_values` hands it. Nothing ever fills them.

## Fix

Route residual mode to `call_amici_twice`, which is what the PEtab v2 collector already does. Its second simulation runs with the inner parameters at their optimum, so AMICI computes the residuals and their sensitivities itself.

That alone trips the least-squares check in `AmiciCalculator.__call__`:

```
RuntimeError: Cannot use least squares solver with parameter dependent sigma!
```

The optimal inner parameters were written into `x_dct` while the parameter mapping still mapped the simulation parameters to their **ids**, so AMICI kept them in the `plist` and differentiated with respect to them. Those sensitivities were then discarded in `par_index_slices`, which skips ids that are not optimization parameters. Writing the optimal values into the mapping instead is what the comment there already claimed the code did:

```python
# directly writing to parameter mapping ensures that plists do not
# include hierarchically computed parameters
```

`par_index_slices` derives each parameter's position in AMICI's sensitivity output from the cumulative count of id-mapped parameters, mirroring how the `plist` is built, so the shorter `plist` needs no other change. The second simulation also stops computing sensitivities that were only going to be thrown away.

## Hierarchical sigmas are not least-squares safe

Making the `plist` change without saying more would **silence** the check quoted above for exactly the case it should catch. At the analytically optimal sigma, σ\* is the RMS deviation, so Σrᵢ² ≡ n identically:

| Δ on `Epo_degradation_BaF3` | nllh | 0.5·‖res‖² |
|---|---|---|
| 0.00 | 133.571498 | 24.000000000 |
| 0.05 | 133.564625 | 24.000000000 |
| −0.10 | 138.616771 | 24.000000000 |
| 0.25 | 146.459417 | 24.000000000 |

A least-squares optimizer would be minimizing a constant.

The residuals themselves are fine — they are the standardized residuals at the fitted noise level, and are worth having for diagnostics — so they stay available. Only the residual **sensitivities** are refused, which is precisely what a least-squares solver needs and precisely what the existing parameter-dependent-sigma check blocks, for the same reason. Same `RuntimeError`, same `mode == MODE_RES and 1 in sensi_orders` condition. It lives in `call_amici_twice` rather than `__call__` so the PEtab v2 collector, which calls it directly, is covered too.

## What now works

With the sigmas fixed and only scalings and offsets solved analytically:

| | before | after |
|---|---|---|
| `res` | `(0,)` | `(48,)` — one per measurement |
| `sres` | `(0, 6)` | `(48, 6)` |

* `0.5 * res @ res` tracks the negative log-likelihood, differing from it by a constant 114.2337 across parameter values — the sigma term, now genuinely constant.
* `sres.T @ res` matches the function-mode gradient to a relative 3e-10.

Both are asserted by `test_hierarchical_residuals`; `test_hierarchical_residuals_with_inner_sigma` pins `res @ res == n_measurements` and the refusal of the Jacobian.

`test/hierarchical`: 45 passed. The one failure, `test_hierarchical_optimization_pipeline`, is `fides` not being installed in my environment and is unrelated. `test_hierarchical_calculator_and_objective` covers the adjoint path through `call_amici_twice` and is unchanged by the shorter `plist`.

## Note on the Jacobian

`sres` treats the inner parameters as constants at their optimum. That is the standard variable-projection choice: the implicit dependence of the inner optimum on the outer parameters contributes nothing to `J^T r`, which is why the Gauss-Newton gradient matches exactly. It is not the full derivative of `res`, so finite-differencing `res` against `sres` will not agree.

Found while refactoring the collector in #1751, which documents the defect and deliberately preserved it rather than changing behaviour inside a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
