### PR TITLE
Fix IndexError when mixing user and automatic reference point colors

### DIFF
--- a/pypesto/visualize/reference_points.py
+++ b/pypesto/visualize/reference_points.py
@@ -136,9 +136,9 @@ def assign_colors(ref: Sequence[ReferencePoint]) -> Sequence[ReferencePoint]:
 
     # loop over reference points and assign auto_colors
     auto_color_count = 0
-    for i_num, i_ref in enumerate(ref):
+    for i_ref in ref:
         if i_ref["auto_color"]:
-            i_ref["color"] = auto_colors[i_num]
+            i_ref["color"] = auto_colors[auto_color_count]
             auto_color_count += 1
 
     return ref

--- a/test/visualize/test_visualize.py
+++ b/test/visualize/test_visualize.py
@@ -1175,6 +1175,23 @@ def test_reference_points():
     visualize.create_references(references=ref_list_2, x=ref2[0], fval=ref2[1])
 
 
+def test_reference_points_mixed_colors():
+    # mixing user-specified and automatic colors must not raise
+    user_color = [1.0, 0.0, 0.0, 1.0]
+    ref_list = visualize.create_references(
+        [
+            {"x": np.array([1.0, 1.5]), "fval": 0.2, "color": user_color},
+            {"x": np.array([1.8, 1.9]), "fval": 0.6},
+            {"x": np.array([1.4, 1.7]), "fval": 0.4},
+        ]
+    )
+
+    # the user-specified color is kept, the others are assigned automatically
+    assert ref_list[0]["color"] == user_color
+    assert all(ref["color"] is not None for ref in ref_list)
+    assert ref_list[1]["color"] != ref_list[2]["color"]
+
+
 def test_process_result_list():
     # create the necessary results
     result_1 = create_optimization_result()


### PR DESCRIPTION
## Summary

Fix `assign_colors` so that automatically assigned colors are indexed independently of the position of reference points in the input list.

Previously, reference points with user-defined colors could cause an `IndexError` when followed by reference points whose colors should be assigned automatically.

## Bug

`assign_colors` first counts the reference points that require automatic colors and creates one color for each of them.

However, when assigning those colors, it used the position of the reference point in the full `ref` list as the index into `auto_colors`.

For a mixed list such as:

```python
import pypesto.visualize

pypesto.visualize.create_references(
    [
        {"x": [1.0, 1.5], "fval": 0.2, "color": [1.0, 0.0, 0.0, 1.0]},
        {"x": [1.8, 1.9], "fval": 0.6},
    ]
)
```

the first point is user-colored and the second requires an automatic color. Since `auto_colors` contains only one entry, indexing it with the second point's position raises:

```text
IndexError: list index out of range
```

## Fix

Use `auto_color_count` as the index for `auto_colors`.

```python
auto_color_count = 0
for i_ref in ref:
    if i_ref["auto_color"]:
        i_ref["color"] = auto_colors[auto_color_count]
        auto_color_count += 1
```

This keeps the indexing of `auto_colors` aligned with the subset of reference points that require automatic colors.

User-specified colors are preserved, while all auto-colored reference points receive distinct automatically generated colors regardless of their position in the input list.

## Tests

Added `test_reference_points_mixed_colors` to cover a reference list containing both user-specified and automatically assigned colors.

The regression test verifies that:

- user-specified colors are preserved;
- all reference points receive a color;
- automatically assigned colors are distinct.

The existing reference-point tests only covered reference points without explicitly specified colors and therefore did not exercise this case.

## Scope

The fix is limited to color assignment in `assign_colors`. It applies to all visualizations that use `create_references`, including `parameters`, `waterfall`, `profiles`, and `optimizer_history`.

Closes #1758.