### PR TITLE
Replacing develop with main as most up-to-date branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor"]
-    target-branch: "develop"
+    target-branch: "main"

--- a/.github/workflows/publish_dockerhub.yml
+++ b/.github/workflows/publish_dockerhub.yml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - develop
+      - main
     paths:
       - 'docker/**'
       - '.github/workflows/docker-publish.yml'

--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -6,13 +6,13 @@ Workflow
 
 If you start working on a new feature or a fix, please create an issue on
 GitHub briefly describing the issue and assign yourself.
-Your startpoint should always be the ``develop`` branch, which contains the
+Your startpoint should always be the ``main`` branch, which contains the
 latest updates.
 
 Create an own branch or fork, on which you can implement your changes. To
 get your work merged, please:
 
-1. create a pull request to the ``develop`` branch with a meaningful summary,
+1. create a pull request to the ``main`` branch with a meaningful summary,
 2. check that code changes are covered by tests, and all tests pass,
 3. check that the documentation is up-to-date,
 4. request a code review from the main developers.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -42,7 +42,7 @@ Install from GitHub
 
 If you want the bleeding edge version, install directly from GitHub::
 
-    pip3 install git+https://github.com/icb-dcm/pypesto.git@develop
+    pip3 install git+https://github.com/icb-dcm/pypesto.git@main
 
 If you need to have access to the source code, you can download it via::
 

--- a/doc/containers.rst
+++ b/doc/containers.rst
@@ -1,6 +1,6 @@
 We provide a pyPESTO OCI image through the Docker.io registry.
 
-A docker image build is triggered on changes/commits in the ``develop`` branch of pyPESTO. The container is built and pushed via a GHA to the Docker.io registry with the tag corresponding to ``latest``.
+A docker image build is triggered on changes/commits in the ``main`` branch of pyPESTO. The container is built and pushed via a GHA to the Docker.io registry with the tag corresponding to ``latest``.
 
 The image can be obtained by a pull from the Docker.io registry: ``docker pull docker.io/stephanmg/pypesto:latest``
 

--- a/doc/deploy.rst
+++ b/doc/deploy.rst
@@ -18,17 +18,18 @@ as suggested by the `Python packaging guide <https://packaging.python.org>`_.
 Create a new release
 --------------------
 
-After new commits have been added via pull requests to the ``develop`` branch,
-changes can be merged to ``main`` and a new version of pyPESTO can be released.
+Contributions are merged directly into ``main`` via pull requests (see
+:doc:`contribute`). Once enough changes have accumulated, a new version of
+pyPESTO can be released from ``main``.
 
-Merge into main
-~~~~~~~~~~~~~~~
+Prepare the release
+~~~~~~~~~~~~~~~~~~~~
 
-1. create a pull request from ``develop`` to ``main``,
-2. check that all code changes are covered by tests and all tests pass,
-3. check that the documentation is up-to-date,
-4. adapt the version number in ``pypesto/version.py`` (see above),
-5. update the release notes in ``CHANGELOG.rst``,
+1. adapt the version number in ``pypesto/version.py`` (see above),
+2. update the release notes in ``CHANGELOG.rst``,
+3. create a pull request with these changes to ``main``,
+4. check that all code changes are covered by tests and all tests pass,
+5. check that the documentation is up-to-date,
 6. request a code review,
 7. merge into the origin ``main`` branch.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,11 +6,11 @@
 cd <path to pypesto base directory>/docker && docker build -t $USER/amici_pypesto:latest .
 ```
 
-To install pyPESTO from a particular branch, e.g. develop, use the following
+To install pyPESTO from a particular branch, e.g. main, use the following
 line in the Dockerfile
 
 ```
-RUN pip3 install git+https://github.com/ICB-DCM/pyPESTO.git@develop#egg=pypesto
+RUN pip3 install git+https://github.com/ICB-DCM/pyPESTO.git@main#egg=pypesto
 ```
 
 environment file can be used with `--set-env` option of `ch-run` command. From


### PR DESCRIPTION
Left it in the CI.yml still in for now, in case some leftover pushes into develop happen.